### PR TITLE
Gotta earn that purple name

### DIFF
--- a/Assets/HSVPicker/UI/ColorPicker.cs
+++ b/Assets/HSVPicker/UI/ColorPicker.cs
@@ -1,8 +1,10 @@
 ﻿using Assets.HSVPicker;
 using UnityEngine;
+using UnityEngine.UI;
 
 public class ColorPicker : MonoBehaviour
 {
+    [SerializeField] private Toggle placeChromaToggle;
 
     private float _hue = 0;
     private float _saturation = 0;
@@ -211,6 +213,7 @@ public class ColorPicker : MonoBehaviour
     {
         onValueChanged.Invoke(CurrentColor);
         onHSVChanged.Invoke(_hue, _saturation, _brightness);
+        placeChromaToggle.isOn = true;
     }
 
     public void AssignColor(ColorValues type, float value)

--- a/Assets/__Scenes/03_Mapper.unity
+++ b/Assets/__Scenes/03_Mapper.unity
@@ -10127,6 +10127,7 @@ MonoBehaviour:
   deleteToggle: {fileID: 2034531416}
   redNoteToggle: {fileID: 1980311109}
   dummyToggle: {fileID: 144720362}
+  placeChromaToggle: {fileID: 626752600}
 --- !u!1 &378072426
 GameObject:
   m_ObjectHideFlags: 0
@@ -23317,7 +23318,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 1946301807}
   m_Direction: 2
   m_Value: 1
-  m_Size: 0.18521775
+  m_Size: 0.15275095
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -29735,9 +29736,9 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
+  m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: -23.999985, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &1223292197
 RectTransform:
@@ -32823,6 +32824,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8262e4a8322117f4da079921eaa72834, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  dummyToggle: {fileID: 144720362}
+  placeChromaToggle: {fileID: 626752600}
   Setup:
     ShowRgb: 1
     ShowHsv: 1

--- a/Assets/__Scenes/03_Mapper.unity
+++ b/Assets/__Scenes/03_Mapper.unity
@@ -15425,6 +15425,7 @@ MonoBehaviour:
   PostProcess: {fileID: 613879333}
   intensitySlider: {fileID: 1875292310}
   intensityLabel: {fileID: 1875292309}
+  chromaticAberration: {fileID: 1580813947}
 --- !u!1 &614713886
 GameObject:
   m_ObjectHideFlags: 0
@@ -32824,7 +32825,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8262e4a8322117f4da079921eaa72834, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  dummyToggle: {fileID: 144720362}
   placeChromaToggle: {fileID: 626752600}
   Setup:
     ShowRgb: 1
@@ -38469,6 +38469,7 @@ RectTransform:
   - {fileID: 1193767764}
   - {fileID: 1875292308}
   - {fileID: 668200489}
