### PR TITLE
Fix Grid ZDir shader on MacOS

### DIFF
--- a/Assets/_Graphics/Shaders/Editor/Grid ZDir.shader
+++ b/Assets/_Graphics/Shaders/Editor/Grid ZDir.shader
@@ -35,8 +35,8 @@ Shader "Grid ZDir" {
 			uniform float4 _GridColour;
 			uniform float4 _BaseColour;
 			uniform float _Rotation;
-			uniform float _BPMChange_Times[2046];
-			uniform float _BPMChange_BPMs[2046];
+			uniform float _BPMChange_Times[1963];
+			uniform float _BPMChange_BPMs[1963];
 			uniform int _BPMChange_Count;
 			uniform float _EditorScale;
 

--- a/Assets/__Scripts/MapEditor/Grid/Collections/BPMChangesContainer.cs
+++ b/Assets/__Scripts/MapEditor/Grid/Collections/BPMChangesContainer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -15,7 +15,7 @@ public class BPMChangesContainer : BeatmapObjectContainerCollection {
     [SerializeField] private MeasureLinesController measureLinesController;
 
     //This is a shader-level restriction and nothing I can fix.
-    public static readonly int ShaderArrayMaxSize = 2046;
+    public static readonly int ShaderArrayMaxSize = 1963;
 
     private static readonly int Times = Shader.PropertyToID("_BPMChange_Times");
     private static readonly int BPMs = Shader.PropertyToID("_BPMChange_BPMs");


### PR DESCRIPTION
Max shader size is 64KB for DirectX but only 16KB for Metal (and OpenGL but we don't talk about OpenGL). Compiled shader for Windows used to look like:
```
Constant Buffer "$Globals" (65536 bytes) on slot 0 {
  Float _GridThickness at 0
  Float _GridSpacing at 4
  Float _Offset at 8
  Vector4 _GridColour at 16
  Vector4 _BaseColour at 32
  Vector1 _BPMChange_Times[2046] at 64
  Vector1 _BPMChange_BPMs[2046] at 32800
  ScalarInt _BPMChange_Count at 65524
  Float _EditorScale at 65528
}
```
Exactly 64KB!

Thankfully the types on Metal uses fewer bytes (16 bytes for a float is crazy though?):
```
Constant Buffer "$Globals" (16424 bytes) {
  Float _GridThickness at 0
  Float _GridSpacing at 4
  Float _Offset at 8
  Vector4 _GridColour at 16
  Vector4 _BaseColour at 32
  Vector1 _BPMChange_Times[2046] at 48
  Vector1 _BPMChange_BPMs[2046] at 8232
  ScalarInt _BPMChange_Count at 16416
  Float _EditorScale at 16420
}
```
That's more than 16KB, but actually not by much. Weirdly I had to drop the array sizes a lot more than you'd expect (there's 624 bytes unaccounted for) but I'm guessing those are local variables or other constants in the shader 🤷‍♂️ 

RIP anyone with 2000 bpm changes who can't edit their map anymore