### PR TITLE
Fix open explorer with commas in path. Increase waveform contrast

### DIFF
--- a/Assets/__Scenes/03_Mapper.unity
+++ b/Assets/__Scenes/03_Mapper.unity
@@ -19835,7 +19835,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   material: {fileID: 2100000, guid: 68b9a414913410a46abcdd5a10666679, type: 2}
-  mat: {fileID: 2040148233}
+  mat: {fileID: 861431808}
   cloneMaterial: 1
   radius: 105
 --- !u!114 &756850815
@@ -19889,7 +19889,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Material: {fileID: 2040148233}
+  m_Material: {fileID: 861431808}
   m_Color: {r: 0.18867922, g: 0.18867922, b: 0.18867922, a: 1}
   m_RaycastTarget: 0
   m_Maskable: 1
@@ -22200,6 +22200,83 @@ Transform:
   m_Father: {fileID: 617466177}
   m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!21 &861431808
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Inherited From Round Corners
+  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _AlphaClip: 0
+    - _Blend: 0
+    - _BumpScale: 1
+    - _ColorMask: 15
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _ReceiveShadows: 1
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _Surface: 0
+    - _UseUIAlphaClip: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+    - _WidthHeightRadius: {r: 750, g: 100, b: 105, a: 0}
+    - _halfSize: {r: 29, g: 10, b: 0, a: 0}
+    - _r: {r: 3, g: 3, b: 3, a: 3}
+    - _rect2props: {r: 0.0000019073486, g: -0.0000038146973, b: 25.455845, a: 25.455845}
 --- !u!1 &866190992
 GameObject:
   m_ObjectHideFlags: 0
@@ -45206,11 +45283,9 @@ MonoBehaviour:
   atsc: {fileID: 570484802}
   lookAheadController: {fileID: 1760665545}
   source: {fileID: 1573635219}
-  mixer: {fileID: 24100000, guid: 05e9e9a5ad79e8c4189d1775afc97309, type: 2}
   spectrogramChunkPrefab: {fileID: 2020271900870039645, guid: 72c20001d18066e418273dabb0efb45d,
     type: 3}
   spectroParent: {fileID: 565602430}
-  saturation: 1
   audioManager: {fileID: 1573635218}
   spectrogramHeightGradient:
     serializedVersion: 2
@@ -45227,6 +45302,35 @@ MonoBehaviour:
     ctime2: 12529
     ctime3: 28334
     ctime4: 58982
+    ctime5: 65535
+    ctime6: 0
+    ctime7: 0
+    atime0: 0
+    atime1: 65535
+    atime2: 0
+    atime3: 0
+    atime4: 0
+    atime5: 0
+    atime6: 0
+    atime7: 0
+    m_Mode: 0
+    m_NumColorKeys: 6
+    m_NumAlphaKeys: 2
+  spectrogramGradient2d:
+    serializedVersion: 2
+    key0: {r: 0, g: 0, b: 0, a: 1}
+    key1: {r: 0, g: 0.019607844, b: 0.34901962, a: 1}
+    key2: {r: 0.15490197, g: 0.01372549, b: 0.39215687, a: 0}
+    key3: {r: 0.745283, g: 0, b: 0.022586089, a: 0}
+    key4: {r: 1, g: 0.9677537, b: 0, a: 0}
+    key5: {r: 2, g: 2, b: 2, a: 0}
+    key6: {r: 0, g: 0, b: 0, a: 0}
+    key7: {r: 0, g: 0, b: 0, a: 0}
+    ctime0: 0
+    ctime1: 5590
+    ctime2: 14649
+    ctime3: 29105
+    ctime4: 44333
     ctime5: 65535
     ctime6: 0
     ctime7: 0
@@ -57409,83 +57513,6 @@ MonoBehaviour:
           m_BoolArgument: 0
         m_CallState: 2
   m_IsOn: 0
