### PR TITLE
Set bomb material and switched shader to opaque

### DIFF
--- a/Assets/_Graphics/Materials/Notes/Bombs.mat
+++ b/Assets/_Graphics/Materials/Notes/Bombs.mat
@@ -8,7 +8,8 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: Bombs
-  m_Shader: {fileID: 4800000, guid: c78da644eb00dde4885d660169e504fe, type: 3}
+  m_Shader: {fileID: -6465566751694194690, guid: e0b541cb24fb9f44bbcb6a8f0652cefd,
+    type: 3}
   m_ShaderKeywords: 
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
@@ -85,11 +86,13 @@ Material:
     - _Cutoff: 0.5
     - _DetailNormalMapScale: 1
     - _DstBlend: 0
+    - _Editor_IsPlaying: 0
     - _GlossMapScale: 0
     - _Glossiness: 0.71
     - _GlossyReflections: 1
     - _Glow: 0
     - _LightIntensity: 1
+    - _Lit: 1
     - _Metallic: 0
     - _Mode: 0
     - _OcclusionStrength: 1
@@ -98,6 +101,7 @@ Material:
     - _Parallax: 0.02
     - _Power: 10
     - _ReceiveShadows: 1
+    - _Rotation: 0
     - _Scale: 5
     - _Smoothness: 1
     - _SmoothnessTextureChannel: 0
@@ -113,4 +117,5 @@ Material:
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _LightDir: {r: 0, g: -1, b: 1, a: 1}
     - _OverNoteInterfaceColor: {r: 1, g: 1, b: 1, a: 0}
+    - _RotationAxis: {r: 0, g: 1, b: 0, a: 0}
     - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}

--- a/Assets/_Graphics/Materials/Notes/Unassigned.mat
+++ b/Assets/_Graphics/Materials/Notes/Unassigned.mat
@@ -91,6 +91,7 @@ Material:
     - _GlossyReflections: 1
     - _Glow: 0
     - _LightIntensity: 1
+    - _Lit: 1
     - _Metallic: 0.5
     - _Mode: 0
     - _OcclusionStrength: 1

--- a/Assets/_Prefabs/MapEditor/Objects/Unassigned Note.prefab
+++ b/Assets/_Prefabs/MapEditor/Objects/Unassigned Note.prefab
@@ -55,6 +55,7 @@ MonoBehaviour:
   SelectionMaterials: []
   boxCollider: {fileID: 5280749955397464935}
   mapNoteData:
+    HasAttachedContainer: 0
     _time: 0
     _lineIndex: 0
     _lineLayer: 0
@@ -336,7 +337,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: 65a0f27365bc7df4886e1f6222b65f48, type: 2}
+  - {fileID: 2100000, guid: 9b516a6323222884b9da32df9a0c4fcc, type: 2}
   - {fileID: 2100000, guid: 714c52575879a884685fa7c22c92f9d0, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0


### PR DESCRIPTION
Fixes issues with the grid rendering over bombs at certain angles where it shouldn't