### PR TITLE
Tweak placement snapping

### DIFF
--- a/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/PlacementController.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/PlacementController.cs
@@ -63,9 +63,12 @@ public abstract class PlacementController<BO, BOC, BOCC> : MonoBehaviour, CMInpu
     {
         roundedHit = parentTrack.InverseTransformPoint(hit.point);
         float realTime = roundedHit.z / EditorScaleController.EditorScale;
-        roundedTime = atsc.FindRoundedBeatTime(realTime) + atsc.offsetBeat;
+
         float roundedCurrent = atsc.FindRoundedBeatTime(atsc.CurrentBeat);
-        float offsetTime = hit.collider.gameObject.name.Contains("Interface") ? 0 : atsc.CurrentBeat - roundedCurrent;
+        float offsetTime = atsc.CurrentBeat - roundedCurrent;
+
+        roundedTime = atsc.FindRoundedBeatTime(realTime - offsetTime) + atsc.offsetBeat;
+
         if (!atsc.IsPlaying) roundedTime += offsetTime;
     }
 


### PR DESCRIPTION
To reproduce these:
* Set precision to 1/2
* Move into a beat
* Create a bookmark
* Set precision back to 1/1
* Navigate to bookmark

With my mouse hovering over the grid here this is not where I expect the note to be placed.
![Bug](https://user-images.githubusercontent.com/534069/86524307-d2c59480-be70-11ea-8353-b754a63a7afa.png)

Likewise this seems to be intended behaviour and it feels really weird to me that pointing specifically at the vertical grid moves my placement back to the beat but pointing anywhere else doesn't.
![Weird](https://user-images.githubusercontent.com/534069/86524316-ea048200-be70-11ea-8d51-dc62e035bce4.png)

With this change, notes can be placed in increments of the current precision _from_ the current position and round how you would expect. So either:
![Place A](https://user-images.githubusercontent.com/534069/86524345-613a1600-be71-11ea-859e-d72f5220a4d4.png)
Or
![Place B](https://user-images.githubusercontent.com/534069/86524346-67c88d80-be71-11ea-8d3f-f1c4a944f45e.png)
depending on which your mouse is closer to