+  - {fileID: 1580813944}
   m_Father: {fileID: 614713887}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -42901,6 +42902,268 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1579100186}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1001 &1580813943
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1354030221}
+    m_Modifications:
+    - target: {fileID: 1783340706785928, guid: 4611abd3f8ccdba4bbbb664c6acb538e, type: 3}
+      propertyPath: m_Name
+      value: Aberration Toggle Container
+      objectReference: {fileID: 0}
+    - target: {fileID: 114832386826627720, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114832386826627720, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_IsOn
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114832386826627720, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_Interactable
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114832386826627720, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 114832386826627720, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 114832386826627720, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 613879335}
+    - target: {fileID: 114832386826627720, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: UpdateChromaticAberration
+      objectReference: {fileID: 0}
+    - target: {fileID: 114832386826627720, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 92.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 220
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 135
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.0000001
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.0000001
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.0000001
+      objectReference: {fileID: 0}
+    - target: {fileID: 114814489792883732, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_text
+      value: 'Chromatic
+
+        Aberration'
+      objectReference: {fileID: 0}
+    - target: {fileID: 114814489792883732, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_havePropertiesChanged
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114814489792883732, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_isInputParsingRequired
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114814489792883732, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_textInfo.characterCount
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 114814489792883732, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_textInfo.spaceCount
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 114814489792883732, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_textInfo.wordCount
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 114814489792883732, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_firstOverflowCharacterIndex
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 114814489792883732, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_textInfo.lineCount
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 114814489792883732, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 114814489792883732, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_fontSizeBase
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 114814489792883732, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_fontAsset
+      value: 
+      objectReference: {fileID: 11400000, guid: 17003b886c2e57b4a9ce9d0d655a397d,
+        type: 2}
+    - target: {fileID: 114814489792883732, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_sharedMaterial
+      value: 
+      objectReference: {fileID: 21947009840950596, guid: 17003b886c2e57b4a9ce9d0d655a397d,
+        type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4611abd3f8ccdba4bbbb664c6acb538e, type: 3}
+--- !u!224 &1580813944 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+    type: 3}
+  m_PrefabInstance: {fileID: 1580813943}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1580813945 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1783340706785928, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+    type: 3}
+  m_PrefabInstance: {fileID: 1580813943}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1580813946
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1580813945}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ec9d0964fc5c07c4d988ebacfd236eb8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  tooltip: 'Enables the Chromatic Aberration
+
+    post processing effect.'
+  advancedTooltip: 
+--- !u!114 &1580813947 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 114832386826627720, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+    type: 3}
+  m_PrefabInstance: {fileID: 1580813943}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 2109663825, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1584806769
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/__Scenes/04_Options.unity
+++ b/Assets/__Scenes/04_Options.unity
@@ -929,6 +929,253 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 42941444}
   m_CullTransparentMesh: 0
+--- !u!1001 &58141240
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1011593270}
+    m_Modifications:
+    - target: {fileID: 1783340706785928, guid: 4611abd3f8ccdba4bbbb664c6acb538e, type: 3}
+      propertyPath: m_Name
+      value: Invert Precision Scroll Toggle
+      objectReference: {fileID: 0}
+    - target: {fileID: 114832386826627720, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114832386826627720, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_IsOn
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 114832386826627720, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_Interactable
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114832386826627720, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 114832386826627720, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 114832386826627720, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 2122444619}
+    - target: {fileID: 114832386826627720, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: UpdateInvertPrecisionScroll
+      objectReference: {fileID: 0}
+    - target: {fileID: 114832386826627720, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 190
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114814489792883732, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_havePropertiesChanged
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114814489792883732, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_isInputParsingRequired
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114814489792883732, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_text
+      value: Invert Precision Scroll
+      objectReference: {fileID: 0}
+    - target: {fileID: 114814489792883732, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_textInfo.characterCount
+      value: 23
+      objectReference: {fileID: 0}
+    - target: {fileID: 114814489792883732, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_textInfo.spaceCount
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 114814489792883732, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_textInfo.wordCount
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 114814489792883732, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_firstOverflowCharacterIndex
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114814489792883732, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_textInfo.lineCount
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114814489792883732, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 114814489792883732, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_fontSizeBase
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 114814489792883732, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_fontAsset
+      value: 
+      objectReference: {fileID: 11400000, guid: 17003b886c2e57b4a9ce9d0d655a397d,
+        type: 2}
+    - target: {fileID: 114814489792883732, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+        type: 3}
+      propertyPath: m_sharedMaterial
+      value: 
+      objectReference: {fileID: 21947009840950596, guid: 17003b886c2e57b4a9ce9d0d655a397d,
+        type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4611abd3f8ccdba4bbbb664c6acb538e, type: 3}
+--- !u!114 &58141241 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 114832386826627720, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+    type: 3}
+  m_PrefabInstance: {fileID: 58141240}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 2109663825, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &69461717
 GameObject:
   m_ObjectHideFlags: 0
@@ -10661,6 +10908,7 @@ RectTransform:
   - {fileID: 320518597}
   - {fileID: 669423013}
   - {fileID: 1623339295}
+  - {fileID: 1384113294}
   m_Father: {fileID: 1925973666}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -14731,6 +14979,32 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1367048659}
   m_CullTransparentMesh: 0
+--- !u!1 &1384113293 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1783340706785928, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+    type: 3}
+  m_PrefabInstance: {fileID: 58141240}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &1384113294 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 224507299272613546, guid: 4611abd3f8ccdba4bbbb664c6acb538e,
+    type: 3}
+  m_PrefabInstance: {fileID: 58141240}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1384113295
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1384113293}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ec9d0964fc5c07c4d988ebacfd236eb8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  tooltip: Invert mouse scroll direction on changing precision step.
+  advancedTooltip: 
 --- !u!1 &1418076363
 GameObject:
   m_ObjectHideFlags: 0
