### PR TITLE
Small fixes

### DIFF
--- a/Assets/__Scripts/Map/BeatmapObjectContainer.cs
+++ b/Assets/__Scripts/Map/BeatmapObjectContainer.cs
@@ -41,7 +41,7 @@ public abstract class BeatmapObjectContainer : MonoBehaviour
     {
         ModelMaterials.Clear();
         SelectionMaterials.Clear();
-        foreach (Renderer renderer in GetComponentsInChildren<Renderer>())
+        foreach (Renderer renderer in GetComponentsInChildren<Renderer>(true))
         {
             if (renderer is SpriteRenderer) continue;
 

--- a/Assets/__Scripts/Map/Obstacles/BeatmapObstacle.cs
+++ b/Assets/__Scripts/Map/Obstacles/BeatmapObstacle.cs
@@ -54,7 +54,10 @@ public class BeatmapObstacle : BeatmapObject
     {
         if (other is BeatmapObstacle obstacle)
         {
-            if (IsNoodleExtensionsWall || obstacle.IsNoodleExtensionsWall) return false;
+            if (IsNoodleExtensionsWall || obstacle.IsNoodleExtensionsWall)
+            {
+                return ConvertToJSON().ToString() == other.ConvertToJSON().ToString();
+            }
             return _lineIndex == obstacle._lineIndex && _type == obstacle._type;
         }
         return false;


### PR DESCRIPTION
Fix selection outline not showing. I think someone had changed which of simple / shiny blocks were enabled in the prefab and we were only searching for selection materials in enabled children.
![image](https://user-images.githubusercontent.com/534069/88706491-d44d4a00-d108-11ea-8473-6f14e79c2e6c.png)

Allow deleting noodle walls. Re-added the json equality check for noodle as the DeleteObject method requires this to match to delete things.