### PR TITLE
Bongo Cat changes

### DIFF
--- a/Assets/__Scenes/00_FirstBoot.unity
+++ b/Assets/__Scenes/00_FirstBoot.unity
@@ -89,7 +89,7 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaAO: 1
     m_ShowResolutionOverlay: 1
   m_LightingDataAsset: {fileID: 0}
-  m_UseShadowmask: 0
+  m_UseShadowmask: 1
 --- !u!196 &4
 NavMeshSettings:
   serializedVersion: 2
@@ -2135,7 +2135,6 @@ GameObject:
   - component: {fileID: 1846672461}
   - component: {fileID: 1846672460}
   - component: {fileID: 1846672459}
-  - component: {fileID: 1846672462}
   m_Layer: 5
   m_Name: Button
   m_TagString: Untagged
@@ -2253,26 +2252,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1846672457}
   m_CullTransparentMesh: 0
---- !u!114 &1846672462
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1846672457}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ec9d0964fc5c07c4d988ebacfd236eb8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  tooltip: 'You do not have to choose a true
-
-    Beat Saber installation - however
-
-    the folder you choose must
-
-    contain a CustomSongs folder'
-  advancedTooltip: 
 --- !u!1 &1848289576
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/__Scripts/MapEditor/Detection/BongoCat.cs
+++ b/Assets/__Scripts/MapEditor/Detection/BongoCat.cs
@@ -32,7 +32,7 @@ public class BongoCat : MonoBehaviour
             PersistentUI.Instance.DisplayMessage("Bongo cat disabled :(", PersistentUI.DisplayMessageType.BOTTOM);
         else
         {
-            audioUtil.PlayOneShotSound(bongoCatAudioClip);
+            //audioUtil.PlayOneShotSound(bongoCatAudioClip); // audio clip way too damn long, gets annoying fast
             PersistentUI.Instance.DisplayMessage("Bongo cat joins the fight!", PersistentUI.DisplayMessageType.BOTTOM);
         }
         Settings.Instance.BongoBoye = !Settings.Instance.BongoBoye;
@@ -44,17 +44,17 @@ public class BongoCat : MonoBehaviour
         if (!Settings.Instance.BongoBoye) return;
         BeatmapObjectContainer next = container.LoadedContainers.Where(x => x.objectData._time > note._time &&
         (x.objectData as BeatmapNote)._type == note._type).OrderBy(x => x.objectData._time).FirstOrDefault();
-        float half = next ? container.AudioTimeSyncController.GetSecondsFromBeat((next.objectData._time - note._time) / 2f)
-            : 0.125f;
+        float half = note._type != BeatmapNote.NOTE_TYPE_BOMB ? container.AudioTimeSyncController.GetSecondsFromBeat((next.objectData._time - note._time) / 2f) : 0f; // ignore bombs
+        float timer = next ? Mathf.Clamp(half, 0.05f, 0.2f) : 0.125f; // clamp to accommodate sliders and long gaps between notes
         switch (note._type)
         {
             case BeatmapNote.NOTE_TYPE_A:
                 Larm = true;
-                LarmTimeout = half;
+                LarmTimeout = timer;
                 break;
             case BeatmapNote.NOTE_TYPE_B:
                 Rarm = true;
-                RarmTimeout = half;
+                RarmTimeout = timer;
                 break;
         }
     }


### PR DESCRIPTION
- Removed the redundant tooltip on the button in 00_FirstBoot
- Bombs no longer lobotomize Bongo Cat
- Clamped Bongo's timeout to prevent Bongo's arm from sticking down for too little or too long