@@ -15839,8 +16113,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 321135046}
   m_HandleRect: {fileID: 321135044}
   m_Direction: 2
-  m_Value: 0.99999994
-  m_Size: 0.32272297
+  m_Value: 1
+  m_Size: 0.21697319
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -16018,8 +16292,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 2143926445}
   m_HandleRect: {fileID: 2143926444}
   m_Direction: 2
-  m_Value: 0.99999934
-  m_Size: 0.82437634
+  m_Value: 1
+  m_Size: 0.5212405
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -18514,7 +18788,7 @@ MonoBehaviour:
   m_enableWordWrapping: 0
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
-  m_firstOverflowCharacterIndex: -1
+  m_firstOverflowCharacterIndex: 0
   m_linkedTextComponent: {fileID: 0}
   m_isLinkedTextComponent: 0
   m_isTextTruncated: 0
@@ -20846,7 +21120,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -199.99997}
+  m_AnchoredPosition: {x: 0, y: -200}
   m_SizeDelta: {x: 0, y: 400}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1925973667
@@ -23965,6 +24239,7 @@ MonoBehaviour:
   chroma: {fileID: 320518596}
   rotateTrack: {fileID: 669423012}
   highlightRecentlyPlaced: {fileID: 1623339294}
+  invertPrecisionScroll: {fileID: 58141241}
 --- !u!1 &2123431281
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/__Scenes/04_Options.unity
+++ b/Assets/__Scenes/04_Options.unity
@@ -89,7 +89,7 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaAO: 1
     m_ShowResolutionOverlay: 1
   m_LightingDataAsset: {fileID: 0}
-  m_UseShadowmask: 0
+  m_UseShadowmask: 1
 --- !u!196 &4
 NavMeshSettings:
   serializedVersion: 2
@@ -2352,6 +2352,8 @@ GameObject:
   - component: {fileID: 159120697}
   - component: {fileID: 159120699}
   - component: {fileID: 159120698}
+  - component: {fileID: 159120701}
+  - component: {fileID: 159120700}
   m_Layer: 5
   m_Name: Container
   m_TagString: Untagged
@@ -2410,7 +2412,7 @@ MonoBehaviour:
   m_Elasticity: 0.1
   m_Inertia: 1
   m_DecelerationRate: 0.135
-  m_ScrollSensitivity: 1
+  m_ScrollSensitivity: 15
   m_Viewport: {fileID: 0}
   m_HorizontalScrollbar: {fileID: 0}
   m_VerticalScrollbar: {fileID: 1498137665}
@@ -2423,6 +2425,43 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: UnityEngine.UI.ScrollRect+ScrollRectEvent, UnityEngine.UI, Version=1.0.0.0,
       Culture=neutral, PublicKeyToken=null
+--- !u!114 &159120700
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 159120696}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+--- !u!222 &159120701
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 159120696}
+  m_CullTransparentMesh: 0
 --- !u!1 &166721873
 GameObject:
   m_ObjectHideFlags: 0
