### PR TITLE
pepega code coming through

### DIFF
--- a/Assets/__Scenes/03_Mapper.unity
+++ b/Assets/__Scenes/03_Mapper.unity
@@ -3839,6 +3839,106 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 139478941}
   m_CullTransparentMesh: 0
+--- !u!1 &144720359
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 144720360}
+  - component: {fileID: 144720362}
+  - component: {fileID: 144720361}
+  m_Layer: 5
+  m_Name: Dummy Toggle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &144720360
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 144720359}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 376516734}
+  m_RootOrder: 12
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: -52.5, y: 80}
+  m_SizeDelta: {x: 35, y: 35}
+  m_Pivot: {x: 1, y: 0.5}
+--- !u!114 &144720361
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 144720359}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ec9d0964fc5c07c4d988ebacfd236eb8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  tooltip: How did you reveal this tooltip?
+  advancedTooltip: 'This is to turn off the other events when you enable the delete
+    tool
+
+    you find a less jank version >.>'
+--- !u!114 &144720362
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 144720359}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 2109663825, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 0}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 0}
+  toggleTransition: 1
+  graphic: {fileID: 0}
+  m_Group: {fileID: 2111875796}
+  onValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.Toggle+ToggleEvent, UnityEngine.UI, Version=1.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  m_IsOn: 0
 --- !u!1 &152414670
 GameObject:
   m_ObjectHideFlags: 0
@@ -9408,6 +9508,7 @@ RectTransform:
   - {fileID: 866190993}
   - {fileID: 1888359316}
   - {fileID: 432640687}
+  - {fileID: 144720360}
   m_Father: {fileID: 2140854277}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -9442,12 +9543,16 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   eventPlacement: {fileID: 1277691436}
   customStandaloneInputModule: {fileID: 806554}
+  keybindsController: {fileID: 1524038336}
   redColorToggle: {fileID: 1090196559}
   blueColorToggle: {fileID: 1879257743}
   offValueToggle: {fileID: 918747283}
   onValueToggle: {fileID: 2050616149}
   fadeValueToggle: {fileID: 1335263902}
   flashValueToggle: {fileID: 1851442476}
+  deleteToggle: {fileID: 2034531416}
+  redNoteToggle: {fileID: 1980311109}
+  dummyToggle: {fileID: 144720362}
 --- !u!1 &378072426
 GameObject:
   m_ObjectHideFlags: 0
@@ -20764,7 +20869,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 376516736}
         m_MethodName: Off
-        m_Mode: 1
+        m_Mode: 0
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -22100,7 +22205,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 1946301807}
   m_Direction: 2
   m_Value: 1
-  m_Size: 0.17548504
+  m_Size: 0.15275095
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -24187,7 +24292,7 @@ PrefabInstance:
     - target: {fileID: 114832386826627720, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
         type: 3}
       propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 114832386826627720, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
         type: 3}
@@ -24370,6 +24475,10 @@ PrefabInstance:
         type: 3}
       propertyPath: m_fontSizeBase
       value: 24
+      objectReference: {fileID: 0}
+    - target: {fileID: 1746501483986880, guid: 4611abd3f8ccdba4bbbb664c6acb538e, type: 3}
+      propertyPath: m_Name
+      value: Red Event Toggle
       objectReference: {fileID: 0}
     - target: {fileID: 224899878580344218, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
         type: 3}
@@ -36394,7 +36503,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 376516736}
         m_MethodName: Fade
-        m_Mode: 1
+        m_Mode: 0
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -39937,7 +40046,19 @@ MonoBehaviour:
   workflowToggle: {fileID: 2140854280}
   measureLinesController: {fileID: 25550676}
   notePlacementUI: {fileID: 1980665313}
+  eventPlacementUI: {fileID: 376516736}
   bookmarkManager: {fileID: 194176332}
