### PR TITLE
big brain coder

### DIFF
--- a/Assets/HSVPicker/UI/ColorPickerMessageSender.cs
+++ b/Assets/HSVPicker/UI/ColorPickerMessageSender.cs
@@ -10,5 +10,7 @@ public class ColorPickerMessageSender : MonoBehaviour, IPointerClickHandler
     {
         if (data.button == PointerEventData.InputButton.Left)
             SendMessageUpwards(KeybindsController.ShiftHeld ? "DeletePreset" : "PresetSelect", GetComponent<Image>());
+        else if (data.button == PointerEventData.InputButton.Middle)
+            SendMessageUpwards("OverridePreset", GetComponent<Image>());
     }
 }

--- a/Assets/HSVPicker/UI/ColorPresets.cs
+++ b/Assets/HSVPicker/UI/ColorPresets.cs
@@ -65,6 +65,13 @@ public class ColorPresets : MonoBehaviour
         OnColorsUpdate(_colors.Colors);
     }
 
+    public void OverridePreset(Image sender)
+    {
+        _colors.Colors[_colors.Colors.IndexOf(sender.color)] = picker.CurrentColor;
+        //_colors.Colors.set(sender.color);
+        OnColorsUpdate(_colors.Colors);
+    }
+
     private void OnDestroy()
     {
         //Whoever made this HSV Picker is a dumbass and forgot to unsubscribe from events when the object is destroyed

--- a/Assets/__Scenes/00_FirstBoot.unity
+++ b/Assets/__Scenes/00_FirstBoot.unity
@@ -89,7 +89,7 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaAO: 1
     m_ShowResolutionOverlay: 1
   m_LightingDataAsset: {fileID: 0}
-  m_UseShadowmask: 1
+  m_UseShadowmask: 0
 --- !u!196 &4
 NavMeshSettings:
   serializedVersion: 2
@@ -1332,7 +1332,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 200, y: 50}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &953115610
 MonoBehaviour:

--- a/Assets/__Scenes/03_Mapper.unity
+++ b/Assets/__Scenes/03_Mapper.unity
@@ -7287,6 +7287,80 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 280050976}
   m_CullTransparentMesh: 0
+--- !u!1 &285428333
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 285428334}
+  - component: {fileID: 285428336}
+  - component: {fileID: 285428335}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &285428334
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 285428333}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.7499983, y: 0.7499983, z: 0.7499983}
+  m_Children: []
+  m_Father: {fileID: 2034531414}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 40, y: 40}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &285428335
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 285428333}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 21300000, guid: c9eb663cc4328ef41b8eb495e02bb977, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+--- !u!222 &285428336
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 285428333}
+  m_CullTransparentMesh: 0
 --- !u!1 &285584385
 GameObject:
   m_ObjectHideFlags: 0
@@ -9262,9 +9336,9 @@ RectTransform:
   m_Father: {fileID: 2140854277}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 1, y: 0.5}
-  m_AnchorMax: {x: 1, y: 0.5}
-  m_AnchoredPosition: {x: -325, y: 36}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 75, y: 36}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!225 &376516735
@@ -16730,6 +16804,81 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &695293221
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 695293222}
+  - component: {fileID: 695293224}
+  - component: {fileID: 695293223}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &695293222
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 695293221}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1773773877}
+  m_Father: {fileID: 2034531414}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.5, y: 0.5}
+  m_SizeDelta: {x: 35, y: 35}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &695293223
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 695293221}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.31764707, g: 0.31764707, b: 0.31764707, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+--- !u!222 &695293224
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 695293221}
+  m_CullTransparentMesh: 0
 --- !u!1 &695639397
 GameObject:
   m_ObjectHideFlags: 0
@@ -44853,6 +45002,80 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1767101867}
   m_CullTransparentMesh: 0
+--- !u!1 &1773773876
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1773773877}
+  - component: {fileID: 1773773879}
+  - component: {fileID: 1773773878}
+  m_Layer: 5
+  m_Name: Checkmark
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1773773877
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1773773876}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 695293222}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 35, y: 35}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1773773878
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1773773876}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.31764707, g: 0.31764707, b: 0.31764707, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+--- !u!222 &1773773879
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1773773876}
+  m_CullTransparentMesh: 0
 --- !u!1 &1780724283
 GameObject:
   m_ObjectHideFlags: 0
@@ -50186,6 +50409,127 @@ CanvasGroup:
   m_Interactable: 1
   m_BlocksRaycasts: 1
   m_IgnoreParentGroups: 0
+--- !u!1 &2034531413
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2034531414}
+  - component: {fileID: 2034531416}
+  - component: {fileID: 2034531415}
+  m_Layer: 5
+  m_Name: Delete Toggle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2034531414
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2034531413}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 695293222}
+  - {fileID: 285428334}
+  m_Father: {fileID: 2054168910}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 466.5, y: 380.81}
+  m_SizeDelta: {x: 35, y: 35}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2034531415
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2034531413}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ec9d0964fc5c07c4d988ebacfd236eb8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  tooltip: Delete stuff.
+  advancedTooltip: 
+--- !u!114 &2034531416
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2034531413}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 2109663825, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 0}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 695293223}
+  toggleTransition: 1
+  graphic: {fileID: 1773773878}
+  m_Group: {fileID: 1719109082}
+  onValueChanged:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1980665313}
+        m_MethodName: Delete
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 376516736}
+        m_MethodName: Delete
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: UnityEngine.UI.Toggle+ToggleEvent, UnityEngine.UI, Version=1.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  m_IsOn: 0
 --- !u!1 &2037167242
 GameObject:
   m_ObjectHideFlags: 0
@@ -50439,6 +50783,7 @@ RectTransform:
   m_Children:
   - {fileID: 247122773}
   - {fileID: 953509554}
+  - {fileID: 2034531414}
   m_Father: {fileID: 23602853}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -52499,8 +52844,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 400, y: 75}
