### PR TITLE
Make fix orphans permenant by marking broken collections as dirty

### DIFF
--- a/Assets/Editor/CrowdIn.cs
+++ b/Assets/Editor/CrowdIn.cs
@@ -181,6 +181,7 @@ public class LocalizationWindow : EditorWindow
             {
                 // Orphaned table, why does it do this?
                 collection.AddTable(table);
+                EditorUtility.SetDirty(collection);
                 Debug.Log(table + " fixed");
             }
             else
@@ -188,6 +189,8 @@ public class LocalizationWindow : EditorWindow
                 Debug.Log(table + " looks ok");
             }
         }
+
+        AssetDatabase.SaveAssets();
     }
 
     public static void FromJSON(string apiKey = "", bool download = false)

--- a/Assets/Locales/Contributors.asset
+++ b/Assets/Locales/Contributors.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
   m_Tables:
   - {fileID: 11400000, guid: 629d8a24657e936408405d0528afe267, type: 2}
   - {fileID: 11400000, guid: 1411c398524482f409501269230bab2b, type: 2}
-  - {fileID: 11400000, guid: 95040785af7ca6d408e06d151cc82a6c, type: 2}
+  - {fileID: 11400000, guid: 05c5475091c47a2499eadfe23c81ec1d, type: 2}
   m_Extensions: []
   references:
     version: 1

--- a/Assets/Locales/FirstBoot.asset
+++ b/Assets/Locales/FirstBoot.asset
@@ -15,6 +15,8 @@ MonoBehaviour:
   m_SharedTableData: {fileID: 11400000, guid: a5ca8edc5f755c041aeda8ff35196c17, type: 2}
   m_Tables:
   - {fileID: 11400000, guid: 3ef08bb38c24ba24e8c4c1494c17d68a, type: 2}
+  - {fileID: 11400000, guid: b285253f8003b1640b8be8066d53f0a5, type: 2}
+  - {fileID: 11400000, guid: 30977124cbc5c9245a394d65a9b2e094, type: 2}
   m_Extensions: []
   references:
     version: 1

--- a/Assets/Locales/SongEditMenu.asset
+++ b/Assets/Locales/SongEditMenu.asset
@@ -15,7 +15,8 @@ MonoBehaviour:
   m_SharedTableData: {fileID: 11400000, guid: b86ac019838731d46842f98842efbe60, type: 2}
   m_Tables:
   - {fileID: 11400000, guid: 470ffe3707b612a44b1b7340c0ce79e7, type: 2}
-  - {fileID: 11400000, guid: 559ea5e659446784bbd78df346b92f14, type: 2}
+  - {fileID: 11400000, guid: 96078c8bb99077345be93ea4b614d283, type: 2}
+  - {fileID: 11400000, guid: 18e3fe20b19bbf54c8b8a1a1e6b59f32, type: 2}
   m_Extensions: []
   references:
     version: 1

--- a/Assets/Locales/SongSelectMenu.asset
+++ b/Assets/Locales/SongSelectMenu.asset
@@ -15,6 +15,8 @@ MonoBehaviour:
   m_SharedTableData: {fileID: 11400000, guid: 95d340fdffc264d469407a049a1fb729, type: 2}
   m_Tables:
   - {fileID: 11400000, guid: effd72c2e9a3d284abeaf195f2793c10, type: 2}
+  - {fileID: 11400000, guid: 8e6ea24a64bc81c44ac824f403c850d0, type: 2}
+  - {fileID: 11400000, guid: a81f4553b175cb245aa7e9df350e122d, type: 2}
   m_Extensions: []
   references:
     version: 1


### PR DESCRIPTION
I found a forum post that explained this as a bug in the current version of unity's library, this makes it so that things don't get re-orphaned when restarting unity.

https://forum.unity.com/threads/english-column-disappearing-automatically.932532/#post-6100209