### PR TITLE
Prevent scrolling the timeline when in the pause or settings menu.

### DIFF
--- a/Assets/__Scripts/MapEditor/AudioTimeSyncController.cs
+++ b/Assets/__Scripts/MapEditor/AudioTimeSyncController.cs
@@ -206,6 +206,9 @@ public class AudioTimeSyncController : MonoBehaviour, CMInput.IPlaybackActions, 
 
     public void OnChangeTimeandPrecision(InputAction.CallbackContext context)
     {
+        if (OptionsController.IsActive || (PauseManager.IsPaused && !IsPlaying))
+            return;
+
         float value = context.ReadValue<float>();
         if (Settings.Instance.InvertPrecisionScroll) value *= -1;
         if (!KeybindsController.AltHeld && context.performed)


### PR DESCRIPTION
At first I thought the settings menu was resetting the timeline to zero but it was just me scrolling down in the menus.