+  redNoteToggle: {fileID: 1980311109}
+  blueNoteToggle: {fileID: 2037167245}
+  bombToggle: {fileID: 1421414148}
+  wallToggle: {fileID: 1797211428}
+  deleteToggle: {fileID: 2034531416}
+  redEventToggle: {fileID: 1090196559}
+  blueEventToggle: {fileID: 1879257743}
+  offToggle: {fileID: 918747283}
+  onToggle: {fileID: 2050616149}
+  fadeToggle: {fileID: 1335263902}
+  flashToggle: {fileID: 1851442476}
 --- !u!114 &1524038337
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -44265,7 +44386,7 @@ MonoBehaviour:
   m_Script: {fileID: -1184210157, guid: f70555f144d8491a825f0804e09c671c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_AllowSwitchOff: 1
+  m_AllowSwitchOff: 0
 --- !u!224 &1719109083
 RectTransform:
   m_ObjectHideFlags: 0
@@ -45664,7 +45785,7 @@ MonoBehaviour:
         m_CallState: 2
     m_TypeName: UnityEngine.UI.Toggle+ToggleEvent, UnityEngine.UI, Version=1.0.0.0,
       Culture=neutral, PublicKeyToken=null
-  m_IsOn: 1
+  m_IsOn: 0
 --- !u!1 &1797895644
 GameObject:
   m_ObjectHideFlags: 0
@@ -46618,7 +46739,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 376516736}
         m_MethodName: Flash
-        m_Mode: 1
+        m_Mode: 0
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -47266,7 +47387,7 @@ PrefabInstance:
     - target: {fileID: 114832386826627720, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
         type: 3}
       propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 114832386826627720, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
         type: 3}
@@ -47454,6 +47575,10 @@ PrefabInstance:
         type: 3}
       propertyPath: m_fontSizeBase
       value: 24
+      objectReference: {fileID: 0}
+    - target: {fileID: 1746501483986880, guid: 4611abd3f8ccdba4bbbb664c6acb538e, type: 3}
+      propertyPath: m_Name
+      value: Blue Event Toggle
       objectReference: {fileID: 0}
     - target: {fileID: 224899878580344218, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
         type: 3}
@@ -50925,7 +51050,7 @@ MonoBehaviour:
         m_CallState: 2
       - m_Target: {fileID: 376516736}
         m_MethodName: Delete
-        m_Mode: 1
+        m_Mode: 0
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -51134,7 +51259,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 376516736}
         m_MethodName: On
-        m_Mode: 1
+        m_Mode: 0
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine

--- a/Assets/__Scripts/MapEditor/Detection/BongoCat.cs
+++ b/Assets/__Scripts/MapEditor/Detection/BongoCat.cs
@@ -44,9 +44,12 @@ public class BongoCat : MonoBehaviour
         if (!Settings.Instance.BongoBoye) return;
         BeatmapObjectContainer next = container.LoadedContainers.Where(x => x.objectData._time > note._time &&
         (x.objectData as BeatmapNote)._type == note._type).OrderBy(x => x.objectData._time).FirstOrDefault();
