### PR TITLE
Fix object selection box

### DIFF
--- a/Assets/__Scripts/MapEditor/Mapping/Selection/BoxSelectionPlacementController.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/Selection/BoxSelectionPlacementController.cs
@@ -128,8 +128,6 @@ public class BoxSelectionPlacementController : PlacementController<MapEvent, Bea
 
             foreach (BeatmapObjectContainer obj in toSelect) SelectionController.Select(obj, true, false);
             SelectionController.RefreshSelectionMaterial(toSelect.Any());
-            IsSelecting = false;
-            OnPhysicsRaycast(previousHit, transformed);
         }
     }
 
@@ -158,6 +156,7 @@ public class BoxSelectionPlacementController : PlacementController<MapEvent, Bea
     {
         yield return new WaitForSeconds(0.1f);
         IsSelecting = false;
+        OnPhysicsRaycast(previousHit, transformed);
     }
 
     private void OnDrawGizmos()

--- a/Assets/__Scripts/MapEditor/Mapping/Selection/BoxSelectionPlacementController.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/Selection/BoxSelectionPlacementController.cs
@@ -66,8 +66,19 @@ public class BoxSelectionPlacementController : PlacementController<MapEvent, Bea
         }
         else
         {
-            instantiatedContainer.transform.localPosition = originPos;
-            Vector3 newLocalScale = roundedHit + new Vector3(0, 0, 0.5f) - originPos;
+            Vector3 originShove = originPos;
+            float xOffset = 0;
+
+            // When moving from right to left, move the origin to the right and make
+            // the selection larger as the origin points are on the left
+            if (roundedHit.x <= originPos.x + 1)
+            {
+                xOffset = -1;
+                originShove.x += 1;
+            }
+
+            instantiatedContainer.transform.localPosition = originShove;
+            Vector3 newLocalScale = roundedHit + new Vector3(xOffset, 0, 0.5f) - originShove;
             newLocalScale = new Vector3(newLocalScale.x, Mathf.Max(newLocalScale.y, 1), newLocalScale.z);
             instantiatedContainer.transform.localScale = newLocalScale;
 


### PR DESCRIPTION
Example selecting from the lighting side to the waveform side. The old code sets the boundary starting from the division between the right-side lanes instead when moving in this direction the origin is offset and the total size is increased to include the extra lanes.

I've also removed the `IsSelecting = false;` and moved the `OnPhysicsRaycast` out of the placement event as this triggers before the click event that causes notes to be placed. This prevents new notes being placed when ending selection.

Before:
![Before](https://user-images.githubusercontent.com/534069/82346622-989e5180-99ee-11ea-8685-df1985f9d840.png)
After:
![After](https://user-images.githubusercontent.com/534069/82346619-976d2480-99ee-11ea-9310-e029e7a88550.png)