### PR TITLE
Development (1-29-20)

### DIFF
--- a/Assets/_Graphics/Textures And Sprites/UI/Options.meta
+++ b/Assets/_Graphics/Textures And Sprites/UI/Options.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 3007b111c3aa3994ea889a518485d82f
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/__Scripts/BeatSaberSong.cs
+++ b/Assets/__Scripts/BeatSaberSong.cs
@@ -84,6 +84,7 @@ public class BeatSaberSong
     public string coverImageFilename = "cover.png";
     public string environmentName = "DefaultEnvironment";
     public string allDirectionsEnvironmentName = "GlassDesertEnvironment";
+    public string editor = "chromapper"; //BeatMapper started doing this so might as well do it for CM too
     public JSONNode customData;
 
     private bool isWIPMap = false;
@@ -143,12 +144,14 @@ public class BeatSaberSong
             json["_environmentName"] = environmentName;
             json["_allDirectionsEnvironmentName"] = allDirectionsEnvironmentName;
             json["_customData"] = customData;
+            json["_customData"]["_editor"] = editor;
 
             JSONArray contributorArrayFUCKYOUGIT = new JSONArray();
             contributors.DistinctBy(x => x.ToJSONNode().ToString()).ToList().ForEach(x => contributorArrayFUCKYOUGIT.Add(x.ToJSONNode()));
             json["_customData"]["_contributors"] = contributorArrayFUCKYOUGIT;
 
             //BeatSaver schema changes, see below comment.
+            if (string.IsNullOrEmpty(customData["_editor"])) json["_customData"]["_editor"] = "chromapper";
             if (string.IsNullOrEmpty(customData["_contributors"])) json["_customData"].Remove("_contributors");
             if (string.IsNullOrEmpty(customData["_customEnvironment"])) json["_customData"].Remove("_customEnvironment");
             if (string.IsNullOrEmpty(customData["_customEnvironmentHash"])) json["_customData"].Remove("_customEnvironmentHash");
@@ -276,6 +279,7 @@ public class BeatSaberSong
                                 foreach (JSONNode contributor in n["_contributors"].AsArray)
                                     song.contributors.Add(new MapContributor(contributor));
                             }
+                            if (n["_editor"]?.Value != null) song.editor = n["_editor"].Value;
                         }
                         break;
 

--- a/Assets/__Scripts/BeatmapActions/Beatmap Action Containers/BeatmapActionContainer.cs
+++ b/Assets/__Scripts/BeatmapActions/Beatmap Action Containers/BeatmapActionContainer.cs
@@ -28,7 +28,7 @@ public class BeatmapActionContainer : MonoBehaviour
         instance.beatmapActions.RemoveAll(x => !x.Active);
         instance.beatmapActions.Add(action);
         instance.beatmapActions = instance.beatmapActions.Distinct().ToList();
-        Debug.Log($"Action of type {action.GetType().Name} added.");
+        Debug.Log($"Action of type {action.GetType().Name} added. ({action.Comment})");
     }
 
     public void Undo()
@@ -36,7 +36,7 @@ public class BeatmapActionContainer : MonoBehaviour
         if (!beatmapActions.Any()) return;
         BeatmapAction lastActive = beatmapActions.LastOrDefault(x => x.Active);
         if (lastActive == null) return;
-        Debug.Log($"Undid a {lastActive.GetType().Name}.");
+        Debug.Log($"Undid a {lastActive.GetType().Name}. ({lastActive.Comment})");
         BeatmapActionParams param = new BeatmapActionParams(this);
         lastActive.Undo(param);
         lastActive.Active = false;
@@ -47,7 +47,7 @@ public class BeatmapActionContainer : MonoBehaviour
         if (!beatmapActions.Any()) return;
         BeatmapAction firstNotActive = beatmapActions.FirstOrDefault(x => !x.Active);
         if (firstNotActive == null) return;
-        Debug.Log($"Redid a {firstNotActive.GetType().Name}.");
+        Debug.Log($"Redid a {firstNotActive.GetType().Name}. ({firstNotActive.Comment})");
         BeatmapActionParams param = new BeatmapActionParams(this);
         firstNotActive.Redo(param);
         firstNotActive.Active = true;

