### PR TITLE
Group duplicated characteristic blocks in info.dat

### DIFF
--- a/Assets/__Scripts/BeatSaberSong.cs
+++ b/Assets/__Scripts/BeatSaberSong.cs
@@ -411,8 +411,15 @@ public class BeatSaberSong
                             set.difficultyBeatmaps = set.difficultyBeatmaps.DistinctBy(it => it.difficultyRank).OrderBy(x => x.difficultyRank).ToList();
                             song.difficultyBeatmapSets.Add(set);
                         }
-                        song.difficultyBeatmapSets = song.difficultyBeatmapSets.OrderBy(x =>
-                        SongInfoEditUI.CharacteristicDropdownToBeatmapName.IndexOf(x.beatmapCharacteristicName)).ToList();
+                        song.difficultyBeatmapSets = song.difficultyBeatmapSets
+                            .GroupBy(it => it.beatmapCharacteristicName)
+                            .Select(it => {
+                                var container = it.First();
+                                container.difficultyBeatmaps = it.SelectMany(a => a.difficultyBeatmaps).ToList();
+
+                                return container;
+                            })
+                            .OrderBy(x => SongInfoEditUI.CharacteristicDropdownToBeatmapName.IndexOf(x.beatmapCharacteristicName)).ToList();
                         break;
                 }
             }

--- a/Assets/__Scripts/UI/SongEditMenu/CharacteristicSelect.cs
+++ b/Assets/__Scripts/UI/SongEditMenu/CharacteristicSelect.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -47,8 +48,8 @@ public class CharacteristicSelect : MonoBehaviour
 
     private void Recalculate(Transform transform)
     {
-        var diff = Song?.difficultyBeatmapSets?.Find(it => it.beatmapCharacteristicName.Equals(transform.name, StringComparison.InvariantCultureIgnoreCase));
-        var count = diff != null ? diff.difficultyBeatmaps.Count : 0;
+        difficultySelect.Characteristics.TryGetValue(transform.name, out Dictionary<string, DifficultySettings> diff);
+        var count = diff != null ? diff.Count : 0;
 
         var diffCountText = transform.Find("Difficulty Count").GetComponent<TMP_Text>();
         diffCountText.text = count.ToString();

--- a/Assets/__Scripts/UI/SongEditMenu/DifficultySelect.cs
+++ b/Assets/__Scripts/UI/SongEditMenu/DifficultySelect.cs
@@ -17,7 +17,7 @@ public class DifficultySelect : MonoBehaviour
 
     private DifficultyBeatmapSet currentCharacteristic;
     private Dictionary<string, DifficultySettings> diffs;
-    private Dictionary<string, Dictionary<string, DifficultySettings>> characteristics;
+    public Dictionary<string, Dictionary<string, DifficultySettings>> Characteristics;
 
     private Dictionary<string, int> diffRankLookup = new Dictionary<string, int>()
     {
@@ -44,17 +44,18 @@ public class DifficultySelect : MonoBehaviour
     {
         if (Song?.difficultyBeatmapSets != null)
         {
-            characteristics = Song.difficultyBeatmapSets.GroupBy(it => it.beatmapCharacteristicName).ToDictionary(
+            Characteristics = Song.difficultyBeatmapSets.GroupBy(it => it.beatmapCharacteristicName).ToDictionary(
                 characteristic => characteristic.Key,
                 characteristic => characteristic.SelectMany(i => i.difficultyBeatmaps).GroupBy(map => map.difficulty).ToDictionary(
                     grouped => grouped.Key,
                     grouped => new DifficultySettings(grouped.First())
-                )
+                ),
+                StringComparer.OrdinalIgnoreCase
             );
         }
         else
         {
-            characteristics = new Dictionary<string, Dictionary<string, DifficultySettings>>();
+            Characteristics = new Dictionary<string, Dictionary<string, DifficultySettings>>();
         }
 
         foreach (Transform child in transform)
@@ -437,11 +438,11 @@ public class DifficultySelect : MonoBehaviour
             currentCharacteristic = new DifficultyBeatmapSet(name);
         }
 
-        if (!characteristics.ContainsKey(name))
+        if (!Characteristics.ContainsKey(name))
         {
-            characteristics.Add(name, new Dictionary<string, DifficultySettings>());
+            Characteristics.Add(name, new Dictionary<string, DifficultySettings>());
         }
-        diffs = characteristics[name];
+        diffs = Characteristics[name];
 
         foreach (DifficultyRow row in rows)
         {
@@ -494,6 +495,6 @@ public class DifficultySelect : MonoBehaviour
     /// <returns>True if there are unsaved changes</returns>
     public bool IsDirty()
     {
-        return characteristics.Any(it => it.Value.Any(diff => diff.Value.IsDirty()));
+        return Characteristics.Any(it => it.Value.Any(diff => diff.Value.IsDirty()));
     }
 }


### PR DESCRIPTION
Already had code that ignores duplicated difficulties within a characteristic but didn't handle duplicated characteristics well.
Mostly because I don't really know how the file gets into this kind of state, but this code helps it be self-healing.