-        if (next is null) return;
-        float half = note._type != BeatmapNote.NOTE_TYPE_BOMB ? container.AudioTimeSyncController.GetSecondsFromBeat((next.objectData._time - note._time) / 2f) : 0f; // ignore bombs
-        float timer = next ? Mathf.Clamp(half, 0.05f, 0.2f) : 0.125f; // clamp to accommodate sliders and long gaps between notes
+        float timer = 0.125f;
+        if (!(next is null))
+        {
+            float half = note._type != BeatmapNote.NOTE_TYPE_BOMB ? container.AudioTimeSyncController.GetSecondsFromBeat((next.objectData._time - note._time) / 2f) : 0f; // ignore bombs
+            timer = next ? Mathf.Clamp(half, 0.05f, 0.2f) : 0.125f; // clamp to accommodate sliders and long gaps between notes
+        }
         switch (note._type)
         {
             case BeatmapNote.NOTE_TYPE_A:

--- a/Assets/__Scripts/MapEditor/Mapping/KeybindsController.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/KeybindsController.cs
@@ -21,7 +21,20 @@ public class KeybindsController : MonoBehaviour {
     [SerializeField] private UIWorkflowToggle workflowToggle;
     [SerializeField] private MeasureLinesController measureLinesController;
     [SerializeField] private NotePlacementUI notePlacementUI;
+    [SerializeField] private EventPlacementUI eventPlacementUI;
     [SerializeField] private BookmarkManager bookmarkManager;
+
+    [SerializeField] private Toggle redNoteToggle;
+    [SerializeField] private Toggle blueNoteToggle;
+    [SerializeField] private Toggle bombToggle;
+    [SerializeField] private Toggle wallToggle;
+    [SerializeField] private Toggle deleteToggle;
+    [SerializeField] private Toggle redEventToggle;
+    [SerializeField] private Toggle blueEventToggle;
+    [SerializeField] private Toggle offToggle;
+    [SerializeField] private Toggle onToggle;
+    [SerializeField] private Toggle fadeToggle;
+    [SerializeField] private Toggle flashToggle;
 
     public bool InvertNoteKeybinds { get => Settings.Instance.InvertNoteControls; }
     public static bool ShiftHeld { get; private set; } = false;
@@ -53,9 +66,9 @@ public class KeybindsController : MonoBehaviour {
             {
                 if (CtrlHeld) { // ctrl modifiers
                     if ((int)vKey >= 48 && (int)vKey <= 57) // laserspeed text done using this instead
-                        if (Input.GetKeyDown(vKey)) laserSpeed.text = (((int)vKey + 2) % 50).ToString();
+                        laserSpeed.text = (((int)vKey + 2) % 50).ToString();
                     if ((int)vKey >= 256 && (int)vKey <= 265)
-                        if (Input.GetKeyDown(vKey)) laserSpeed.text = ((int)vKey + 4 - 260).ToString();
+                        laserSpeed.text = ((int)vKey + 4 - 260).ToString();
 
                     switch (vKey)
                     {
@@ -88,31 +101,30 @@ public class KeybindsController : MonoBehaviour {
                     case KeyCode.V:
                         if (!AnyCriticalKeys && !NodeEditorController.IsActive) notesContainer.UpdateSwingArcVisualizer();
                         break;
-                    case KeyCode.Alpha1: // placement activators
+                    case KeyCode.Alpha1: // ui keybinds ( for top bar )
+                        redEventToggle.isOn = true;
+                        redNoteToggle.isOn = true;
+                        break;
                     case KeyCode.Alpha2:
+                        blueEventToggle.isOn = true;
+                        blueNoteToggle.isOn = true;
+                        break;
+                    case KeyCode.Alpha3:
+                        bombToggle.isOn = true;
+                        break;
+                    case KeyCode.Alpha4:
+                        wallToggle.isOn = true;
+                        break;
+                    case KeyCode.Alpha5:
+                        deleteToggle.isOn = true;
+                        break; // end of ui keybinds
                     case KeyCode.W:
                     case KeyCode.A:
                     case KeyCode.S:
                     case KeyCode.D:
                     case KeyCode.F:
-                        notePlacement.IsActive = true;
-                        bombPlacement.IsActive = false;
-                        obstaclePlacement.IsActive = false;
-                        eventPlacement.IsActive = true;
-                        NotePlacementUI.delete = false;
+                        wasdCase(vKey);
                         break;
-                    case KeyCode.Alpha3:
-                        notePlacement.IsActive = false;
-                        bombPlacement.IsActive = true;
-                        obstaclePlacement.IsActive = false;
-                        NotePlacementUI.delete = false;
-                        break;
-                    case KeyCode.Alpha4:
-                        notePlacement.IsActive = false;
-                        bombPlacement.IsActive = false;
-                        obstaclePlacement.IsActive = true;
-                        NotePlacementUI.delete = false;
-                        break; // end of placement activators
                     case KeyCode.F11:
                         if (!Application.isEditor) Screen.fullScreen = !Screen.fullScreen;
                         break;
@@ -128,7 +140,7 @@ public class KeybindsController : MonoBehaviour {
     {
         if (NodeEditorController.IsActive || PersistentUI.Instance.InputBox_IsEnabled) return;
         if (Input.GetKeyDown(KeyCode.T)) sc.AssignTrack();
-        if (Input.GetKeyDown(KeyCode.Delete)) sc.Delete();
+        if (Input.GetKeyDown(KeyCode.Delete) || Input.GetKeyDown(KeyCode.Backspace)) sc.Delete();
         if (CtrlHeld)
         {
             if (Input.GetKeyDown(KeyCode.A)) SelectionController.DeselectAll();
@@ -151,10 +163,10 @@ public class KeybindsController : MonoBehaviour {
 
     void NotesKeybinds()
     {
-        if (Input.GetKeyDown(KeyCode.Alpha1))
+        /*if (Input.GetKeyDown(KeyCode.Alpha1))
             notePlacement.UpdateType(BN.NOTE_TYPE_A);
         else if (Input.GetKeyDown(KeyCode.Alpha2))
-            notePlacement.UpdateType(BN.NOTE_TYPE_B);
+            notePlacement.UpdateType(BN.NOTE_TYPE_B);*/
 
         if (!notePlacement.IsValid) return;
 
@@ -192,8 +204,8 @@ public class KeybindsController : MonoBehaviour {
     void EventsKeybinds()
     {
         if (!eventPlacement.IsValid) return;
-        if (Input.GetKeyDown(KeyCode.Alpha1)) eventPlacement.SwapColors(true);
-        else if (Input.GetKeyDown(KeyCode.Alpha2)) eventPlacement.SwapColors(false);
+        /*if (Input.GetKeyDown(KeyCode.Alpha1)) eventPlacement.SwapColors(true);
+        else if (Input.GetKeyDown(KeyCode.Alpha2)) eventPlacement.SwapColors(false);*/
 
         if (Input.GetKeyDown(KeyCode.P))
         {
@@ -201,7 +213,7 @@ public class KeybindsController : MonoBehaviour {
                 !eventPlacement.objectContainerCollection.RingPropagationEditing;
         }
 
-        if (Input.GetKeyDown(KeyCode.W))
+        /*if (Input.GetKeyDown(KeyCode.W))
             eventPlacement.UpdateValue(IsRedNote() ? MapEvent.LIGHT_VALUE_RED_ON : MapEvent.LIGHT_VALUE_BLUE_ON);
         else if (Input.GetKeyDown(KeyCode.D))
             eventPlacement.UpdateValue(IsRedNote() ? MapEvent.LIGHT_VALUE_RED_FADE : MapEvent.LIGHT_VALUE_BLUE_FADE);
@@ -209,7 +221,28 @@ public class KeybindsController : MonoBehaviour {
             eventPlacement.UpdateValue(MapEvent.LIGHT_VALUE_OFF);
         else if (Input.GetKeyDown(KeyCode.A))
             eventPlacement.UpdateValue(IsRedNote() ? MapEvent.LIGHT_VALUE_RED_FLASH : MapEvent.LIGHT_VALUE_BLUE_FLASH);
-        else if (Input.GetKeyDown(KeyCode.F)) eventPlacement.SwapColors(!IsRedNote());
+        else if (Input.GetKeyDown(KeyCode.F)) eventPlacement.SwapColors(!IsRedNote());*/
+    }
+
+    public void wasdCase(KeyCode vKey = KeyCode.Escape)
+    {
+        switch (vKey)
+        {
+            case KeyCode.W:
+                onToggle.isOn = true;
+                break;
+            case KeyCode.A:
+                flashToggle.isOn = true;
+                break;
+            case KeyCode.S:
+                offToggle.isOn = true;
+                break;
+            case KeyCode.D:
+                fadeToggle.isOn = true;
+                break;
+        }
+        if (notePlacement.queuedData._type == BeatmapNote.NOTE_TYPE_B) blueNoteToggle.isOn = true;
+        else redNoteToggle.isOn = true;
     }
 
     private bool IsRedNote()

--- a/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/EventPlacement.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/EventPlacement.cs
@@ -73,7 +73,6 @@ public class EventPlacement : PlacementController<MapEvent, BeatmapEventContaine
         if (instantiatedContainer is null) return;
         instantiatedContainer.eventData = queuedData;
         eventAppearanceSO.SetEventAppearance(instantiatedContainer);
-        eventPlacementUI.UpdateUI(queuedData);
     }
 
     public void PlaceChroma(bool v)

--- a/Assets/__Scripts/MapEditor/UI/Info Panel/ChroMapperInfo.txt
+++ b/Assets/__Scripts/MapEditor/UI/Info Panel/ChroMapperInfo.txt
@@ -32,15 +32,17 @@ General Controls
 	Scroll Wheel - Scroll up or down the song according to your Precision Step.
 	Ctrl + Scroll Wheel - Change Precision Step.
 	Delete - Deletes highlighted object, or your selection.
-	Ctrl + Middle Mouse - Deletes highlighted object, or your selection.
-	F10 - Toggles fullscreen mode.
+	Backspace - Delets your selection.
+	Shift + Middle Mouse - Deletes highlighted object.
+	F11 - Toggles fullscreen mode.
 	N - Bring up Node Editor (if Node Editor Keybind is enabled in Options)
 
 Note Controls (While hovering over the Note interface)
 	1/2/3 - Switches between Red, Blue, and Bomb.
 	4 - Switches to a Wall.
+	5 - Switches to Delete Tool.
 	Left Click - Place a note
-	WASD - Change Note Direction (F for dot)
+	WASDF - Change Note Direction (F for dot)
 	Numpad Keys - Change Note Direction (Numpad 5 for dot)
 	Numpad 0 - Change note type to ChromaToggle's Deflect variant.
 	Numpad Period - Change note type to ChromaToggle's Bidirectional variant.
@@ -61,6 +63,11 @@ Lighting Controls (While hovering over the Event interface)
 	F - Swap between Red/Blue
 	Left Click - Place event
 	Delete - Delete highlighted event, and any nearby Chroma RGB event.
+
+Chroma Panel Controls
+	Left Click - Empty palette: Save color in color picker, Full palette: Push saved color to color picker.
+	Shift Left Click - Delete color in palette slot.
+	Middle Click - Overwrite color in palette slot.
 
 Middle Click over Objects without Shift held
 	Event: Swap between Red/Blue

--- a/Assets/__Scripts/MapEditor/UI/Placement Controller UI/EventPlacementUI.cs
+++ b/Assets/__Scripts/MapEditor/UI/Placement Controller UI/EventPlacementUI.cs
@@ -5,64 +5,90 @@ public class EventPlacementUI : MonoBehaviour
 {
     [SerializeField] private EventPlacement eventPlacement;
     [SerializeField] private CustomStandaloneInputModule customStandaloneInputModule;
+    [SerializeField] private KeybindsController keybindsController;
     [SerializeField] private Toggle redColorToggle;
     [SerializeField] private Toggle blueColorToggle;
     [SerializeField] private Toggle offValueToggle;
     [SerializeField] private Toggle onValueToggle;
     [SerializeField] private Toggle fadeValueToggle;
     [SerializeField] private Toggle flashValueToggle;
+    [SerializeField] private Toggle deleteToggle;
+    [SerializeField] private Toggle redNoteToggle;
+    [SerializeField] private Toggle dummyToggle;
     private bool red = true;
 
-    public void Off()
+    public void Off(bool active)
     {
+        if (!active) return;
         UpdateValue(MapEvent.LIGHT_VALUE_OFF);
+        UpdateUI(false);
     }
 
-    public void On()
+    public void On(bool active)
     {
+        if (!active) return;
         UpdateValue(red ? MapEvent.LIGHT_VALUE_RED_ON : MapEvent.LIGHT_VALUE_BLUE_ON);
+        UpdateUI(false);
     }
 
-    public void Fade()
+    public void Fade(bool active)
     {
+        if (!active) return;
         UpdateValue(red ? MapEvent.LIGHT_VALUE_RED_FADE : MapEvent.LIGHT_VALUE_BLUE_FADE);
+        UpdateUI(false);
     }
 
-    public void Flash()
+    public void Flash(bool active)
     {
+        if (!active) return;
         UpdateValue(red ? MapEvent.LIGHT_VALUE_RED_FLASH : MapEvent.LIGHT_VALUE_BLUE_FLASH);
+        UpdateUI(false);
     }
 
-    public void Red()
+    public void Red(bool active)
     {
+        if (!active) return;
         red = true;
+        UpdateUI(false, true);
         eventPlacement.SwapColors(true);
     }
 
-    public void Blue()
+    public void Blue(bool active)
     {
+        if (!active) return;
         red = false;
+        UpdateUI(false, true);
         eventPlacement.SwapColors(false);
     }
 
-    public void Delete()
+    public void Delete(bool active)
     {
-        eventPlacement.IsActive = false;
+        if (!active) return;
+        UpdateUI(true);
     }
 
-    public void UpdateUI(MapEvent previewEvent)
+    public void UpdateUI(bool del, bool on = false) // delete toggle isnt in event toggle group, so lets fake it
     {
-        redColorToggle.isOn = IsRedNote();
-        blueColorToggle.isOn = !IsRedNote();
-        offValueToggle.isOn = previewEvent._value == MapEvent.LIGHT_VALUE_OFF;
-        onValueToggle.isOn = previewEvent._value == MapEvent.LIGHT_VALUE_BLUE_ON || previewEvent._value == MapEvent.LIGHT_VALUE_RED_ON;
-        fadeValueToggle.isOn = previewEvent._value == MapEvent.LIGHT_VALUE_BLUE_FADE || previewEvent._value == MapEvent.LIGHT_VALUE_RED_FADE;
-        flashValueToggle.isOn = previewEvent._value == MapEvent.LIGHT_VALUE_BLUE_FLASH || previewEvent._value == MapEvent.LIGHT_VALUE_RED_FLASH;
+        if (del)
+        {
+            eventPlacement.IsActive = false;
+            dummyToggle.isOn = true;
+        }
+        else
+        {
+            if (NotePlacementUI.delete)
+            {
+                eventPlacement.IsActive = true;
+                keybindsController.wasdCase(); //wtf am i doing; this is for clicking the button
+                NotePlacementUI.delete = false;
+                if (on) onValueToggle.isOn = true;
+            }
+        }
     }
 
     private void UpdateValue(int value)
     {
-        if (!customStandaloneInputModule.IsPointerOverGameObject<GraphicRaycaster>(-1, true)) return;
+        //if (!customStandaloneInputModule.IsPointerOverGameObject<GraphicRaycaster>(-1, true)) return; // again idk what this is
         eventPlacement.UpdateValue(value);
     }
 

--- a/Assets/__Scripts/MapEditor/UI/Placement Controller UI/NotePlacementUI.cs
+++ b/Assets/__Scripts/MapEditor/UI/Placement Controller UI/NotePlacementUI.cs
@@ -21,7 +21,7 @@ public class NotePlacementUI : MonoBehaviour
 
     public void Bomb(bool active)
     {
-        if (!active) return; 
+        if (!active) return;
         notePlacement.IsActive = false;
         bombPlacement.IsActive = true;
         obstaclePlacement.IsActive = false;
@@ -68,8 +68,8 @@ public class NotePlacementUI : MonoBehaviour
 
     private void UpdateValue(int v, bool isChroma = false, int chromaType = 0)
     {
-        if (notePlacement.atsc.IsPlaying) return;
-        if (!customStandaloneInputModule.IsPointerOverGameObject<GraphicRaycaster>(-1, true)) return;
+        //if (notePlacement.atsc.IsPlaying) return;
+        //if (!customStandaloneInputModule.IsPointerOverGameObject<GraphicRaycaster>(-1, true)) return; // not sure what these do?
         notePlacement.IsActive = true;
         bombPlacement.IsActive = false;
         obstaclePlacement.IsActive = false;


### PR DESCRIPTION
- Bongo Cat will now properly smack down on notes when there are no notes afterwards
- Backspace added as a key for deleting a selection
- Few additions to controls listing
- Some jankiness removed from top bar in 03_Mapper
- Some jankiness added to top bar in 03_Mapper
- Key binds reworked to toggle the buttons on the top bar and in turn do their effects through that (Instead of key binds running their own duplicate code directly) This should also mean that the buttons in top bar are correctly highlighted when using key binds

Lots of code I commented out that I probably should have just deleted