+  m_AnchoredPosition: {x: -16.05, y: 0}
+  m_SizeDelta: {x: 430, y: 75}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2140854278
 MonoBehaviour:

--- a/Assets/__Scenes/03_Mapper.unity
+++ b/Assets/__Scenes/03_Mapper.unity
@@ -52554,6 +52554,7 @@ MonoBehaviour:
   workflowGroups:
   - {fileID: 1980665312}
   - {fileID: 376516734}
+  measureLinesController: {fileID: 25550676}
 --- !u!1 &2145012307
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/__Scenes/03_Mapper.unity
+++ b/Assets/__Scenes/03_Mapper.unity
@@ -7431,6 +7431,135 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 285584385}
   m_CullTransparentMesh: 0
+--- !u!1 &286391073
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 286391074}
+  - component: {fileID: 286391078}
+  - component: {fileID: 286391077}
+  - component: {fileID: 286391076}
+  m_Layer: 5
+  m_Name: Reset Button
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &286391074
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 286391073}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1339425638}
+  m_Father: {fileID: 950224398}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -89, y: -92}
+  m_SizeDelta: {x: 80.7, y: 40}
+  m_Pivot: {x: 0, y: 0}
+--- !u!114 &286391076
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 286391073}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 286391077}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2069920280}
+        m_MethodName: Reset
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+--- !u!114 &286391077
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 286391073}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.39705884, g: 0.39705884, b: 0.39705884, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+--- !u!222 &286391078
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 286391073}
+  m_CullTransparentMesh: 0
 --- !u!1 &292602773
 GameObject:
   m_ObjectHideFlags: 0
@@ -20778,6 +20907,7 @@ RectTransform:
   m_Children:
   - {fileID: 325388640}
   - {fileID: 303602844}
+  - {fileID: 286391074}
   - {fileID: 1899361212}
   m_Father: {fileID: 2069920279}
   m_RootOrder: 0
@@ -27654,9 +27784,9 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
+  m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: -23.999985, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &1223292197
 RectTransform:
@@ -35927,6 +36057,167 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1339425637
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1339425638}
+  - component: {fileID: 1339425640}
+  - component: {fileID: 1339425639}
+  m_Layer: 5
+  m_Name: TextMeshPro Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1339425638
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1339425637}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 286391074}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0.000030517578, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1339425639
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1339425637}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_text: Reset
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 5b2df7ab397c94346983e8b98acd826e, type: 2}
+  m_sharedMaterial: {fileID: 21947009840950596, guid: 5b2df7ab397c94346983e8b98acd826e,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_outlineColor:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontSize: 30
+  m_fontSizeBase: 30
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_textAlignment: 514
+  m_isAlignmentEnumConverted: 1
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_firstOverflowCharacterIndex: -1
+  m_linkedTextComponent: {fileID: 0}
+  m_isLinkedTextComponent: 0
+  m_isTextTruncated: 0
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_ignoreRectMaskCulling: 0
+  m_ignoreCulling: 1
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_firstVisibleCharacter: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: -0.065968305, w: 0}
+  m_textInfo:
+    textComponent: {fileID: 1339425639}
+    characterCount: 5
+    spriteCount: 0
+    spaceCount: 0
+    wordCount: 1
+    linkCount: 0
+    lineCount: 1
+    pageCount: 1
+    materialCount: 1
+  m_havePropertiesChanged: 0
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_spriteAnimator: {fileID: 0}
+  m_isInputParsingRequired: 0
+  m_inputSource: 0
+  m_hasFontAssetChanged: 0
+  m_subTextObjects:
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1339425640
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1339425637}
+  m_CullTransparentMesh: 0
 --- !u!1 &1339692332
 GameObject:
   m_ObjectHideFlags: 0
@@ -47374,12 +47665,12 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 950224398}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 9.1, y: -68.2}
-  m_SizeDelta: {x: -115, y: 50}
+  m_AnchoredPosition: {x: -37.5, y: -72}
+  m_SizeDelta: {x: -125, y: 30}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1899361213
 MonoBehaviour:
@@ -47437,7 +47728,7 @@ MonoBehaviour:
   m_fontSizeMin: 18
   m_fontSizeMax: 72
   m_fontStyle: 0
-  m_textAlignment: 514
+  m_textAlignment: 513
   m_isAlignmentEnumConverted: 1
   m_characterSpacing: 0
   m_wordSpacing: 0
@@ -50945,7 +51236,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0}
   m_AnchorMax: {x: 0.5, y: 0}
-  m_AnchoredPosition: {x: 279, y: -63.19995}
+  m_AnchoredPosition: {x: 279, y: -200}
   m_SizeDelta: {x: 200, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2069920280

--- a/Assets/__Scenes/03_Mapper.unity
+++ b/Assets/__Scenes/03_Mapper.unity
@@ -39686,6 +39686,7 @@ MonoBehaviour:
   customEventsContainer: {fileID: 25550677}
   workflowToggle: {fileID: 2140854280}
   measureLinesController: {fileID: 25550676}
+  notePlacementUI: {fileID: 0}
 --- !u!114 &1524038337
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -48466,6 +48467,163 @@ Transform:
   m_Father: {fileID: 25550672}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1938067912
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1938067913}
+  - component: {fileID: 1938067918}
+  - component: {fileID: 1938067917}
+  - component: {fileID: 1938067916}
+  - component: {fileID: 1938067915}
+  - component: {fileID: 1938067914}
+  m_Layer: 5
+  m_Name: Mirror Selection Button
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1938067913
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1938067912}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2102093505}
+  m_Father: {fileID: 2054168910}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -368.5, y: -17.5}
+  m_SizeDelta: {x: 35, y: 35}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1938067914
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1938067912}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ec9d0964fc5c07c4d988ebacfd236eb8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  tooltip: Mirror selection, similar to left handed-mode.
+  advancedTooltip: 
+--- !u!225 &1938067915
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1938067912}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 0
+--- !u!114 &1938067916
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1938067912}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 0}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1938067917}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2140854281}
+        m_MethodName: Mirror
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+--- !u!114 &1938067917
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1938067912}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.31617647, g: 0.31617647, b: 0.31617647, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+--- !u!222 &1938067918
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1938067912}
+  m_CullTransparentMesh: 0
 --- !u!1 &1946301806
 GameObject:
   m_ObjectHideFlags: 0
