### PR TITLE
Feature/fix pastemove propagation

### DIFF
--- a/Assets/__Scenes/03_Mapper.unity
+++ b/Assets/__Scenes/03_Mapper.unity
@@ -42668,6 +42668,7 @@ MonoBehaviour:
   selectedColor: {r: 0, g: 1, b: 1, a: 1}
   copiedColor: {r: 0, g: 1, b: 0, a: 1}
   tracksManager: {fileID: 25550679}
+  eventPlacement: {fileID: 1277691436}
 --- !u!114 &1524038336
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/__Scripts/MapEditor/Grid/Collections/EventsContainer.cs
+++ b/Assets/__Scripts/MapEditor/Grid/Collections/EventsContainer.cs
@@ -53,8 +53,8 @@ public class EventsContainer : BeatmapObjectContainerCollection
             if (ringPropagationEditing)
             {
                 int pos = 0;
-                if (con.objectData._customData != null)
-                    pos = (con.objectData?._customData["_propID"]?.AsInt ?? -1) + 1;
+                if (con.objectData._customData != null && con.objectData._customData["_propID"].IsNumber)
+                    pos = (con.objectData?._customData["_propID"]?.AsInt  ?? -1) + 1;
                 if ((con is BeatmapEventContainer e) && e.eventData._type != MapEvent.EVENT_TYPE_RING_LIGHTS)
                 {
                     e.UpdateAlpha(0);
@@ -134,10 +134,11 @@ public class EventsContainer : BeatmapObjectContainerCollection
         beatmapEvent.UpdateGridPosition();
         if (RingPropagationEditing && (obj as MapEvent)._type == MapEvent.EVENT_TYPE_RING_LIGHTS)
         {
-            
-            int pos = -1;
-            if (!(obj._customData is null))
-                pos = obj._customData["_propID"].AsInt + 1;
+            int pos = 0;
+            if (!(obj._customData is null) && (obj._customData["_propID"].IsNumber))
+            {
+                pos = (obj._customData["_propID"]?.AsInt ?? -1) + 1;
+            }
             beatmapEvent.transform.localPosition = new Vector3(pos + 0.5f, 0.5f, beatmapEvent.transform.localPosition.z);
         }
         LoadedContainers.Add(beatmapEvent);

--- a/Assets/__Scripts/MapEditor/Grid/Collections/EventsContainer.cs
+++ b/Assets/__Scripts/MapEditor/Grid/Collections/EventsContainer.cs
@@ -134,8 +134,10 @@ public class EventsContainer : BeatmapObjectContainerCollection
         beatmapEvent.UpdateGridPosition();
         if (RingPropagationEditing && (obj as MapEvent)._type == MapEvent.EVENT_TYPE_RING_LIGHTS)
         {
-            int pos = 0;
-            if (!(obj._customData is null)) pos = obj._customData["_propID"].AsInt + 1;
+            
+            int pos = -1;
+            if (!(obj._customData is null))
+                pos = obj._customData["_propID"].AsInt + 1;
             beatmapEvent.transform.localPosition = new Vector3(pos + 0.5f, 0.5f, beatmapEvent.transform.localPosition.z);
         }
         LoadedContainers.Add(beatmapEvent);

--- a/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/EventPlacement.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/EventPlacement.cs
@@ -56,7 +56,7 @@ public class EventPlacement : PlacementController<MapEvent, BeatmapEventContaine
                 if (queuedData._customData is null) queuedData._customData = new SimpleJSON.JSONObject();
                 queuedData._customData["_propID"] = propID;
             }
-            else queuedData._customData?.Remove("_propID");
+            else queuedData._customData = null;
         }
         if (!PlacePrecisionRotation)
         {

--- a/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/EventPlacement.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/EventPlacement.cs
@@ -45,7 +45,7 @@ public class EventPlacement : PlacementController<MapEvent, BeatmapEventContaine
         if (!objectContainerCollection.RingPropagationEditing)
         {
             queuedData._type = BeatmapEventContainer.ModifiedTypeToEventType(Mathf.FloorToInt(instantiatedContainer.transform.localPosition.x) );
-            queuedData._customData = null;
+            queuedData._customData?.Remove("_propID");
         }
         else
         {
@@ -56,7 +56,7 @@ public class EventPlacement : PlacementController<MapEvent, BeatmapEventContaine
                 if (queuedData._customData is null) queuedData._customData = new SimpleJSON.JSONObject();
                 queuedData._customData["_propID"] = propID;
             }
-            else queuedData._customData = null;
+            else queuedData._customData?.Remove("_propID");
         }
         if (!PlacePrecisionRotation)
         {

--- a/Assets/__Scripts/MapEditor/Mapping/Selection/SelectionController.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/Selection/SelectionController.cs
@@ -241,13 +241,18 @@ public class SelectionController : MonoBehaviour
                     }
                     else
                     {
-                        if (pos < 0) pos = 0;
-                        if (pos > 15) pos = 15;
+                        if (pos < -1) pos = -1;
+                        if (pos > 14) pos = 14;
                     }