@@ -2919,6 +2958,8 @@ GameObject:
   - component: {fileID: 192616574}
   - component: {fileID: 192616577}
   - component: {fileID: 192616576}
+  - component: {fileID: 192616578}
+  - component: {fileID: 192616575}
   m_Layer: 5
   m_Name: Container
   m_TagString: Untagged
@@ -2946,6 +2987,35 @@ RectTransform:
   m_AnchoredPosition: {x: -10, y: 0}
   m_SizeDelta: {x: -20, y: -10}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &192616575
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 192616573}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
 --- !u!114 &192616576
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2977,7 +3047,7 @@ MonoBehaviour:
   m_Elasticity: 0.1
   m_Inertia: 1
   m_DecelerationRate: 0.135
-  m_ScrollSensitivity: 1
+  m_ScrollSensitivity: 15
   m_Viewport: {fileID: 0}
   m_HorizontalScrollbar: {fileID: 0}
   m_VerticalScrollbar: {fileID: 1505966416}
@@ -2990,6 +3060,14 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: UnityEngine.UI.ScrollRect+ScrollRectEvent, UnityEngine.UI, Version=1.0.0.0,
       Culture=neutral, PublicKeyToken=null
+--- !u!222 &192616578
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 192616573}
+  m_CullTransparentMesh: 0
 --- !u!1 &195831781
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/__Scripts/Map/Events/BeatmapEventContainer.cs
+++ b/Assets/__Scripts/Map/Events/BeatmapEventContainer.cs
@@ -33,7 +33,7 @@ public class BeatmapEventContainer : BeatmapObjectContainer {
         container.eventData = data;
         container.eventAppearance = eventAppearanceSO;
         container.transform.localEulerAngles = Vector3.zero;
-        eventAppearanceSO.SetEventAppearance(container);
+        eventAppearanceSO.SetEventAppearance(container, true);
         return container;
     }
 
@@ -132,6 +132,12 @@ public class BeatmapEventContainer : BeatmapObjectContainer {
         if (gameObject.activeInHierarchy)
             if (mat.GetFloat("_MainAlpha") > 0) oldAlpha = mat.GetFloat("_MainAlpha");
             mat.SetFloat("_MainAlpha", alpha == -1 ? oldAlpha : alpha);
+    }
+
+    public void UpdateScale(float scale)
+    {
+        if (gameObject.activeInHierarchy)
+            transform.localScale = new Vector3(scale, scale, scale);
     }
 
     public void RefreshAppearance()

--- a/Assets/__Scripts/Map/Events/EventAppearanceSO.cs
+++ b/Assets/__Scripts/Map/Events/EventAppearanceSO.cs
@@ -23,9 +23,11 @@ public class EventAppearanceSO : ScriptableObject
     private int[] TextLabelTypes = new int[] { MapEvent.EVENT_TYPE_LEFT_LASERS_SPEED, MapEvent.EVENT_TYPE_RIGHT_LASERS_SPEED,
         MapEvent.EVENT_TYPE_EARLY_ROTATION, MapEvent.EVENT_TYPE_LATE_ROTATION};
 