--- a/Assets/__Scripts/BeatmapActions/Beatmap Actions/BeatmapObjectDeletionAction.cs
+++ b/Assets/__Scripts/BeatmapActions/Beatmap Actions/BeatmapObjectDeletionAction.cs
@@ -3,9 +3,9 @@ using System.Linq;
 
 public class BeatmapObjectDeletionAction : BeatmapAction
 {
-    public BeatmapObjectDeletionAction(IEnumerable<BeatmapObjectContainer> objs) : base(objs) { }
+    public BeatmapObjectDeletionAction(IEnumerable<BeatmapObjectContainer> objs, string comment) : base(objs, comment) { }
 
-    public BeatmapObjectDeletionAction(BeatmapObjectContainer obj) : base(new List<BeatmapObjectContainer>() { obj }) { }
+    public BeatmapObjectDeletionAction(BeatmapObjectContainer obj, string comment) : base(new [] { obj }, comment) { }
 
     public override void Undo(BeatmapActionContainer.BeatmapActionParams param)
     {
@@ -19,6 +19,7 @@ public class BeatmapObjectDeletionAction : BeatmapAction
 
     public override void Redo(BeatmapActionContainer.BeatmapActionParams param)
     {
-        foreach (BeatmapObjectContainer obj in containers) param.collections.ForEach(x => x.DeleteObject(obj));
+        foreach (BeatmapObjectContainer obj in containers)
+            param.collections.ForEach(x => x.DeleteObject(obj, false, Comment));
     }
 }

--- a/Assets/__Scripts/BeatmapActions/Beatmap Actions/BeatmapObjectPlacementAction.cs
+++ b/Assets/__Scripts/BeatmapActions/Beatmap Actions/BeatmapObjectPlacementAction.cs
@@ -7,7 +7,7 @@ public class BeatmapObjectPlacementAction : BeatmapAction
     internal List<BeatmapObject> removedConflictObjectsData = new List<BeatmapObject>();
 
     public BeatmapObjectPlacementAction(IEnumerable<BeatmapObjectContainer> conflictingObjects, 
-        IEnumerable<BeatmapObjectContainer> placedContainers) : base(placedContainers) {
+        IEnumerable<BeatmapObjectContainer> placedContainers, string comment) : base(placedContainers, comment) {
         foreach (BeatmapObjectContainer con in conflictingObjects)
         {
             if (con is null) continue;
@@ -17,14 +17,14 @@ public class BeatmapObjectPlacementAction : BeatmapAction
     }
 
     public BeatmapObjectPlacementAction(BeatmapObjectContainer placedContainer,
-       BeatmapObjectContainer conflictingObject) : base(new List<BeatmapObjectContainer>() { placedContainer })
+       BeatmapObjectContainer conflictingObject, string comment) : base(new [] { placedContainer }, comment)
     {
         removedConflictObjects.Add(conflictingObject);
     }
 
     public override void Undo(BeatmapActionContainer.BeatmapActionParams param)
     {
-        foreach (BeatmapObjectContainer obj in containers) param.collections.ForEach(x => x.DeleteObject(obj));
+        foreach (BeatmapObjectContainer obj in containers) param.collections.ForEach(x => x.DeleteObject(obj, false));
         removedConflictObjects.Clear();
         foreach (BeatmapObject data in removedConflictObjectsData)
             removedConflictObjects.Add(param.collections.FirstOrDefault(x => x.ContainerType == data.beatmapType)?.SpawnObject(
@@ -34,7 +34,7 @@ public class BeatmapObjectPlacementAction : BeatmapAction
 
     public override void Redo(BeatmapActionContainer.BeatmapActionParams param)
     {
-        foreach (BeatmapObjectContainer obj in removedConflictObjects) param.collections.ForEach(x => x.DeleteObject(obj));
+        foreach (BeatmapObjectContainer obj in removedConflictObjects) param.collections.ForEach(x => x.DeleteObject(obj, false));
         containers.Clear();
         foreach (BeatmapObject con in data)
             containers.Add(param.collections.FirstOrDefault(x => x.ContainerType == con.beatmapType)?.SpawnObject(

--- a/Assets/__Scripts/BeatmapActions/Beatmap Actions/NodeEditorUpdatedNodeAction.cs
+++ b/Assets/__Scripts/BeatmapActions/Beatmap Actions/NodeEditorUpdatedNodeAction.cs
@@ -7,7 +7,7 @@ public class NodeEditorUpdatedNodeAction : BeatmapAction
     private JSONNode editedData;//todo: is this needed
 
     public NodeEditorUpdatedNodeAction(BeatmapObjectContainer obj, JSONNode edited, JSONNode original)
-        : base(new List<BeatmapObjectContainer>() { obj })
+        : base(new List<BeatmapObjectContainer>() { obj }, $"Edited a {obj.objectData.beatmapType} with Node Editor.")
     {
         editedData = edited;
         originalData = original;

--- a/Assets/__Scripts/BeatmapActions/Beatmap Actions/StrobeGeneratorGenerationAction.cs
+++ b/Assets/__Scripts/BeatmapActions/Beatmap Actions/StrobeGeneratorGenerationAction.cs
@@ -14,7 +14,7 @@ public class StrobeGeneratorGenerationAction : BeatmapAction
     public override void Undo(BeatmapActionContainer.BeatmapActionParams param)
     {
         SelectionController.DeselectAll();
-        foreach (BeatmapObjectContainer obj in containers) param.collections.ForEach(x => x.DeleteObject(obj));
+        foreach (BeatmapObjectContainer obj in containers) param.collections.ForEach(x => x.DeleteObject(obj, false));
         foreach (BeatmapObject obj in conflictingData)
         {
             conflictingContainers.Add(param.collections.First(x => x.ContainerType == BeatmapObject.Type.EVENT).SpawnObject(BeatmapObject.GenerateCopy(obj), out _));
@@ -27,7 +27,7 @@ public class StrobeGeneratorGenerationAction : BeatmapAction
     public override void Redo(BeatmapActionContainer.BeatmapActionParams param)
     {
         SelectionController.DeselectAll();
-        foreach (BeatmapObjectContainer obj in conflictingContainers) param.collections.ForEach(x => x.DeleteObject(obj));
+        foreach (BeatmapObjectContainer obj in conflictingContainers) param.collections.ForEach(x => x.DeleteObject(obj, false));
         foreach (BeatmapObject obj in data)
         {
             containers.Add(param.collections.First(x => x.ContainerType == BeatmapObject.Type.EVENT).SpawnObject(BeatmapObject.GenerateCopy(obj), out _));

--- a/Assets/__Scripts/BeatmapActions/BeatmapAction.cs
+++ b/Assets/__Scripts/BeatmapActions/BeatmapAction.cs
@@ -10,11 +10,11 @@ using System;
 public abstract class BeatmapAction : IEquatable<BeatmapAction>
 {
     public bool Active = true;
-
+    public string Comment { get; private set; } = "No comment.";
     public List<BeatmapObjectContainer> containers = new List<BeatmapObjectContainer>();
     public List<BeatmapObject> data = new List<BeatmapObject>();
 
-    public BeatmapAction (IEnumerable<BeatmapObjectContainer> containers){
+    public BeatmapAction (IEnumerable<BeatmapObjectContainer> containers, string comment = "No comment."){
         if (containers is null) return;
         foreach(BeatmapObjectContainer con in containers)
         {
@@ -22,6 +22,7 @@ public abstract class BeatmapAction : IEquatable<BeatmapAction>
             this.containers.Add(con);
             data.Add(con.objectData);
         }
+        Comment = comment;
     }
 
     public static bool operator ==(BeatmapAction a, BeatmapAction b)

--- a/Assets/__Scripts/Map/BeatmapObjectContainer.cs
+++ b/Assets/__Scripts/Map/BeatmapObjectContainer.cs
@@ -7,7 +7,7 @@ public abstract class BeatmapObjectContainer : MonoBehaviour {
     public static readonly int BeatmapObjectLayer = 9; //todo: is this needed
     public static readonly int BeatmapObjectSelectedLayer = 10; //todo: is this needed
 
-    public static Action<BeatmapObjectContainer, bool> FlaggedForDeletionEvent;
+    public static Action<BeatmapObjectContainer, bool, string> FlaggedForDeletionEvent;
 
     [SerializeField] protected Material SelectionMaterial;
     public bool OutlineVisible { get => SelectionMaterial.GetFloat(Outline) != 0;
@@ -59,7 +59,8 @@ public abstract class BeatmapObjectContainer : MonoBehaviour {
     internal virtual void OnMouseOver()
     {
         if (!KeybindsController.ShiftHeld) {
-            if (Input.GetMouseButtonDown(0) && NotePlacementUI.delete) FlaggedForDeletionEvent?.Invoke(this, true);
+            if (Input.GetMouseButtonDown(0) && NotePlacementUI.delete)
+                FlaggedForDeletionEvent?.Invoke(this, true, "Deleted with the Delete Tool.");
             return;
         }
         if (Input.GetMouseButton(0) && !selectionStateChanged)
@@ -69,7 +70,7 @@ public abstract class BeatmapObjectContainer : MonoBehaviour {
             selectionStateChanged = true;
         }
         else if (Input.GetMouseButtonDown(2))
-            FlaggedForDeletionEvent?.Invoke(this, true);
+            FlaggedForDeletionEvent?.Invoke(this, true, "Deleted by a Middle Mouse event.");
     }
 
     internal virtual void SafeSetActive(bool active)

--- a/Assets/__Scripts/Map/Events/MapEvent.cs
+++ b/Assets/__Scripts/Map/Events/MapEvent.cs
@@ -60,10 +60,9 @@ public class MapEvent : BeatmapObject {
     }
 
     public int? GetRotationDegreeFromValue()
-    {
+    {   //Mapping Extensions precision rotation from 1000 to 1720: 1000 = -360 degrees, 1360 = 0 degrees, 1720 = 360 degrees
         if (_value >= 0 && _value < LIGHT_VALUE_TO_ROTATION_DEGREES.Length) return LIGHT_VALUE_TO_ROTATION_DEGREES[_value];
-        else if (_value >= 1000 && _value <= 1720) //Mapping Extensions precision rotation
-            return _value - 1360; //1000 = -360 degrees, 1360 = 0 degrees, 1720 = 360 degrees
+        else if (_value >= 1000 && _value <= 1720)  return _value - 1360;
         return null;
     }
 

--- a/Assets/__Scripts/MapEditor/Grid/Collections/BeatmapObjectContainerCollection.cs
+++ b/Assets/__Scripts/MapEditor/Grid/Collections/BeatmapObjectContainerCollection.cs
@@ -31,11 +31,11 @@ public abstract class BeatmapObjectContainerCollection : MonoBehaviour
         levelLoaded = true;
     }
 
-    public void DeleteObject(BeatmapObjectContainer obj, bool triggersAction = true)
+    public void DeleteObject(BeatmapObjectContainer obj, bool triggersAction = true, string comment = "No comment.")
     {
         if (LoadedContainers.Contains(obj))
         {
-            if (triggersAction) BeatmapActionContainer.AddAction(new BeatmapObjectDeletionAction(obj));
+            if (triggersAction) BeatmapActionContainer.AddAction(new BeatmapObjectDeletionAction(obj, comment));
             LoadedContainers.Remove(obj);
             Destroy(obj.gameObject);
             SelectionController.RefreshMap();

--- a/Assets/__Scripts/MapEditor/Grid/Collections/EventsContainer.cs
+++ b/Assets/__Scripts/MapEditor/Grid/Collections/EventsContainer.cs
@@ -125,7 +125,7 @@ public class EventsContainer : BeatmapObjectContainerCollection
         );
         if (conflicting != null)
         {
-            if (removeConflicting) DeleteObject(conflicting);
+            if (removeConflicting) DeleteObject(conflicting, true, $"Conflicted with a newer object at time {obj._time}");
             else return null;
         }
         BeatmapEventContainer beatmapEvent = BeatmapEventContainer.SpawnEvent(obj as MapEvent, ref eventPrefab, ref eventAppearanceSO, ref tracksManager);

--- a/Assets/__Scripts/MapEditor/Grid/Collections/NotesContainer.cs
+++ b/Assets/__Scripts/MapEditor/Grid/Collections/NotesContainer.cs
@@ -96,7 +96,7 @@ public class NotesContainer : BeatmapObjectContainerCollection {
             ((BeatmapNote) obj)._type == ((BeatmapNote) x.objectData)._type &&
             ConflictingByTrackIDs(obj, x.objectData)
         );
-        if (conflicting != null && removeConflicting) DeleteObject(conflicting);
+        if (conflicting != null && removeConflicting) DeleteObject(conflicting, true, $"Conflicted with a newer object at time {obj._time}");
         BeatmapNoteContainer beatmapNote = BeatmapNoteContainer.SpawnBeatmapNote(obj as BeatmapNote, ref notePrefab, ref bombPrefab, ref noteAppearanceSO);
         beatmapNote.transform.SetParent(GridTransform);
         beatmapNote.UpdateGridPosition();

--- a/Assets/__Scripts/MapEditor/Grid/Collections/ObstaclesContainer.cs
+++ b/Assets/__Scripts/MapEditor/Grid/Collections/ObstaclesContainer.cs
@@ -74,7 +74,7 @@ public class ObstaclesContainer : BeatmapObjectContainerCollection
             ((BeatmapObstacle) obj)._type == ((BeatmapObstacle) x.objectData)._type &&
             ConflictingByTrackIDs(obj, x.objectData)
         );
-        if (conflicting != null && removeConflicting) DeleteObject(conflicting);
+        if (conflicting != null && removeConflicting) DeleteObject(conflicting, true, $"Conflicted with a newer object at time {obj._time}");
         BeatmapObstacleContainer beatmapObstacle = BeatmapObstacleContainer.SpawnObstacle(obj as BeatmapObstacle, AudioTimeSyncController, ref obstaclePrefab, ref obstacleAppearanceSO);
         beatmapObstacle.transform.SetParent(GridTransform);
         beatmapObstacle.UpdateGridPosition();

--- a/Assets/__Scripts/MapEditor/Grid/Tracks/TracksManager.cs
+++ b/Assets/__Scripts/MapEditor/Grid/Tracks/TracksManager.cs
@@ -21,7 +21,7 @@ public class TracksManager : MonoBehaviour
         BeatmapObjectContainer.FlaggedForDeletionEvent += FlaggedForDeletion;
     }
 
-    private void FlaggedForDeletion(BeatmapObjectContainer obj, bool _)
+    private void FlaggedForDeletion(BeatmapObjectContainer obj, bool _, string __)
     {
         //Refresh the tracks if we delete any rotation event
         if (obj is BeatmapEventContainer e && e.eventData.IsRotationEvent)

--- a/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/BombPlacement.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/BombPlacement.cs
@@ -4,7 +4,7 @@ public class BombPlacement : PlacementController<BeatmapNote, BeatmapNoteContain
 {
     public override BeatmapAction GenerateAction(BeatmapNoteContainer spawned, BeatmapObjectContainer container)
     {
-        return new BeatmapObjectPlacementAction(spawned, container);
+        return new BeatmapObjectPlacementAction(spawned, container, "Placed a Bomb.");
     }
 
     public override BeatmapNote GenerateOriginalData()

--- a/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/CustomEventPlacement.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/CustomEventPlacement.cs
@@ -11,7 +11,7 @@ public class CustomEventPlacement : PlacementController<BeatmapCustomEvent, Beat
 
     public override BeatmapAction GenerateAction(BeatmapCustomEventContainer spawned, BeatmapObjectContainer conflicting)
     {
-        return new BeatmapObjectPlacementAction(conflicting, spawned);
+        return new BeatmapObjectPlacementAction(conflicting, spawned, "Placed a Custom Event.");
     }
 
     public override BeatmapCustomEvent GenerateOriginalData()

--- a/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/EventPlacement.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/EventPlacement.cs
@@ -18,7 +18,7 @@ public class EventPlacement : PlacementController<MapEvent, BeatmapEventContaine
 
     public override BeatmapAction GenerateAction(BeatmapEventContainer spawned, BeatmapObjectContainer container)
     {
-        return new BeatmapObjectPlacementAction(spawned, container);
+        return new BeatmapObjectPlacementAction(spawned, container, "Placed an Event.");
     }
 
     public override MapEvent GenerateOriginalData()
@@ -111,7 +111,7 @@ public class EventPlacement : PlacementController<MapEvent, BeatmapEventContaine
             BeatmapEventContainer container = objectContainerCollection.SpawnObject(justChroma, out BeatmapObjectContainer conflicting2) as BeatmapEventContainer;
             if (container == null) return;
             BeatmapActionContainer.AddAction(new BeatmapObjectPlacementAction(new List<BeatmapObjectContainer>() { conflicting2 },
-                new List<BeatmapObjectContainer>() { container } ));
+                new List<BeatmapObjectContainer>() { container }, "Placed a Chroma event." ));
             SelectionController.RefreshMap();
             queuedData = BeatmapObject.GenerateCopy(queuedData);
             return;
@@ -127,7 +127,7 @@ public class EventPlacement : PlacementController<MapEvent, BeatmapEventContaine
             chroma = objectContainerCollection.SpawnObject(chromaData, out _) as BeatmapEventContainer;
         }
         BeatmapActionContainer.AddAction(new BeatmapObjectPlacementAction(new List<BeatmapObjectContainer>() { conflicting },
-            new List<BeatmapObjectContainer>() { spawned, chroma }));
+            new List<BeatmapObjectContainer>() { spawned, chroma }, "Placed an Event with an attached Chroma event."));
         SelectionController.RefreshMap();
         queuedData = BeatmapObject.GenerateCopy(queuedData);
         tracksManager.RefreshTracks();

--- a/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/NotePlacement.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/NotePlacement.cs
@@ -11,7 +11,7 @@ public class NotePlacement : PlacementController<BeatmapNote, BeatmapNoteContain
 
     public override BeatmapAction GenerateAction(BeatmapNoteContainer spawned, BeatmapObjectContainer container)
     {
-        return new BeatmapObjectPlacementAction(spawned, container);
+        return new BeatmapObjectPlacementAction(spawned, container, "Placed a note.");
     }
 
     public override BeatmapNote GenerateOriginalData()

--- a/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/ObstaclePlacement.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/ObstaclePlacement.cs
@@ -9,7 +9,7 @@ public class ObstaclePlacement : PlacementController<BeatmapObstacle, BeatmapObs
 
     public override BeatmapAction GenerateAction(BeatmapObstacleContainer spawned, BeatmapObjectContainer container)
     {
-        return new BeatmapObjectPlacementAction(spawned, container);
+        return new BeatmapObjectPlacementAction(spawned, container, "Place a Wall.");
     }
 
     public override BeatmapObstacle GenerateOriginalData()

--- a/Assets/__Scripts/MapEditor/Mapping/Selection/SelectionController.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/Selection/SelectionController.cs
@@ -124,7 +124,7 @@ public class SelectionController : MonoBehaviour
     {
         if (triggersAction) BeatmapActionContainer.AddAction(new SelectionDeletedAction(SelectedObjects));
         foreach (BeatmapObjectContainer con in SelectedObjects)
-            foreach (BeatmapObjectContainerCollection container in collections) container.DeleteObject(con);
+            foreach (BeatmapObjectContainerCollection container in collections) container.DeleteObject(con, false);
         SelectedObjects.Clear();
         RefreshMap();
         tracksManager.RefreshTracks();


### PR DESCRIPTION
- ChroMapper now places an `_editor` field in `Info._customData` to identify itself.
  - BeatMapper has been using this field in the past, so why not add on to it?
- Actions have been improved
  - Comments to actions have been added to make potential debugging faster.
  - Actions involving multiple objects now do not stack `BeatmapObjectDeletionAction`s when undoing (Such as undoing a Paste or a gradient made with Strobe Generator)
- I'm about to switch to Unity `2019.3.0f6` to convert CM to DOTS and ECS. I'll make a new branch for this.