@@ -50784,6 +50942,7 @@ RectTransform:
   - {fileID: 247122773}
   - {fileID: 953509554}
   - {fileID: 2034531414}
+  - {fileID: 1938067913}
   m_Father: {fileID: 23602853}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -52312,6 +52471,80 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2097533474}
   m_CullTransparentMesh: 0
+--- !u!1 &2102093504
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2102093505}
+  - component: {fileID: 2102093507}
+  - component: {fileID: 2102093506}
+  m_Layer: 5
+  m_Name: Mirror Selection
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2102093505
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2102093504}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.75, y: 0.75, z: 0.75}
+  m_Children: []
+  m_Father: {fileID: 1938067913}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 40, y: 40}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2102093506
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2102093504}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 21300000, guid: c9eb663cc4328ef41b8eb495e02bb977, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+--- !u!222 &2102093507
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2102093504}
+  m_CullTransparentMesh: 0
 --- !u!1 &2108936574
 GameObject:
   m_ObjectHideFlags: 0
@@ -52819,6 +53052,7 @@ GameObject:
   - component: {fileID: 2140854279}
   - component: {fileID: 2140854278}
   - component: {fileID: 2140854280}
+  - component: {fileID: 2140854281}
   m_Layer: 5
   m_Name: Buttons and Stuff
   m_TagString: Untagged
@@ -52844,8 +53078,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: -16.05, y: 0}
-  m_SizeDelta: {x: 430, y: 75}
+  m_AnchoredPosition: {x: -34.66, y: 0}
+  m_SizeDelta: {x: 470, y: 75}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2140854278
 MonoBehaviour:
@@ -52900,6 +53134,20 @@ MonoBehaviour:
   - {fileID: 1980665312}
   - {fileID: 376516734}
   measureLinesController: {fileID: 25550676}
+--- !u!114 &2140854281
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2140854276}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 79ef6dda16cd96e4c86b4763cab11725, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  noteAppearance: {fileID: 11400000, guid: 2e49cb79fe1ae9e448bc9363be6040c5, type: 2}
+  eventAppearance: {fileID: 11400000, guid: 2bea2298a3153ae4f907f2b615f67d0b, type: 2}
 --- !u!1 &2145012307
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/__Scenes/03_Mapper.unity
+++ b/Assets/__Scenes/03_Mapper.unity
@@ -903,7 +903,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 100, y: -87.5}
+  m_AnchoredPosition: {x: 100, y: -12.5}
   m_SizeDelta: {x: 200, y: 25}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &20201636
@@ -1006,11 +1006,11 @@ MonoBehaviour:
     lineCount: 1
     pageCount: 1
     materialCount: 1
-  m_havePropertiesChanged: 1
+  m_havePropertiesChanged: 0
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_isInputParsingRequired: 1
+  m_isInputParsingRequired: 0
   m_inputSource: 0
   m_hasFontAssetChanged: 0
   m_subTextObjects:
@@ -2512,7 +2512,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 100, y: -112.5}
+  m_AnchoredPosition: {x: 100, y: -12.5}
   m_SizeDelta: {x: 200, y: 25}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &89530294
@@ -2613,11 +2613,11 @@ MonoBehaviour:
     lineCount: 1
     pageCount: 1
     materialCount: 1
-  m_havePropertiesChanged: 1
+  m_havePropertiesChanged: 0
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_isInputParsingRequired: 1
+  m_isInputParsingRequired: 0
   m_inputSource: 0
   m_hasFontAssetChanged: 0
   m_subTextObjects:
@@ -11407,7 +11407,7 @@ RectTransform:
   m_GameObject: {fileID: 471772268}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 0.7, y: 0.7, z: 1}
   m_Children:
   - {fileID: 687914312}
   - {fileID: 1048626097}
@@ -11420,7 +11420,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 100, y: -75}
+  m_AnchoredPosition: {x: 60, y: -295}
   m_SizeDelta: {x: 150, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &471772270
@@ -16484,11 +16484,11 @@ MonoBehaviour:
     lineCount: 1
     pageCount: 1
     materialCount: 1
-  m_havePropertiesChanged: 1
+  m_havePropertiesChanged: 0
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_isInputParsingRequired: 1
+  m_isInputParsingRequired: 0
   m_inputSource: 0
   m_hasFontAssetChanged: 0
   m_subTextObjects:
@@ -19729,11 +19729,11 @@ MonoBehaviour:
     lineCount: 1
     pageCount: 1
     materialCount: 1
-  m_havePropertiesChanged: 1
+  m_havePropertiesChanged: 0
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_isInputParsingRequired: 1
+  m_isInputParsingRequired: 0
   m_inputSource: 0
   m_hasFontAssetChanged: 0
   m_subTextObjects:
@@ -19771,7 +19771,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 100, y: -137.5}
+  m_AnchoredPosition: {x: 100, y: -12.5}
   m_SizeDelta: {x: 200, y: 25}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &892554127
@@ -22080,7 +22080,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 100, y: -62.5}
+  m_AnchoredPosition: {x: 100, y: -12.5}
   m_SizeDelta: {x: 200, y: 25}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &996239674
@@ -22183,11 +22183,11 @@ MonoBehaviour:
     lineCount: 1
     pageCount: 1
     materialCount: 1
-  m_havePropertiesChanged: 1
+  m_havePropertiesChanged: 0
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_isInputParsingRequired: 1
+  m_isInputParsingRequired: 0
   m_inputSource: 0
   m_hasFontAssetChanged: 0
   m_subTextObjects:
@@ -23251,7 +23251,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 100, y: -37.5}
+  m_AnchoredPosition: {x: 100, y: -12.5}
   m_SizeDelta: {x: 200, y: 25}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1048626098
