### PR TITLE
Fix middle-click events flipping to incorrect value

### DIFF
--- a/Assets/Plugins/x86.meta
+++ b/Assets/Plugins/x86.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 21f428266e6b5e4499d21349c0b80064
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/__Scripts/Map/Events/BeatmapEventContainer.cs
+++ b/Assets/__Scripts/Map/Events/BeatmapEventContainer.cs
@@ -169,8 +169,8 @@ public class BeatmapEventContainer : BeatmapObjectContainer {
         if (Input.GetMouseButtonDown(2) && !KeybindsController.ShiftHeld)
         {
             if (eventData.IsUtilityEvent()) return;
-            if (eventData._value >= 4 && eventData._value < 8) eventData._value -= 3;
-            else if (eventData._value >= 1) eventData._value += 3;
+            if (eventData._value > 4 && eventData._value < 8) eventData._value -= 4;
+            else if (eventData._value > 0) eventData._value += 4;
             eventAppearance.SetEventAppearance(this);
         }
         else if (Input.GetAxis("Mouse ScrollWheel") != 0)


### PR DESCRIPTION
In accordance with:
https://docs.google.com/spreadsheets/d/1vCTlDvx0ZW8NkkZBYW6ecvXaVRxDUKX7QIoah9PCp_c/htmlview
also pls ignore x86.meta idk what its doin

	modified:   Assets/__Scripts/Map/Events/BeatmapEventContainer.cs