-
-                    con.objectData._customData["_propID"] = pos;
-
                     con.transform.localPosition = new Vector3(pos + 0.5f, 0.5f, con.transform.localPosition.z);
+                    if (pos == -1)
+                    {
+                        con.objectData._customData = null;
+                    }
+                    else
+                    {
+                        con.objectData._customData["_propID"] = pos;
+                    }
                 }
                 else
                 {

--- a/Assets/__Scripts/MapEditor/Mapping/Selection/SelectionController.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/Selection/SelectionController.cs
@@ -224,9 +224,11 @@ public class SelectionController : MonoBehaviour
                     if (obstacle.obstacleData._lineIndex > -1000) obstacle.obstacleData._lineIndex = -1000;
                 }
                 else obstacle.obstacleData._lineIndex += leftRight;
+                obstacle.obstacleData._time += ((1f / atsc.gridMeasureSnapping) * upDown);
             }
             else if (con is BeatmapEventContainer e)
             {
+                e.eventData._time += ((1f / atsc.gridMeasureSnapping) * upDown);
                 if (eventPlacement.objectContainerCollection.RingPropagationEditing)
                 {
                     int pos = 0;

--- a/Assets/__Scripts/MapEditor/Mapping/Selection/SelectionController.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/Selection/SelectionController.cs
@@ -21,6 +21,7 @@ public class SelectionController : MonoBehaviour
     [SerializeField] private Color selectedColor;
     [SerializeField] private Color copiedColor;
     [SerializeField] private TracksManager tracksManager;
+    [SerializeField] private EventPlacement eventPlacement;
 
     private static SelectionController instance;
 
@@ -173,6 +174,9 @@ public class SelectionController : MonoBehaviour
         RefreshMap();
         tracksManager.RefreshTracks();
         foreach (BeatmapObjectContainer obj in pasted) obj.UpdateGridPosition();
+
+        if (eventPlacement.objectContainerCollection.RingPropagationEditing)
+            eventPlacement.objectContainerCollection.RingPropagationEditing = eventPlacement.objectContainerCollection.RingPropagationEditing;
         Debug.Log("Pasted!");
     }
 

--- a/Assets/__Scripts/MapEditor/Mapping/Selection/SelectionController.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/Selection/SelectionController.cs
@@ -231,8 +231,8 @@ public class SelectionController : MonoBehaviour
                 e.eventData._time += ((1f / atsc.gridMeasureSnapping) * upDown);
                 if (eventPlacement.objectContainerCollection.RingPropagationEditing)
                 {
-                    int pos = 0;
-                    if (con.objectData._customData != null)
+                    int pos = -1 + leftRight;
+                    if (con.objectData._customData != null && con.objectData._customData["_propID"].IsNumber)
                         pos = (con.objectData?._customData["_propID"]?.AsInt ?? -1) + leftRight;
                     if (e.eventData._type != MapEvent.EVENT_TYPE_RING_LIGHTS)
                     {
@@ -247,7 +247,7 @@ public class SelectionController : MonoBehaviour
                     con.transform.localPosition = new Vector3(pos + 0.5f, 0.5f, con.transform.localPosition.z);
                     if (pos == -1)
                     {
-                        con.objectData._customData = null;
+                        con.objectData._customData?.Remove("_propID");
                     }
                     else
                     {

--- a/Assets/__Scripts/MapEditor/Mapping/Selection/SelectionController.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/Selection/SelectionController.cs
@@ -227,18 +227,43 @@ public class SelectionController : MonoBehaviour
             }
             else if (con is BeatmapEventContainer e)
             {
-                if (e.eventData._customData != null && e.eventData._customData["_propID"] != null)
-                    e.eventData._customData["_propID"] = e.eventData._customData["_propID"].AsInt + leftRight;
-                int modified = BeatmapEventContainer.EventTypeToModifiedType(e.eventData._type);
-                modified += leftRight;
-                if (modified < 0) modified = 0;
-                if (modified > 15) modified = 15;
-                e.eventData._type = BeatmapEventContainer.ModifiedTypeToEventType(modified);
-                e.RefreshAppearance();
-                if (e.eventData.IsRotationEvent || e.eventData._type - leftRight == MapEvent.EVENT_TYPE_LATE_ROTATION || 
-                    e.eventData._type - leftRight == MapEvent.EVENT_TYPE_EARLY_ROTATION) tracksManager.RefreshTracks();
+                if (eventPlacement.objectContainerCollection.RingPropagationEditing)
+                {
+                    int pos = 0;
+                    if (con.objectData._customData != null)
+                        pos = (con.objectData?._customData["_propID"]?.AsInt ?? -1) + leftRight;
+                    if (e.eventData._type != MapEvent.EVENT_TYPE_RING_LIGHTS)
+                    {
+                        e.UpdateAlpha(0);
+                        pos = -1;
+                    }
+                    else
+                    {
+                        if (pos < 0) pos = 0;
+                        if (pos > 15) pos = 15;
+                    }
+
+                    con.objectData._customData["_propID"] = pos;
+
+                    con.transform.localPosition = new Vector3(pos + 0.5f, 0.5f, con.transform.localPosition.z);
+                }
+                else
+                {
+                    if (e.eventData._customData != null && e.eventData._customData["_propID"] != null)
+                        e.eventData._customData["_propID"] = e.eventData._customData["_propID"].AsInt + leftRight;
+                    int modified = BeatmapEventContainer.EventTypeToModifiedType(e.eventData._type);
+                    modified += leftRight;
+                    if (modified < 0) modified = 0;
+                    if (modified > 15) modified = 15;
+                    e.eventData._type = BeatmapEventContainer.ModifiedTypeToEventType(modified);
+                    e.RefreshAppearance();
+                    if (e.eventData.IsRotationEvent || e.eventData._type - leftRight == MapEvent.EVENT_TYPE_LATE_ROTATION ||
+                        e.eventData._type - leftRight == MapEvent.EVENT_TYPE_EARLY_ROTATION) tracksManager.RefreshTracks();
+                }
             }
             con.UpdateGridPosition();
+            if (eventPlacement.objectContainerCollection.RingPropagationEditing) 
+                eventPlacement.objectContainerCollection.RingPropagationEditing = eventPlacement.objectContainerCollection.RingPropagationEditing;
         }
         RefreshMap();
     }


### PR DESCRIPTION
Fixes the issues described in #38

Should be tested well, I tried my best and did not find any side effects from my changes.

This also allows to Shift the lights in propagation correctly (left/right/up/down) and in normal lights mode as well as obstacles can now be moved up/down, which was not possible

I will open a new ticket, as there are still other issues which must be checked in relation to ring propagation