### PR TITLE
Bug fixes

### DIFF
--- a/Assets/_Prefabs/MapEditor/Objects/Selection Wall of Doom.prefab
+++ b/Assets/_Prefabs/MapEditor/Objects/Selection Wall of Doom.prefab
@@ -46,13 +46,19 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 49ca58ce40fce7e49b2b44aa558a5819, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SelectionMaterial: {fileID: 0}
+  ModelMaterials: []
+  SelectionMaterials: []
   boxCollider: {fileID: 7868185745459121827}
   eventData:
+    _time: 0
     _type: 0
     _value: 0
+  eventsContainer: {fileID: 0}
   eventAppearance: {fileID: 0}
-  eventRenderer: {fileID: 23329621693881470}
+  eventRenderer: []
+  tracksManager: {fileID: 0}
+  valueDisplay: {fileID: 0}
+  eventGradientController: {fileID: 0}
 --- !u!65 &7868185745459121827
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -120,6 +126,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -131,6 +138,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -219,6 +227,7 @@ LineRenderer:
   m_MotionVectors: 0
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -230,6 +239,7 @@ LineRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0

--- a/Assets/__Scripts/MapEditor/UI/CountersPlusController.cs
+++ b/Assets/__Scripts/MapEditor/UI/CountersPlusController.cs
@@ -31,13 +31,13 @@ public class CountersPlusController : MonoBehaviour {
         while (true)
         {
             yield return new WaitForSeconds(1); //I wouldn't want to update this every single frame.
-            List<BeatmapObject> sel = SelectionController.SelectedObjects.ToList();
+            List<BeatmapObject> sel = SelectionController.SelectedObjects.OrderBy(it => it._time).ToList();
             int notesel = SelectionController.SelectedObjects.Where(x => x is BeatmapNote).Count(); // only active when notes are selected
             if (SelectionController.HasSelectedObjects() && notesel > 0) {
                 notesMesh.text = $"Selected Notes: {notesel}";
                 float beatTimeDiff = sel.Last()._time - sel.First()._time;
                 float secDiff = atsc.GetSecondsFromBeat(beatTimeDiff);
-                notesPSMesh.text = $"Selected NPS: {(notesel / secDiff).ToString("F2")}";
+                notesPSMesh.text = $"Selected NPS: {notesel / secDiff:F2}";
             }
             else {
                 notesMesh.text = $"Notes: {notes.LoadedObjects.Count}";

--- a/Assets/__Scripts/UI/SongEditMenu/DifficultySelect.cs
+++ b/Assets/__Scripts/UI/SongEditMenu/DifficultySelect.cs
@@ -144,6 +144,7 @@ public class DifficultySelect : MonoBehaviour
     private void SaveDiff(DifficultyRow row)
     {
         var localDiff = diffs[row.Name];
+        var firstSave = localDiff.ForceDirty;
         localDiff.Commit();
         row.ShowDirtyObjects(false, true);
 
@@ -169,7 +170,14 @@ public class DifficultySelect : MonoBehaviour
         map.directoryAndFile = Path.Combine(Song.directory, diff.beatmapFilename);
         if (File.Exists(oldPath) && oldPath != map.directoryAndFile && !File.Exists(map.directoryAndFile))
         {
-            File.Move(oldPath, map.directoryAndFile); //This should properly "convert" difficulties just fine
+            if (firstSave)
+            {
+                File.Copy(oldPath, map.directoryAndFile);
+            }
+            else
+            {
+                File.Move(oldPath, map.directoryAndFile); //This should properly "convert" difficulties just fine
+            }
         }
         else
         {


### PR DESCRIPTION
It's 3 for 1!

Changed selection wall's eventRenderer from [Empty] to [].
Fixed selected NPS being negative and sometimes just wrong as things get added in random orders.
Actually copy instead of move on copy paste, I don't know how I didn't notice this.
