### PR TITLE
Fix spectogram sync

### DIFF
--- a/Assets/__Scripts/MapEditor/Audio/SpectrogramChunk.cs
+++ b/Assets/__Scripts/MapEditor/Audio/SpectrogramChunk.cs
@@ -43,8 +43,10 @@ public class SpectrogramChunk : MonoBehaviour
         if (EditorScaleController.EditorScale != previousEditorScale)
         {
             previousEditorScale = EditorScaleController.EditorScale;
+            // Beats per centisecond, only needed for the 3d waveform. I don't know why
+            float bpcs = BeatSaberSongContainer.Instance.song.beatsPerMinute / (60f * 100);
             transform.localPosition = new Vector3(0, -0.15f,
-                (chunkID + (waveform.WaveformType == 2 ? 0.01f : 0)) * (EditorScaleController.EditorScale * BeatmapObjectContainerCollection.ChunkSize));
+                (chunkID + (waveform.WaveformType == 2 ? bpcs : 0)) * (EditorScaleController.EditorScale * BeatmapObjectContainerCollection.ChunkSize));
             transform.localScale = new Vector3(spectrogramScale.x, spectrogramScale.y,
                 BeatmapObjectContainerCollection.ChunkSize * EditorScaleController.EditorScale);
         }


### PR DESCRIPTION
It seems the 3d spectogram sync issue I tried to fix is worse at higher bpms, my original test was at 60bpm. This now works at least between that and 256 bpm. Please don't ask why.

![](https://user-images.githubusercontent.com/534069/85103416-84708e80-b1fe-11ea-84f1-ed697a486290.png)