-    public void SetEventAppearance(BeatmapEventContainer e) {
+    public void SetEventAppearance(BeatmapEventContainer e, bool final = false) {
         Color color = Color.white;
-        foreach(TextMeshProUGUI t in e.GetComponentsInChildren<TextMeshProUGUI>()) Destroy(t.transform.parent.gameObject);
+        e.UpdateAlpha(final ? 1.0f : 0.6f);
+        e.UpdateScale(final ? 0.75f : 0.6f);
+        foreach (TextMeshProUGUI t in e.GetComponentsInChildren<TextMeshProUGUI>()) Destroy(t.transform.parent.gameObject);
         if (TextLabelTypes.Contains(e.eventData._type))
         {
             GameObject instantiate = Instantiate(LaserSpeedPrefab, e.transform);
@@ -53,7 +55,7 @@ public class EventAppearanceSO : ScriptableObject
             if (e.eventData._value >= ColourManager.RGB_INT_OFFSET)
             {
                 color = ColourManager.ColourFromInt(e.eventData._value);
-                e.UpdateAlpha(0.75f);
+                e.UpdateAlpha(final ? 0.9f : 0.6f);
             }
             else if (e.eventData._value <= 3)
             {

--- a/Assets/__Scripts/MapEditor/AudioTimeSyncController.cs
+++ b/Assets/__Scripts/MapEditor/AudioTimeSyncController.cs
@@ -101,7 +101,9 @@ public class AudioTimeSyncController : MonoBehaviour {
                 {
                     if (KeybindsController.CtrlHeld)
                     {
-                        float scrollDirection = Input.GetAxis("Mouse ScrollWheel") > 0 ? 2 : 0.5f;
+                        float scrollDirection;
+                        if (Settings.Instance.InvertPrecisionScroll) scrollDirection = Input.GetAxis("Mouse ScrollWheel") > 0 ? 0.5f : 2;
+                        else scrollDirection = Input.GetAxis("Mouse ScrollWheel") > 0 ? 2 : 0.5f;
                         gridMeasureSnapping = Mathf.Clamp(Mathf.RoundToInt(gridMeasureSnapping * scrollDirection), 1, 64);
                     }
                     else

--- a/Assets/__Scripts/MapEditor/AudioTimeSyncController.cs
+++ b/Assets/__Scripts/MapEditor/AudioTimeSyncController.cs
@@ -97,17 +97,17 @@ public class AudioTimeSyncController : MonoBehaviour {
             }
             else if (!(PauseManager.IsPaused || OptionsController.IsActive) && !NodeEditorController.IsActive)
             {
-                if (Input.GetAxis("Mouse ScrollWheel") != 0 && !KeybindsController.AltHeld)
+                if (Input.GetAxisRaw("Mouse ScrollWheel") != 0 && !KeybindsController.AltHeld)
                 {
                     if (KeybindsController.CtrlHeld)
                     {
                         float scrollDirection;
-                        if (Settings.Instance.InvertPrecisionScroll) scrollDirection = Input.GetAxis("Mouse ScrollWheel") > 0 ? 0.5f : 2;
-                        else scrollDirection = Input.GetAxis("Mouse ScrollWheel") > 0 ? 2 : 0.5f;
+                        if (Settings.Instance.InvertPrecisionScroll) scrollDirection = Input.GetAxisRaw("Mouse ScrollWheel") > 0 ? 0.5f : 2;
+                        else scrollDirection = Input.GetAxisRaw("Mouse ScrollWheel") > 0 ? 2 : 0.5f;
                         gridMeasureSnapping = Mathf.Clamp(Mathf.RoundToInt(gridMeasureSnapping * scrollDirection), 1, 64);
                     }
                     else
-                        MoveToTimeInBeats(CurrentBeat + (1f / gridMeasureSnapping * (Input.GetAxis("Mouse ScrollWheel") > 0 ? 1f : -1f)));
+                        MoveToTimeInBeats(CurrentBeat + (1f / gridMeasureSnapping * (Input.GetAxisRaw("Mouse ScrollWheel") > 0 ? 1f : -1f)));
                 }
             }
 

--- a/Assets/__Scripts/MapEditor/Grid/Collections/EventsContainer.cs
+++ b/Assets/__Scripts/MapEditor/Grid/Collections/EventsContainer.cs
@@ -116,14 +116,18 @@ public class EventsContainer : BeatmapObjectContainerCollection
         OnPlayToggle(AudioTimeSyncController.IsPlaying);
     }
 
-    public override BeatmapObjectContainer SpawnObject(BeatmapObject obj, out BeatmapObjectContainer conflicting, bool removeConflicting = true)
+    public override BeatmapObjectContainer SpawnObject(BeatmapObject obj, out BeatmapObjectContainer conflicting, bool removeConflicting = false)
     {
         UseChunkLoading = false;
         conflicting = LoadedContainers.FirstOrDefault(x => x.objectData._time == obj._time &&
             (obj as MapEvent)._type == (x.objectData as MapEvent)._type &&
             (obj as MapEvent)._customData == (x.objectData as MapEvent)._customData
         );
-        if (conflicting != null && removeConflicting) DeleteObject(conflicting);
+        if (conflicting != null)
+        {
+            if (removeConflicting) DeleteObject(conflicting);
+            else return null;
+        }
         BeatmapEventContainer beatmapEvent = BeatmapEventContainer.SpawnEvent(obj as MapEvent, ref eventPrefab, ref eventAppearanceSO);
         beatmapEvent.transform.SetParent(GridTransform);
         beatmapEvent.UpdateGridPosition();

--- a/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/EventPlacement.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/EventPlacement.cs
@@ -113,6 +113,7 @@ public class EventPlacement : PlacementController<MapEvent, BeatmapEventContaine
             MapEvent justChroma = BeatmapObject.GenerateCopy(queuedData);
             justChroma._value = ColourManager.ColourToInt(colorPicker.CurrentColor);
             BeatmapEventContainer container = objectContainerCollection.SpawnObject(justChroma, out BeatmapObjectContainer conflicting2) as BeatmapEventContainer;
+            if (container == null) return;
             BeatmapActionContainer.AddAction(new BeatmapObjectPlacementAction(new List<BeatmapObjectContainer>() { conflicting2 },
                 new List<BeatmapObjectContainer>() { container } ));
             SelectionController.RefreshMap();
@@ -120,6 +121,7 @@ public class EventPlacement : PlacementController<MapEvent, BeatmapEventContaine
             return;
         }
         BeatmapEventContainer spawned = objectContainerCollection.SpawnObject(BeatmapObject.GenerateCopy(queuedData), out BeatmapObjectContainer conflicting) as BeatmapEventContainer;
+        if (spawned == null) return;
         BeatmapEventContainer chroma = null;
         if (Settings.Instance.PlaceChromaEvents && !queuedData.IsUtilityEvent() && (queuedValue != MapEvent.LIGHT_VALUE_OFF))
         {

--- a/Assets/__Scripts/MapEditor/UI/MirrorSelection.cs
+++ b/Assets/__Scripts/MapEditor/UI/MirrorSelection.cs
@@ -30,51 +30,48 @@ public class MirrorSelection : MonoBehaviour
             {
                 bool precisionWidth = obstacle.obstacleData._width >= 1000;
                 int __state = obstacle.obstacleData._lineIndex;
-                if (__state > 3 || __state < 0 || precisionWidth) // thank you past me for this code
+                if (__state >= 1000 || __state <= -1000 || precisionWidth) // precision lineIndex
                 {
-                    if (__state >= 1000 || __state <= -1000 || precisionWidth) // precision lineIndex
+                    int newIndex = __state;
+                    if (newIndex <= -1000) // normalize index values, we'll fix them later
                     {
-                        int newIndex = __state;
-                        if (newIndex <= -1000) // normalize index values, we'll fix them later
-                        {
-                            newIndex += 1000;
-                        }
-                        else if (newIndex >= 1000)
-                        {
-                            newIndex -= 1000;
-                        }
-                        else
-                        {
-                            newIndex = newIndex * 1000; //convert lineIndex to precision if not already
-                        }
-                        newIndex = (((newIndex - 2000) * -1) + 2000); //flip lineIndex
-
-                        int newWidth = obstacle.obstacleData._width; //normalize wall width
-                        if (newWidth < 1000)
-                        {
-                            newWidth = newWidth * 1000;
-                        }
-                        else
-                        {
-                            newWidth -= 1000;
-                        }
-                        newIndex = newIndex - newWidth;
-
-                        if (newIndex < 0)
-                        { //this is where we fix them
-                            newIndex -= 1000;
-                        }
-                        else
-                        {
-                            newIndex += 1000;
-                        }
-                        obstacle.obstacleData._lineIndex = newIndex;
+                        newIndex += 1000;
                     }
-                    else // state > -1000 || state < 1000 assumes no precision width
+                    else if (newIndex >= 1000)
                     {
-                        int mirrorLane = (((__state - 2) * -1) + 2); //flip lineIndex
-                        obstacle.obstacleData._lineIndex = mirrorLane - obstacle.obstacleData._width; //adjust for wall width
+                        newIndex -= 1000;
                     }
+                    else
+                    {
+                        newIndex = newIndex * 1000; //convert lineIndex to precision if not already
+                    }
+                    newIndex = (((newIndex - 2000) * -1) + 2000); //flip lineIndex
+
+                    int newWidth = obstacle.obstacleData._width; //normalize wall width
+                    if (newWidth < 1000)
+                    {
+                        newWidth = newWidth * 1000;
+                    }
+                    else
+                    {
+                        newWidth -= 1000;
+                    }
+                    newIndex = newIndex - newWidth;
+
+                    if (newIndex < 0)
+                    { //this is where we fix them
+                        newIndex -= 1000;
+                    }
+                    else
+                    {
+                        newIndex += 1000;
+                    }
+                    obstacle.obstacleData._lineIndex = newIndex;
+                }
+                else // state > -1000 || state < 1000 assumes no precision width
+                {
+                    int mirrorLane = (((__state - 2) * -1) + 2); //flip lineIndex
+                    obstacle.obstacleData._lineIndex = mirrorLane - obstacle.obstacleData._width; //adjust for wall width
                 }
                 con.UpdateGridPosition();
             }

--- a/Assets/__Scripts/MapEditor/UI/Placement Controller UI/EventPlacementUI.cs
+++ b/Assets/__Scripts/MapEditor/UI/Placement Controller UI/EventPlacementUI.cs
@@ -15,6 +15,7 @@ public class EventPlacementUI : MonoBehaviour
     [SerializeField] private Toggle deleteToggle;
     [SerializeField] private Toggle redNoteToggle;
     [SerializeField] private Toggle dummyToggle;
+    [SerializeField] private Toggle placeChromaToggle;
     private bool red = true;
 
     public void Off(bool active)
@@ -69,6 +70,7 @@ public class EventPlacementUI : MonoBehaviour
 
     public void UpdateUI(bool del, bool on = false) // delete toggle isnt in event toggle group, so lets fake it
     {
+        placeChromaToggle.isOn = false;
         if (del)
         {
             eventPlacement.IsActive = false;

--- a/Assets/__Scripts/MapEditor/UI/PostProcessingController.cs
+++ b/Assets/__Scripts/MapEditor/UI/PostProcessingController.cs
@@ -8,6 +8,7 @@ public class PostProcessingController : MonoBehaviour {
     public PostProcessVolume PostProcess;
     [SerializeField] private Slider intensitySlider;
     [SerializeField] private TextMeshProUGUI intensityLabel;
+    [SerializeField] private Toggle chromaticAberration;
 
     private void Start()
     {
@@ -15,6 +16,8 @@ public class PostProcessingController : MonoBehaviour {
         intensitySlider.value = v * 2;
         intensityLabel.text = v.ToString();
         PostProcess.profile.GetSetting<Bloom>().intensity.value = v;
+
+        chromaticAberration.isOn = Settings.Instance.ChromaticAberration;
     }
 
     public void UpdatePostProcessIntensity(float v)
@@ -22,5 +25,11 @@ public class PostProcessingController : MonoBehaviour {
         PostProcess.profile.GetSetting<Bloom>().intensity.value = v / 2;
         intensityLabel.text = (v / 2).ToString();
         Settings.Instance.PostProcessingIntensity = v / 2;
+    }
+
+    public void UpdateChromaticAberration(bool enabled)
+    {
+        PostProcess.profile.GetSetting<ChromaticAberration>().active = enabled;
+        Settings.Instance.ChromaticAberration = enabled;
     }
 }

--- a/Assets/__Scripts/Settings/Settings.cs
+++ b/Assets/__Scripts/Settings/Settings.cs
@@ -50,6 +50,7 @@ public class Settings {
     public bool EmulateChromaAdvanced = true; //Ring propagation and other advanced chroma features
     public bool RotateTrack = true;
     public bool HighlightLastPlacedNotes = false;
+    public bool InvertPrecisionScroll = false;
     public bool Reminder_Loading360Levels = true;
     public bool Reminder_SettingsFailed = true;
     public bool AdvancedShit = false;

--- a/Assets/__Scripts/Settings/Settings.cs
+++ b/Assets/__Scripts/Settings/Settings.cs
@@ -55,6 +55,7 @@ public class Settings {
     public bool Reminder_SettingsFailed = true;
     public bool AdvancedShit = false;
     public bool InstantEscapeMenuTransitions = false;
+    public bool ChromaticAberration = true;
 
     private static Settings Load()
     {

--- a/Assets/__Scripts/UI/Options/OptionsEditorSettings.cs
+++ b/Assets/__Scripts/UI/Options/OptionsEditorSettings.cs
@@ -35,6 +35,7 @@ public class OptionsEditorSettings : MonoBehaviour
     [SerializeField] private Toggle chroma;
     [SerializeField] private Toggle rotateTrack;
     [SerializeField] private Toggle highlightRecentlyPlaced;
+    [SerializeField] private Toggle invertPrecisionScroll;
     void Start()
     {
         editorScaleSlider.value = Settings.Instance.EditorScale;
@@ -64,6 +65,7 @@ public class OptionsEditorSettings : MonoBehaviour
         chroma.isOn = Settings.Instance.EmulateChromaAdvanced;
         rotateTrack.isOn = Settings.Instance.RotateTrack;
         highlightRecentlyPlaced.isOn = Settings.Instance.HighlightLastPlacedNotes;
+        invertPrecisionScroll.isOn = Settings.Instance.InvertPrecisionScroll;
     }
 
     #region Update Editor Variables
@@ -224,6 +226,11 @@ public class OptionsEditorSettings : MonoBehaviour
     public void UpdateRecentlyPlacedNotes(bool enabled)
     {
         Settings.Instance.HighlightLastPlacedNotes = enabled;
+    }
+
+    public void UpdateInvertPrecisionScroll(bool enabled)
+    {
+        Settings.Instance.InvertPrecisionScroll = enabled;
     }
     #endregion
 }


### PR DESCRIPTION
- Fix: Mirror selection tool now works on non-mapping extensions walls (can't believe I forgot to do that)
- Added "Invert Precision Scroll" option in 04_Options, this will invert the direction you scroll the mouse wheel to change precision step
- Fix: You can now correctly hover over any part of the scroll area in 04_Options to scroll with mouse wheel (this was fixed by placing a fully transparent image over the whole area)
- Fix: Bumped up scroll sensitivity in 04_Options so you can actually scroll with mouse wheel (note: this may cause problems on non-windows devices and may need to be adjusted)
- Changed event placement to no longer overwrite existing events at the same timestamp, will instead no longer place (parameter still in function to allow old functionality in case we want this to be an option)
- The preview event is now smaller and transparent than placed events to more easily distinguish, go see this in-game and this you'll love this change the most
- Color picker will automatically enable the "Place Chroma Event" toggle
- Picking an event type will disable the "Place Chroma Event" toggle (may need future tweaking)
- Added option in pause menu to disable Chromatic Aberration