### PR TITLE
Steam discovery doesn't work on fresh install

### DIFF
--- a/Assets/__Scripts/UI/FirstBootMenu.cs
+++ b/Assets/__Scripts/UI/FirstBootMenu.cs
@@ -1,4 +1,6 @@
 ﻿using System.Globalization;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using UnityEngine;
 using UnityEngine.UI;
 using Microsoft.Win32;
@@ -23,8 +25,11 @@ public class FirstBootMenu : MonoBehaviour {
 
     private static string oculusStoreBeatSaberFolderName = "hyperbolic-magnetism-beat-saber";
 
-	// Use this for initialization
-	void Start() {
+    private Regex appManifestRegex = new Regex(@"\s""installdir""\s+""(.+)""", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private Regex libraryRegex = new Regex(@"\s""\d""\s+""(.+)""", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    // Use this for initialization
+    void Start() {
         //Fixes weird shit regarding how people write numbers (20,35 VS 20.35), causing issues in JSON
         //This should be thread-wide, but I have this set throughout just in case it isnt.
         System.Threading.Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
@@ -45,7 +50,7 @@ public class FirstBootMenu : MonoBehaviour {
         }
 
         directoryCanvas.SetActive(true);
-	}
+    }
 
     public void SetDirectoryButtonPressed() {
         string installation = directoryField.text;
@@ -89,12 +94,70 @@ public class FirstBootMenu : MonoBehaviour {
         string registryValue = "InstallLocation";
         try
         {
-            return (string) Registry.GetValue(steamRegistryKey, registryValue, "");
+            string installDirectory = (string) Registry.GetValue(steamRegistryKey, registryValue, "");
+            if (!string.IsNullOrEmpty(installDirectory))
+            {
+                return installDirectory;
+            }
+            return guessSteamInstallationDirectoryComplex();
         } catch(System.Exception e)
         {
             Debug.Log("Error reading Steam registry key" + e);
             return "";
         }
+    }
+
+    private string guessSteamInstallationDirectoryComplex()
+    {
+        // The above registry key only exists if you've installed Beat Saber since last installing windows
+        // if you copy the game files or reinstall windows then the registry key will be missing even though
+        // the game launches just fine
+        string steamRegistryKey = "HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\Valve\\Steam";
+        string registryValue = "InstallPath";
+
+        List<string> libraryFolders = new List<string>();
+
+        string mainSteamFolder = (string) Registry.GetValue(steamRegistryKey, registryValue, "");
+        libraryFolders.Add(mainSteamFolder);
+
+        string libraryFolderFilename = mainSteamFolder + "\\steamapps\\libraryfolders.vdf";
+        if (File.Exists(libraryFolderFilename))
+        {
+            using (StreamReader reader = new StreamReader(libraryFolderFilename))
+            {
+                string text = reader.ReadToEnd();
+                MatchCollection matches = libraryRegex.Matches(text);
+
+                foreach (Match match in matches)
+                {
+                    if (Directory.Exists(match.Groups[1].Value))
+                    {
+                        libraryFolders.Add(match.Groups[1].Value);
+                    }
+                }
+            }
+        }
+
+        foreach (string libraryFolder in libraryFolders)
+        {
+            string fileName = libraryFolder + "\\steamapps\\appmanifest_620980.acf";
+            if (File.Exists(fileName))
+            {
+                using (StreamReader reader = new StreamReader(fileName))
+                {
+                    string text = reader.ReadToEnd();
+
+                    GroupCollection installDirMatch = appManifestRegex.Matches(text)[0].Groups;
+                    string installDir = libraryFolder + "\\steamapps\\common\\" + installDirMatch[1].Value;
+
+                    if (Directory.Exists(installDir))
+                    {
+                        return installDir;
+                    }
+                }
+            }
+        }
+        return "";
     }
 
     private string guessOculusInstallationDirectory()


### PR DESCRIPTION
If you have games on an external hard drive or library location then steam can run then without ever "installing" them, thus uninstall registry entries aren't created. When booting steam on a fresh windows install it "fixes" the registry which at least puts in the install folder for the client itself and using this we can read steam files to find the game directory.

This is pretty much how MMA2 finds the steam directory.

I've left the existing code as it's a lot simpler if the registry key *does* exist but this code should work in any case where the existing code does.