@@ -23354,11 +23354,11 @@ MonoBehaviour:
     lineCount: 1
     pageCount: 1
     materialCount: 1
-  m_havePropertiesChanged: 1
+  m_havePropertiesChanged: 0
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_isInputParsingRequired: 1
+  m_isInputParsingRequired: 0
   m_inputSource: 0
   m_hasFontAssetChanged: 0
   m_subTextObjects:
@@ -27654,9 +27654,9 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: -23.999985, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &1223292197
 RectTransform:

--- a/Assets/__Scripts/Map/BeatmapObjectContainer.cs
+++ b/Assets/__Scripts/Map/BeatmapObjectContainer.cs
@@ -45,11 +45,11 @@ public abstract class BeatmapObjectContainer : MonoBehaviour {
         }
         else if (Input.GetMouseButtonDown(2))
         {
-            if (SelectionController.HasSelectedObjects())
+            /*if (SelectionController.HasSelectedObjects())
             {
                 SelectionController.Select(this, true, false);
                 return;
-            }else FlaggedForDeletionEvent?.Invoke(this);
+            }else*/ FlaggedForDeletionEvent?.Invoke(this);
         }
     }
 

--- a/Assets/__Scripts/Map/BeatmapObjectContainer.cs
+++ b/Assets/__Scripts/Map/BeatmapObjectContainer.cs
@@ -34,7 +34,10 @@ public abstract class BeatmapObjectContainer : MonoBehaviour {
         if (KeybindsController.AltHeld && Input.GetMouseButton(0) && !SelectionController.IsObjectSelected(this)
             && !Settings.Instance.BoxSelect)
             SelectionController.Select(this, true);
-        if (!KeybindsController.ShiftHeld) return;
+        if (!KeybindsController.ShiftHeld) {
+            if (Input.GetMouseButtonDown(0) && NotePlacementUI.delete) FlaggedForDeletionEvent?.Invoke(this);
+            return;
+        }
         if (Input.GetMouseButtonDown(0))
         { //Selects if it's not already selected, deselect if it is.
             if (SelectionController.IsObjectSelected(this)) SelectionController.Deselect(this);

--- a/Assets/__Scripts/Map/Events/BeatmapEventContainer.cs
+++ b/Assets/__Scripts/Map/Events/BeatmapEventContainer.cs
@@ -170,7 +170,7 @@ public class BeatmapEventContainer : BeatmapObjectContainer {
         {
             if (eventData.IsUtilityEvent()) return;
             if (eventData._value > 4 && eventData._value < 8) eventData._value -= 4;
-            else if (eventData._value > 0) eventData._value += 4;
+            else if (eventData._value > 0 && eventData._value <= 4) eventData._value += 4;
             eventAppearance.SetEventAppearance(this);
         }
         else if (Input.GetAxis("Mouse ScrollWheel") != 0)

--- a/Assets/__Scripts/Map/Events/EventAppearanceSO.cs
+++ b/Assets/__Scripts/Map/Events/EventAppearanceSO.cs
@@ -23,7 +23,8 @@ public class EventAppearanceSO : ScriptableObject
     public void SetEventAppearance(BeatmapEventContainer e) {
         Color color = Color.white;
         foreach(TextMeshProUGUI t in e.GetComponentsInChildren<TextMeshProUGUI>()) Destroy(t.transform.parent.gameObject);
-        if (e.eventData._type == MapEvent.EVENT_TYPE_LEFT_LASERS_SPEED || e.eventData._type == MapEvent.EVENT_TYPE_RIGHT_LASERS_SPEED) {
+        if (e.eventData._type == MapEvent.EVENT_TYPE_LEFT_LASERS_SPEED || e.eventData._type == MapEvent.EVENT_TYPE_RIGHT_LASERS_SPEED)
+        {
             GameObject instantiate = Instantiate(LaserSpeedPrefab, e.transform);
             instantiate.transform.localPosition = new Vector3(0, 0.25f, 0);
             instantiate.GetComponentInChildren<TextMeshProUGUI>().text = e.eventData._value.ToString();

--- a/Assets/__Scripts/MapEditor/Grid/MeasureLinesController.cs
+++ b/Assets/__Scripts/MapEditor/Grid/MeasureLinesController.cs
@@ -59,6 +59,6 @@ public class MeasureLinesController : MonoBehaviour
     public void UpdateParentPosition()
     {
         float x = workflowToggle.SelectedWorkflowGroup == 0 ? 1.2f + ((noteGrid.localScale.x - 0.01f) * 5) : 14;
-        parent.transform.localPosition = new Vector3(x, atsc.gridStartPosition, -0.55f);
+        parent.transform.localPosition = new Vector3(x, atsc.gridStartPosition, 0);
     }
 }

--- a/Assets/__Scripts/MapEditor/Mapping/KeybindsController.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/KeybindsController.cs
@@ -56,7 +56,6 @@ public class KeybindsController : MonoBehaviour {
         if (Input.GetKeyDown(KeyCode.Tab) && !NodeEditorController.IsActive)
         {
             workflowToggle.UpdateWorkflowGroup();
-            measureLinesController.UpdateParentPosition();
         }
         if (Input.GetKeyDown(KeyCode.V) && !AnyCriticalKeys && !NodeEditorController.IsActive)
             notesContainer.UpdateSwingArcVisualizer();

--- a/Assets/__Scripts/MapEditor/Mapping/KeybindsController.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/KeybindsController.cs
@@ -130,7 +130,7 @@ public class KeybindsController : MonoBehaviour {
     {
         if (NodeEditorController.IsActive || PersistentUI.Instance.InputBox_IsEnabled) return;
         if (Input.GetKeyDown(KeyCode.T)) sc.AssignTrack();
-        if (Input.GetKeyDown(KeyCode.Delete) || (ShiftHeld && Input.GetMouseButtonDown(2))) sc.Delete();
+        if (Input.GetKeyDown(KeyCode.Delete)) sc.Delete();
         if (CtrlHeld)
         {
             if (Input.GetKeyDown(KeyCode.A)) SelectionController.DeselectAll();

--- a/Assets/__Scripts/MapEditor/Mapping/KeybindsController.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/KeybindsController.cs
@@ -20,6 +20,7 @@ public class KeybindsController : MonoBehaviour {
     [SerializeField] private CustomEventsContainer customEventsContainer;
     [SerializeField] private UIWorkflowToggle workflowToggle;
     [SerializeField] private MeasureLinesController measureLinesController;
+    [SerializeField] private NotePlacementUI notePlacementUI;
 
     public bool InvertNoteKeybinds
     {
@@ -45,48 +46,84 @@ public class KeybindsController : MonoBehaviour {
 
         GlobalKeybinds(); //These guys are here all day, all night
         if (notePlacement.IsActive) NotesKeybinds(); //Present when placing a note
-        if (bombPlacement.IsActive) BombsKeybinds(); //Present when placing a bomb
-        if (obstaclePlacement.IsActive) ObstacleKeybinds(); //Present when placing an obstacle
         if (eventPlacement.IsActive) EventsKeybinds(); //Present when placing an event.
         if (SelectionController.HasSelectedObjects()) SelectionKeybinds(); //Present if objects are selected
     }
 
     void GlobalKeybinds()
     {
-        if (Input.GetKeyDown(KeyCode.Tab) && !NodeEditorController.IsActive)
+        foreach (KeyCode vKey in System.Enum.GetValues(typeof(KeyCode))) // stahp with the if else spam; wrap everything in this instead
         {
-            workflowToggle.UpdateWorkflowGroup();
-        }
-        if (Input.GetKeyDown(KeyCode.V) && !AnyCriticalKeys && !NodeEditorController.IsActive)
-            notesContainer.UpdateSwingArcVisualizer();
-        if (CtrlHeld)
-        {
-            if (Input.GetKeyDown(KeyCode.T))
+            if (Input.GetKeyDown(vKey))
             {
-                if (ShiftHeld) customEventsContainer.CreateNewType();
-                else customEventsContainer.SetTrackFilter();
+                if (CtrlHeld) { // ctrl modifiers
+                    if ((int)vKey >= 48 && (int)vKey <= 57) // laserspeed text done using this instead
+                    {
+                        if (Input.GetKeyDown(vKey)) laserSpeed.text = (((int)vKey + 2) % 50).ToString();
+                    }
+
+                    switch (vKey)
+                    {
+                        case KeyCode.T:
+                            if (ShiftHeld) customEventsContainer.CreateNewType();
+                            else customEventsContainer.SetTrackFilter();
+                            break;
+                        case KeyCode.S:
+                            if (!Input.GetMouseButton(1)) autosave.Save();
+                            break;
+                        case KeyCode.Z:
+                            if (!ShiftHeld) actionContainer.Undo();
+                            else actionContainer.Redo();
+                            break;
+                        case KeyCode.Y:
+                            if (!ShiftHeld) actionContainer.Redo();
+                            else actionContainer.Undo();
+                            break;
+                        case KeyCode.V:
+                            if (SelectionController.HasCopiedObjects() && !NodeEditorController.IsActive) sc.Paste();
+                            break;
+                    }
+                }
+
+                switch (vKey) 
+                {
+                    case KeyCode.Tab:
+                        if (!NodeEditorController.IsActive) workflowToggle.UpdateWorkflowGroup();
+                        break;
+                    case KeyCode.V:
+                        if (!AnyCriticalKeys && !NodeEditorController.IsActive) notesContainer.UpdateSwingArcVisualizer();
+                        break;
+                    case KeyCode.Alpha1: // placement activators
+                    case KeyCode.Alpha2:
+                    case KeyCode.W:
+                    case KeyCode.A:
+                    case KeyCode.S:
+                    case KeyCode.D:
+                    case KeyCode.F:
+                        notePlacement.IsActive = true;
+                        bombPlacement.IsActive = false;
+                        obstaclePlacement.IsActive = false;
+                        eventPlacement.IsActive = true;
+                        NotePlacementUI.delete = false;
+                        break;
+                    case KeyCode.Alpha3:
+                        notePlacement.IsActive = false;
+                        bombPlacement.IsActive = true;
+                        obstaclePlacement.IsActive = false;
+                        NotePlacementUI.delete = false;
+                        break;
+                    case KeyCode.Alpha4:
+                        notePlacement.IsActive = false;
+                        bombPlacement.IsActive = false;
+                        obstaclePlacement.IsActive = true;
+                        NotePlacementUI.delete = false;
+                        break; // end of placement activators
+                    case KeyCode.F11:
+                        if (!Application.isEditor) Screen.fullScreen = !Screen.fullScreen;
+                        break;
+                }
             }
-            if (Input.GetKeyDown(KeyCode.S) && !Input.GetMouseButton(1)) autosave.Save();
-            if (Input.GetKeyDown(KeyCode.Alpha1)) laserSpeed.text = "1";
-            else if (Input.GetKeyDown(KeyCode.Alpha2)) laserSpeed.text = "2";
-            else if (Input.GetKeyDown(KeyCode.Alpha3)) laserSpeed.text = "3";
-            else if (Input.GetKeyDown(KeyCode.Alpha4)) laserSpeed.text = "4";
-            else if (Input.GetKeyDown(KeyCode.Alpha5)) laserSpeed.text = "5";
-            else if (Input.GetKeyDown(KeyCode.Alpha6)) laserSpeed.text = "6";
-            else if (Input.GetKeyDown(KeyCode.Alpha7)) laserSpeed.text = "7";
-            else if (Input.GetKeyDown(KeyCode.Alpha8)) laserSpeed.text = "8";
-            else if (Input.GetKeyDown(KeyCode.Alpha9)) laserSpeed.text = "9";
-            else if (Input.GetKeyDown(KeyCode.Alpha0)) laserSpeed.text = "0";
-
-            if (Input.GetKeyDown(KeyCode.Z) || (ShiftHeld && Input.GetKeyDown(KeyCode.Y))) actionContainer.Undo();
-            else if (Input.GetKeyDown(KeyCode.Y) || (ShiftHeld && Input.GetKeyDown(KeyCode.Z))) actionContainer.Redo();
-
-
-            if (Input.GetKeyDown(KeyCode.V) && SelectionController.HasCopiedObjects() && !NodeEditorController.IsActive) sc.Paste();
         }
-        if (Input.GetKeyDown(KeyCode.F11) && !Application.isEditor) Screen.fullScreen = !Screen.fullScreen;
-        //if (Input.GetKeyDown(KeyCode.Z) || (ShiftHeld && Input.GetKeyDown(KeyCode.Y))) undoRedo.Undo();
-        //if (Input.GetKeyDown(KeyCode.Y) || (ShiftHeld && Input.GetKeyDown(KeyCode.Z))) undoRedo.Redo();
     }
 
     void SelectionKeybinds()
@@ -120,16 +157,6 @@ public class KeybindsController : MonoBehaviour {
             notePlacement.UpdateType(BN.NOTE_TYPE_A);
         else if (Input.GetKeyDown(KeyCode.Alpha2))
             notePlacement.UpdateType(BN.NOTE_TYPE_B);
-        else if (Input.GetKeyDown(KeyCode.Alpha3))
-        {
-            notePlacement.IsActive = false;
-            bombPlacement.IsActive = true;
-        }
-        else if (Input.GetKeyDown(KeyCode.Alpha4))
-        {
-            notePlacement.IsActive = false;
-            obstaclePlacement.IsActive = true;
-        }
 
         if (!notePlacement.IsValid) return;
 
@@ -162,35 +189,6 @@ public class KeybindsController : MonoBehaviour {
             notePlacement.UpdateChromaValue(BeatmapChromaNote.BIDIRECTIONAL);
         }
         if (Input.GetKeyDown(KeyCode.R)) notePlacement.ChangeChromaToggle(false);
-    }
-
-    void BombsKeybinds()
-    {
-        if (Input.GetKeyDown(KeyCode.Alpha1) || Input.GetKey(KeyCode.Alpha2))
-        {
-            bombPlacement.IsActive = false;
-            notePlacement.IsActive = true;
-            notePlacement.UpdateType(Input.GetKeyDown(KeyCode.Alpha1) ? BN.NOTE_TYPE_A : BN.NOTE_TYPE_B);
-        }else if (Input.GetKeyDown(KeyCode.Alpha4))
-        {
-            bombPlacement.IsActive = false;
-            obstaclePlacement.IsActive = true;
-        }
-    }
-
-    void ObstacleKeybinds()
-    {
-        if (Input.GetKeyDown(KeyCode.Alpha1) || Input.GetKey(KeyCode.Alpha2))
-        {
-            obstaclePlacement.IsActive = false;
-            notePlacement.IsActive = true;
-            notePlacement.UpdateType(Input.GetKeyDown(KeyCode.Alpha1) ? BN.NOTE_TYPE_A : BN.NOTE_TYPE_B);
-        }
-        else if (Input.GetKeyDown(KeyCode.Alpha3))
-        {
-            bombPlacement.IsActive = true;
-            obstaclePlacement.IsActive = false;
-        }
     }
 
     void EventsKeybinds()

--- a/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/EventPlacement.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/EventPlacement.cs
@@ -83,7 +83,7 @@ public class EventPlacement : PlacementController<MapEvent, BeatmapEventContaine
     {
         queuedData._time = (instantiatedContainer.transform.position.z / EditorScaleController.EditorScale)
         + atsc.CurrentBeat - atsc.offsetBeat;
-        if ((KeybindsController.AltHeld || (Settings.Instance.PlaceOnlyChromaEvents && Settings.Instance.PlaceChromaEvents)) && !queuedData.IsUtilityEvent()) // no more laser speed events gone wack
+        if ((KeybindsController.AltHeld || (Settings.Instance.PlaceOnlyChromaEvents && Settings.Instance.PlaceChromaEvents)) && !queuedData.IsUtilityEvent())
         {
             MapEvent justChroma = BeatmapObject.GenerateCopy(queuedData);
             justChroma._value = ColourManager.ColourToInt(colorPicker.CurrentColor);
@@ -96,7 +96,7 @@ public class EventPlacement : PlacementController<MapEvent, BeatmapEventContaine
         }
         BeatmapEventContainer spawned = objectContainerCollection.SpawnObject(BeatmapObject.GenerateCopy(queuedData), out BeatmapObjectContainer conflicting) as BeatmapEventContainer;
         BeatmapEventContainer chroma = null;
-        if (Settings.Instance.PlaceChromaEvents && !queuedData.IsUtilityEvent() && (queuedValue != MapEvent.LIGHT_VALUE_OFF)) // off events arent affected by chroma blocks, no need to create extra ones
+        if (Settings.Instance.PlaceChromaEvents && !queuedData.IsUtilityEvent() && (queuedValue != MapEvent.LIGHT_VALUE_OFF))
         {
             MapEvent chromaData = BeatmapObject.GenerateCopy(queuedData);
             chromaData._time -= 1 / 64f;

--- a/Assets/__Scripts/MapEditor/UI/BPM Tapper/BPMTapperController.cs
+++ b/Assets/__Scripts/MapEditor/UI/BPM Tapper/BPMTapperController.cs
@@ -14,16 +14,13 @@ public class BPMTapperController : MonoBehaviour
 
     private void Start()
     {
-        _bpmText.text = "Tap";
+        _bpmText.text = "";
     }
     private void Update()
     {
         if (Input.GetKeyDown(KeyCode.RightShift))
         {
-            if (Swap)
-                Swap = false;
-            else if (!Swap)
-                Swap = true;
+            Swap = !Swap;
 
             StopAllCoroutines();
             StartCoroutine(UpdateGroup(Swap, transform as RectTransform));
@@ -36,15 +33,24 @@ public class BPMTapperController : MonoBehaviour
 
         float og = group.anchoredPosition.y;
         float t = 0;
-        while (t < 1)
+        while (t < 0.4)
         {
             t += Time.deltaTime;
             group.anchoredPosition = new Vector2(group.anchoredPosition.x, Mathf.Lerp(og, dest, t));
             og = group.anchoredPosition.y;
             yield return new WaitForEndOfFrame();
         }
+        if (!enabled) Reset();
         group.anchoredPosition = new Vector2(group.anchoredPosition.x, dest);
         IsActive = enabled;
+    }
+
+    public void Reset()
+    {
+        isTapping = false;
+        StopAllCoroutines();
+        _bpmText.text = "Tap...";
+        taps.Clear();
     }
 
     public void Tap()
@@ -89,7 +95,6 @@ public class BPMTapperController : MonoBehaviour
             timeSinceLastTap += Time.deltaTime;
             yield return new WaitForEndOfFrame();
         }
-        taps.Clear();
-        isTapping = false;
+        Reset();
     }
 }

--- a/Assets/__Scripts/MapEditor/UI/CountersPlusController.cs
+++ b/Assets/__Scripts/MapEditor/UI/CountersPlusController.cs
@@ -58,7 +58,7 @@ public class CountersPlusController : MonoBehaviour {
 
     private void Update() // i do want to update this every single frame
     {
-        BeatSaberSongContainer.Instance.map._time += Time.deltaTime / 60;
+        if (Application.isFocused) BeatSaberSongContainer.Instance.map._time += Time.deltaTime / 60; // only tick while application is focused
         if (SelectionController.HasSelectedObjects()) // selected counter; does not rely on counters+ option
         {
             selectionMesh.text = $"Selected: {SelectionController.SelectedObjects.Count()}";

--- a/Assets/__Scripts/MapEditor/UI/MirrorSelection.cs
+++ b/Assets/__Scripts/MapEditor/UI/MirrorSelection.cs
@@ -1,0 +1,120 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class MirrorSelection : MonoBehaviour
+{
+    [SerializeField] private NoteAppearanceSO noteAppearance;
+    [SerializeField] private EventAppearanceSO eventAppearance;
+
+    public void Mirror()
+    {
+        if (!SelectionController.HasSelectedObjects())
+        {
+            PersistentUI.Instance.DisplayMessage("Select stuff first!", PersistentUI.DisplayMessageType.BOTTOM);
+            return;
+        }
+        foreach (BeatmapObjectContainer con in SelectionController.SelectedObjects)
+        {
+            if (con is BeatmapObstacleContainer obstacle)
+            {
+                bool precisionWidth = obstacle.obstacleData._width >= 1000;
+                int __state = obstacle.obstacleData._lineIndex;
+                if (__state > 3 || __state < 0 || precisionWidth) // thank you past me for this code
+                {
+                    if (__state >= 1000 || __state <= -1000 || precisionWidth) // precision lineIndex
+                    {
+                        int newIndex = __state;
+                        if (newIndex <= -1000) // normalize index values, we'll fix them later
+                        {
+                            newIndex += 1000;
+                        }
+                        else if (newIndex >= 1000)
+                        {
+                            newIndex -= 1000;
+                        }
+                        else
+                        {
+                            newIndex = newIndex * 1000; //convert lineIndex to precision if not already
+                        }
+                        newIndex = (((newIndex - 2000) * -1) + 2000); //flip lineIndex
+
+                        int newWidth = obstacle.obstacleData._width; //normalize wall width
+                        if (newWidth < 1000)
+                        {
+                            newWidth = newWidth * 1000;
+                        }
+                        else
+                        {
+                            newWidth -= 1000;
+                        }
+                        newIndex = newIndex - newWidth;
+
+                        if (newIndex < 0)
+                        { //this is where we fix them
+                            newIndex -= 1000;
+                        }
+                        else
+                        {
+                            newIndex += 1000;
+                        }
+                        obstacle.obstacleData._lineIndex = newIndex;
+                    }
+                    else // state > -1000 || state < 1000 assumes no precision width
+                    {
+                        int mirrorLane = (((__state - 2) * -1) + 2); //flip lineIndex
+                        obstacle.obstacleData._lineIndex = mirrorLane - obstacle.obstacleData._width; //adjust for wall width
+                    }
+                }
+                con.UpdateGridPosition();
+            }
+            else if (con is BeatmapNoteContainer note)
+            {
+                int __state = note.mapNoteData._lineIndex; // flip line index
+                if (__state > 3 || __state < 0) // precision case
+                {
+                    int newIndex = __state;
+                    if (newIndex <= -1000) // normalize index values, we'll fix them later
+                    {
+                        newIndex += 1000;
+                    }
+                    else if (newIndex >= 1000)
+                    {
+                        newIndex -= 1000;
+                    }
+                    newIndex = (((newIndex - 1500) * -1) + 1500); //flip lineIndex
+
+                    if (newIndex < 0) //this is where we fix them
+                    { 
+                        newIndex -= 1000;
+                    }
+                    else
+                    {
+                        newIndex += 1000;
+                    }
+                    note.mapNoteData._lineIndex = newIndex;
+                }
+                else
+                {
+                    int mirrorLane = (int)(((__state - 1.5f) * -1) + 1.5f);
+                    note.mapNoteData._lineIndex = mirrorLane;
+                }
+                con.UpdateGridPosition();
+
+                //flip colors
+                if (note.mapNoteData is BeatmapChromaNote chroma) note.mapNoteData = chroma.originalNote; //Revert Chroma status, then invert types
+                if (note.mapNoteData._type != BeatmapNote.NOTE_TYPE_BOMB)
+                    note.mapNoteData._type = note.mapNoteData._type == BeatmapNote.NOTE_TYPE_A ? BeatmapNote.NOTE_TYPE_B : BeatmapNote.NOTE_TYPE_A;
+                noteAppearance.SetNoteAppearance(note);
+            }
+            else if (con is BeatmapEventContainer e)
+            {
+                if (e.eventData.IsUtilityEvent()) return;
+                if (e.eventData._value > 4 && e.eventData._value < 8) e.eventData._value -= 4;
+                else if (e.eventData._value > 0 && e.eventData._value <= 4) e.eventData._value += 4;
+                eventAppearance.SetEventAppearance(e);
+            }
+        }
+        SelectionController.RefreshMap();
+    }
+}

--- a/Assets/__Scripts/MapEditor/UI/MirrorSelection.cs.meta
+++ b/Assets/__Scripts/MapEditor/UI/MirrorSelection.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 79ef6dda16cd96e4c86b4763cab11725
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/__Scripts/MapEditor/UI/Placement Controller UI/EventPlacementUI.cs
+++ b/Assets/__Scripts/MapEditor/UI/Placement Controller UI/EventPlacementUI.cs
@@ -45,6 +45,11 @@ public class EventPlacementUI : MonoBehaviour
         eventPlacement.SwapColors(false);
     }
 
+    public void Delete()
+    {
+        eventPlacement.IsActive = false;
+    }
+
     public void UpdateUI(MapEvent previewEvent)
     {
         redColorToggle.isOn = IsRedNote();

--- a/Assets/__Scripts/MapEditor/UI/Placement Controller UI/NotePlacementUI.cs
+++ b/Assets/__Scripts/MapEditor/UI/Placement Controller UI/NotePlacementUI.cs
@@ -7,6 +7,7 @@ public class NotePlacementUI : MonoBehaviour
     [SerializeField] private BombPlacement bombPlacement;
     [SerializeField] private ObstaclePlacement obstaclePlacement;
     [SerializeField] private CustomStandaloneInputModule customStandaloneInputModule;
+    public static bool delete = false; // boolean for delete tool
 
     public void RedNote(bool active)
     {
@@ -24,6 +25,7 @@ public class NotePlacementUI : MonoBehaviour
         notePlacement.IsActive = false;
         bombPlacement.IsActive = true;
         obstaclePlacement.IsActive = false;
+        delete = false;
     }
 
     public void Wall(bool active)
@@ -32,6 +34,7 @@ public class NotePlacementUI : MonoBehaviour
         notePlacement.IsActive = false;
         bombPlacement.IsActive = false;
         obstaclePlacement.IsActive = true;
+        delete = false;
     }
 
     public void RedAlt(bool active)
@@ -54,6 +57,15 @@ public class NotePlacementUI : MonoBehaviour
         if (active) UpdateValue(BeatmapNote.NOTE_TYPE_A, true, BeatmapChromaNote.DUOCHROME);
     }
 
+    public void Delete(bool active)
+    {
+        if (!active) return;
+        notePlacement.IsActive = false;
+        bombPlacement.IsActive = false;
+        obstaclePlacement.IsActive = false;
+        delete = true;
+    }
+
     private void UpdateValue(int v, bool isChroma = false, int chromaType = 0)
     {
         if (notePlacement.atsc.IsPlaying) return;
@@ -61,6 +73,7 @@ public class NotePlacementUI : MonoBehaviour
         notePlacement.IsActive = true;
         bombPlacement.IsActive = false;
         obstaclePlacement.IsActive = false;
+        delete = false;
         notePlacement.ChangeChromaToggle(isChroma);
         notePlacement.UpdateType(v);
         if (isChroma) notePlacement.UpdateChromaValue(chromaType);

--- a/Assets/__Scripts/MapEditor/UI/UIWorkflowToggle.cs
+++ b/Assets/__Scripts/MapEditor/UI/UIWorkflowToggle.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 public class UIWorkflowToggle : MonoBehaviour
 {
     [SerializeField] private RectTransform[] workflowGroups;
+    [SerializeField] private MeasureLinesController measureLinesController;
 
     public int SelectedWorkflowGroup { get; private set; } = 0;
 
@@ -28,5 +29,7 @@ public class UIWorkflowToggle : MonoBehaviour
         if (SelectedWorkflowGroup >= workflowGroups.Length) SelectedWorkflowGroup = 0;
         for (int i = 0; i < workflowGroups.Length; i++)
             StartCoroutine(UpdateGroup(i == SelectedWorkflowGroup ? 0 : 35, workflowGroups[i]));
+
+        measureLinesController.UpdateParentPosition();
     }
 }

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ Why would you choose ChroMapper over an already existing map editor, or even the
 |**Perspective**|3D|3D|3D|3D/2D|2D|
 |**Mapping Extensions**|🗹|🗹|🗷|🗷|🗷|
 |**Chroma RGB Lightmapping**|🗹|🗹|🗷|🗷|🗷|
-|**ChromaToggle**|🗹|🗷|🗷|🗷|🗷|
+|**ChromaToggle**|🗹|🗹|🗷|🗷|🗷|
 |**Beatmap v2 Support**|🗹|🗹|🗷|🗹|🗹|
+|**Ring Propagation**|🗹|🗷|🗷|🗷|🗷|
 
 With that big chart out of the way, here are some reasons why ChroMapper might better appeal to you than the other editors.
 - Being built in **Unity** means ChroMapper has the potential to be visually closer to Beat Saber than any other map editor, and [the results do show.](https://streamable.com/a0lh6)


### PR DESCRIPTION
- Small change on README.md
- Made Counters+ a little smaller to be less obtrusive and moved it to be symmetrical to song time on the right
- Added Reset button to BPM Tapper
- Fixed wonky hit box for "Let's Go!" on 00_Firstboot
- Measure line number will now properly flip to other grid when clicking the workflow button
- Measure line number now remains flush with grid after moving (previously started floating whenever it shifted sides)
- Can now middle click presets in the Chroma panel to override the preset
- Added a dedicated delete tool on the top bar
- Added a mirror selection tool on the top bar
- Cleaned up some pepega code in KeybindsController.cs (unfinished)
- Shift+M3 will now only delete a single object when you have a selection instead of deleting the entire selection