---- !u!21 &2040148233
-Material:
-  serializedVersion: 6
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: Inherited From Round Corners
-  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
-  m_ShaderKeywords: 
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _BumpMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _EmissionMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _MetallicGlossMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _OcclusionMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _SpecGlossMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Floats:
-    - _AlphaClip: 0
-    - _Blend: 0
-    - _BumpScale: 1
-    - _ColorMask: 15
-    - _Cull: 2
-    - _Cutoff: 0.5
-    - _DstBlend: 0
-    - _GlossMapScale: 1
-    - _Glossiness: 0.5
-    - _GlossyReflections: 1
-    - _Metallic: 0
-    - _OcclusionStrength: 1
-    - _ReceiveShadows: 1
-    - _SmoothnessTextureChannel: 0
-    - _SpecularHighlights: 1
-    - _SrcBlend: 1
-    - _Stencil: 0
-    - _StencilComp: 8
-    - _StencilOp: 0
-    - _StencilReadMask: 255
-    - _StencilWriteMask: 255
-    - _Surface: 0
-    - _UseUIAlphaClip: 0
-    - _WorkflowMode: 1
-    - _ZWrite: 1
-    m_Colors:
-    - _Color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
-    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
-    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
-    - _WidthHeightRadius: {r: 750, g: 100, b: 105, a: 0}
-    - _halfSize: {r: 29, g: 10, b: 0, a: 0}
-    - _r: {r: 3, g: 3, b: 3, a: 3}
-    - _rect2props: {r: 0.0000019073486, g: -0.0000038146973, b: 25.455845, a: 25.455845}
 --- !u!1 &2050616147
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/__Scripts/MapEditor/Audio/WaveformGenerator.cs
+++ b/Assets/__Scripts/MapEditor/Audio/WaveformGenerator.cs
@@ -7,13 +7,13 @@ public class WaveformGenerator : MonoBehaviour {
     public AudioTimeSyncController atsc;
     [SerializeField] private BeatmapObjectCallbackController lookAheadController;
     [SerializeField] private AudioSource source;
-    [SerializeField] private AudioMixer mixer;
     [SerializeField] private GameObject spectrogramChunkPrefab;
     [SerializeField] private Transform spectroParent;
-    [SerializeField] private float saturation = 1;
     public AudioManager audioManager;
     [GradientUsage(true)]
     public Gradient spectrogramHeightGradient;
+    [GradientUsage(true)]
+    public Gradient spectrogramGradient2d;
 
     public static float UpdateTick = 0.1f;
 
@@ -35,7 +35,7 @@ public class WaveformGenerator : MonoBehaviour {
         yield return new WaitUntil(() => !SceneTransitionManager.IsLoading); //How we know "Start" has been called
 
         // Start the background worker
-        audioManager.Begin(WaveformType == 2, spectrogramHeightGradient, source.clip, waveformData, atsc, BeatmapObjectContainerCollection.ChunkSize);
+        audioManager.Begin(WaveformType == 2, WaveformType == 2 ? spectrogramHeightGradient : spectrogramGradient2d, source.clip, waveformData, atsc, BeatmapObjectContainerCollection.ChunkSize);
 
         int chunkId;
         HashSet<int> renderedChunks = new HashSet<int>();

--- a/Assets/__Scripts/UI/SongInfoEditUI.cs
+++ b/Assets/__Scripts/UI/SongInfoEditUI.cs
@@ -391,7 +391,7 @@ public class SongInfoEditUI : MenuBase
         {
             string winPath = Song.directory.Replace("/", "\\").Replace("\\\\", "\\");
             Debug.Log($"Opening song directory ({winPath}) with Windows...");
-            System.Diagnostics.Process.Start("explorer.exe", winPath);
+            System.Diagnostics.Process.Start("explorer.exe", $"\"{winPath}\"");
         }catch
         {
             if (Song.directory == null)


### PR DESCRIPTION
Adds a second gradient for the 2d waveform and fixes opening explorer when paths have funky characters