### PR TITLE
Use note position for conflict check

### DIFF
--- a/Assets/__Scripts/Map/Notes/BeatmapNote.cs
+++ b/Assets/__Scripts/Map/Notes/BeatmapNote.cs
@@ -1,5 +1,6 @@
 ﻿using SimpleJSON;
 using System;
+using UnityEngine;
 
 [Serializable]
 public class BeatmapNote : BeatmapObject
@@ -66,11 +67,39 @@ public class BeatmapNote : BeatmapObject
         return node;
     }
 
+    public Vector2 GetPosition()
+    {
+        if (_customData?.HasKey("_position") ?? false)
+        {
+            return _customData["_position"].ReadVector2();
+        }
+
+        float position = _lineIndex - 1.5f;
+        float layer = _lineLayer;
+
+        if (_lineIndex >= 1000)
+        {
+            position = (_lineIndex / 1000f) - 2.5f;
+        }
+        else if (_lineIndex <= -1000)
+        {
+            position = (_lineIndex / 1000f) - 0.5f;
+        }
+
+        if (_lineLayer >= 1000 || _lineLayer <= -1000)
+        {
+            layer = (_lineLayer / 1000f) - 1f;
+        }
+
+        return new Vector2(position, layer);
+    }
+
     protected override bool IsConflictingWithObjectAtSameTime(BeatmapObject other)
     {
         if (other is BeatmapNote note)
         {
-            return _lineIndex == note._lineIndex && _lineLayer == note._lineLayer;
+            // Only down to 1/4 spacing
+            return Vector2.Distance(note.GetPosition(), GetPosition()) < 0.25;
         }
         return false;
     }

--- a/Assets/__Scripts/Map/Notes/BeatmapNoteContainer.cs
+++ b/Assets/__Scripts/Map/Notes/BeatmapNoteContainer.cs
@@ -111,28 +111,8 @@ public class BeatmapNoteContainer : BeatmapObjectContainer {
     }
 
     public override void UpdateGridPosition() {
-        float position = mapNoteData._lineIndex - 1.5f;
-        float layer = mapNoteData._lineLayer + 0.5f;
-        if (mapNoteData._customData?.HasKey("_position") ?? false)
-        {
-            Vector2 NEPosition = mapNoteData._customData["_position"].ReadVector2();
-            position = NEPosition.x;
-            layer = NEPosition.y + 0.5f;
-        }
-        else
-        {
-            if (mapNoteData._lineIndex >= 1000)
-                position = (mapNoteData._lineIndex / 1000f) - 2.5f;
-            else if (mapNoteData._lineIndex <= -1000)
-                position = (mapNoteData._lineIndex / 1000f) - 0.5f;
-            if (mapNoteData._lineLayer >= 1000 || mapNoteData._lineLayer <= -1000)
-                layer = (mapNoteData._lineLayer / 1000f) - 0.5f;
-        }
-        transform.localPosition = new Vector3(
-            position,
-            layer,
-            mapNoteData._time * EditorScaleController.EditorScale
-            );
+        transform.localPosition = (Vector3)mapNoteData.GetPosition() +
+            new Vector3(0, 0.5f, mapNoteData._time * EditorScaleController.EditorScale);
 
         noteRenderer.ForEach(it =>
         {

--- a/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/BombPlacement.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/BombPlacement.cs
@@ -78,7 +78,7 @@ public class BombPlacement : PlacementController<BeatmapNote, BeatmapNoteContain
 
             JSONArray position = new JSONArray(); //We do some manual array stuff to get rounding decimals to work.
             position[0] = Math.Round(roundedHit.x, 3);
-            position[1] = Math.Round(roundedHit.y, 3);
+            position[1] = Math.Round(roundedHit.y - 0.5, 3);
             queuedData._customData["_position"] = position;
 
             precisionPlacement.TogglePrecisionPlacement(true);


### PR DESCRIPTION
Moved the lineIndex and lineLayer to vector calculation into the note object and then used distance rather than checking the index and layer match to determine if they conflict.

Also fixed bomb placement being half a block off vertically.