### PR TITLE
Various fixes

### DIFF
--- a/Assets/_Prefabs/Global/PersistentCanvas.prefab
+++ b/Assets/_Prefabs/Global/PersistentCanvas.prefab
@@ -1245,7 +1245,18 @@ MonoBehaviour:
   m_CharacterLimit: 0
   m_OnEndEdit:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 7633229469409116205}
+        m_MethodName: EndEdit
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   m_OnSubmit:
     m_PersistentCalls:
       m_Calls: []

--- a/Assets/__Scenes/03_Mapper.unity
+++ b/Assets/__Scenes/03_Mapper.unity
@@ -15380,6 +15380,83 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectParentTransform: {fileID: 565602430}
   RotationValue: {x: 0, y: 0, z: 0}
+--- !u!21 &566287520
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Inherited From Round Corners
+  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _AlphaClip: 0
+    - _Blend: 0
+    - _BumpScale: 1
+    - _ColorMask: 15
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _ReceiveShadows: 1
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _Surface: 0
+    - _UseUIAlphaClip: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+    - _WidthHeightRadius: {r: 750, g: 100, b: 105, a: 0}
+    - _halfSize: {r: 29, g: 10, b: 0, a: 0}
+    - _r: {r: 3, g: 3, b: 3, a: 3}
+    - _rect2props: {r: 0.0000019073486, g: -0.0000038146973, b: 25.455845, a: 25.455845}
 --- !u!1 &570484800
 GameObject:
   m_ObjectHideFlags: 0
@@ -20838,7 +20915,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   material: {fileID: 2100000, guid: 68b9a414913410a46abcdd5a10666679, type: 2}
-  mat: {fileID: 1144760784}
+  mat: {fileID: 566287520}
   cloneMaterial: 1
   radius: 105
 --- !u!114 &756850815
@@ -20892,7 +20969,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Material: {fileID: 1144760784}
+  m_Material: {fileID: 566287520}
   m_Color: {r: 0.18867922, g: 0.18867922, b: 0.18867922, a: 1}
   m_RaycastTarget: 0
   m_Maskable: 1
@@ -30546,83 +30623,6 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
---- !u!21 &1144760784
-Material:
-  serializedVersion: 6
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: Inherited From Round Corners
-  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
-  m_ShaderKeywords: 
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _BumpMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _EmissionMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _MetallicGlossMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _OcclusionMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _SpecGlossMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Floats:
-    - _AlphaClip: 0
-    - _Blend: 0
-    - _BumpScale: 1
-    - _ColorMask: 15
-    - _Cull: 2
-    - _Cutoff: 0.5
-    - _DstBlend: 0
-    - _GlossMapScale: 1
-    - _Glossiness: 0.5
-    - _GlossyReflections: 1
-    - _Metallic: 0
-    - _OcclusionStrength: 1
-    - _ReceiveShadows: 1
-    - _SmoothnessTextureChannel: 0
-    - _SpecularHighlights: 1
-    - _SrcBlend: 1
-    - _Stencil: 0
-    - _StencilComp: 8
-    - _StencilOp: 0
-    - _StencilReadMask: 255
-    - _StencilWriteMask: 255
-    - _Surface: 0
-    - _UseUIAlphaClip: 0
-    - _WorkflowMode: 1
-    - _ZWrite: 1
-    m_Colors:
-    - _Color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
-    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
-    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
-    - _WidthHeightRadius: {r: 750, g: 100, b: 105, a: 0}
-    - _halfSize: {r: 29, g: 10, b: 0, a: 0}
-    - _r: {r: 3, g: 3, b: 3, a: 3}
-    - _rect2props: {r: 0.0000019073486, g: -0.0000038146973, b: 25.455845, a: 25.455845}
 --- !u!1 &1148681368
 GameObject:
   m_ObjectHideFlags: 0
@@ -33475,9 +33475,9 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
+  m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: -23.999985, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &1223292197
 RectTransform:
@@ -53764,6 +53764,7 @@ MonoBehaviour:
   - {fileID: 1125491375}
   - {fileID: 565602430}
   _rotationCallbackController: {fileID: 226696885}
+  atsc: {fileID: 570484802}
   selectedMode: 0
   Keybind: Ctrl+H
 --- !u!225 &1799035894

--- a/Assets/__Scenes/03_Mapper.unity
+++ b/Assets/__Scenes/03_Mapper.unity
@@ -17199,6 +17199,7 @@ GameObject:
   - component: {fileID: 635786348}
   - component: {fileID: 635786347}
   - component: {fileID: 635786346}
+  - component: {fileID: 635786349}
   m_Layer: 5
   m_Name: Text
   m_TagString: Untagged
@@ -17220,11 +17221,11 @@ RectTransform:
   m_Father: {fileID: 1666533554}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -7.5, y: -750}
-  m_SizeDelta: {x: -25, y: 1500}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 217.1, y: -0.000061035156}
+  m_SizeDelta: {x: 425, y: 0}
+  m_Pivot: {x: 0.5, y: 1}
 --- !u!114 &635786346
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -17378,6 +17379,20 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 635786344}
   m_CullTransparentMesh: 0
+--- !u!114 &635786349
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 635786344}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 0
+  m_VerticalFit: 2
 --- !u!1 &637273205
 GameObject:
   m_ObjectHideFlags: 0
@@ -20823,7 +20838,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   material: {fileID: 2100000, guid: 68b9a414913410a46abcdd5a10666679, type: 2}
-  mat: {fileID: 1553616757}
+  mat: {fileID: 1144760784}
   cloneMaterial: 1
   radius: 105
 --- !u!114 &756850815
@@ -20877,7 +20892,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Material: {fileID: 1553616757}
+  m_Material: {fileID: 1144760784}
   m_Color: {r: 0.18867922, g: 0.18867922, b: 0.18867922, a: 1}
   m_RaycastTarget: 0
   m_Maskable: 1
@@ -25861,7 +25876,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 1946301807}
   m_Direction: 2
   m_Value: 1
-  m_Size: 0.17141478
+  m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -30531,6 +30546,83 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+--- !u!21 &1144760784
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Inherited From Round Corners
+  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _AlphaClip: 0
+    - _Blend: 0
+    - _BumpScale: 1
+    - _ColorMask: 15
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _ReceiveShadows: 1
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _Surface: 0
+    - _UseUIAlphaClip: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+    - _WidthHeightRadius: {r: 750, g: 100, b: 105, a: 0}
+    - _halfSize: {r: 29, g: 10, b: 0, a: 0}
+    - _r: {r: 3, g: 3, b: 3, a: 3}
+    - _rect2props: {r: 0.0000019073486, g: -0.0000038146973, b: 25.455845, a: 25.455845}
 --- !u!1 &1148681368
 GameObject:
   m_ObjectHideFlags: 0
@@ -33383,9 +33475,9 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: -23.999985, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &1223292197
 RectTransform:
@@ -46606,83 +46698,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1553080213}
   m_CullTransparentMesh: 0
---- !u!21 &1553616757
-Material:
-  serializedVersion: 6
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: Inherited From Round Corners
-  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
-  m_ShaderKeywords: 
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _BumpMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _EmissionMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _MetallicGlossMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _OcclusionMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _SpecGlossMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Floats:
-    - _AlphaClip: 0
-    - _Blend: 0
-    - _BumpScale: 1
-    - _ColorMask: 15
-    - _Cull: 2
-    - _Cutoff: 0.5
-    - _DstBlend: 0
-    - _GlossMapScale: 1
-    - _Glossiness: 0.5
-    - _GlossyReflections: 1
-    - _Metallic: 0
-    - _OcclusionStrength: 1
-    - _ReceiveShadows: 1
-    - _SmoothnessTextureChannel: 0
-    - _SpecularHighlights: 1
-    - _SrcBlend: 1
-    - _Stencil: 0
-    - _StencilComp: 8
-    - _StencilOp: 0
-    - _StencilReadMask: 255
-    - _StencilWriteMask: 255
-    - _Surface: 0
-    - _UseUIAlphaClip: 0
-    - _WorkflowMode: 1
-    - _ZWrite: 1
-    m_Colors:
-    - _Color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
-    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
-    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
-    - _WidthHeightRadius: {r: 750, g: 100, b: 105, a: 0}
-    - _halfSize: {r: 29, g: 10, b: 0, a: 0}
-    - _r: {r: 3, g: 3, b: 3, a: 3}
-    - _rect2props: {r: 0.0000019073486, g: -0.0000038146973, b: 25.455845, a: 25.455845}
 --- !u!1 &1555442089
 GameObject:
   m_ObjectHideFlags: 0
@@ -50398,7 +50413,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -225, y: 0}
+  m_AnchoredPosition: {x: -224.99998, y: 0}
   m_SizeDelta: {x: 450, y: -10}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1666533555
@@ -50433,7 +50448,7 @@ MonoBehaviour:
   m_Elasticity: 0.1
   m_Inertia: 1
   m_DecelerationRate: 0.135
-  m_ScrollSensitivity: 1
+  m_ScrollSensitivity: 15
   m_Viewport: {fileID: 0}
   m_HorizontalScrollbar: {fileID: 0}
   m_VerticalScrollbar: {fileID: 974257905}

--- a/Assets/__Scripts/Input/ChroMapper/CMInputCallbackInstaller.cs
+++ b/Assets/__Scripts/Input/ChroMapper/CMInputCallbackInstaller.cs
@@ -30,6 +30,8 @@ public class CMInputCallbackInstaller : MonoBehaviour
     private List<IEnumerable<Type>> queuedToDisable = new List<IEnumerable<Type>>();
     private List<IEnumerable<Type>> queuedToEnable = new List<IEnumerable<Type>>();
 
+    private List<Transform> persistentObjects = new List<Transform>();
+
     private List<EventHandler> allEventHandlers = new List<EventHandler>();
     private List<EventHandler> disabledEventHandlers = new List<EventHandler>();
 
@@ -143,6 +145,10 @@ public class CMInputCallbackInstaller : MonoBehaviour
         {
             FindAndInstallCallbacksRecursive(obj.transform);
         }
+        foreach (var transform in persistentObjects)
+        {
+            FindAndInstallCallbacksRecursive(transform);
+        }
         StartCoroutine(WaitThenReenableInputs());
     }
 
@@ -176,6 +182,11 @@ public class CMInputCallbackInstaller : MonoBehaviour
         return true;
     }
 
+    public static void PersistentObject(Transform obj)
+    {
+        instance.persistentObjects.Add(obj);
+    }
+
     // Here we find all MonoBehaviours with an Input Map interface and set its callbacks.
     // Looping through each monobehaviour on each object might be time consuming, but this is done only once when a scene loads.
     private void FindAndInstallCallbacksRecursive(Transform obj)
@@ -195,8 +206,7 @@ public class CMInputCallbackInstaller : MonoBehaviour
                             InputAction action = (InputAction)info.GetValue(interfaceNameToReference[interfaceType.Name]);
                             foreach (EventInfo e in info.PropertyType.GetEvents())
                             {
-                                AddEventHandler(e, info.GetValue(interfaceNameToReference[interfaceType.Name]),
-                                    behaviour, interfaceType.GetMethod($"On{info.Name}"), interfaceType);
+                                AddEventHandler(e, action, behaviour, interfaceType.GetMethod($"On{info.Name}"), interfaceType);
                             }
                         }
                     }

--- a/Assets/__Scripts/Input/ChroMapper/CMInputCallbackInstaller.cs.meta
+++ b/Assets/__Scripts/Input/ChroMapper/CMInputCallbackInstaller.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: -50
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/Assets/__Scripts/MapEditor/AudioTimeSyncController.cs
+++ b/Assets/__Scripts/MapEditor/AudioTimeSyncController.cs
@@ -168,6 +168,11 @@ public class AudioTimeSyncController : MonoBehaviour, CMInput.IPlaybackActions, 
         songAudioSource.time = CurrentSeconds + offsetMS;
     }
 
+    public void RefreshGridSnapping()
+    {
+        GridMeasureSnappingChanged?.Invoke(gridMeasureSnapping);
+    }
+
     public void MoveToTimeInBeats(float beats) {
         if (IsPlaying) return;
         CurrentBeat = beats;

--- a/Assets/__Scripts/MapEditor/UI/PauseManager.cs
+++ b/Assets/__Scripts/MapEditor/UI/PauseManager.cs
@@ -13,6 +13,11 @@ public class PauseManager : MonoBehaviour, CMInput.IPauseMenuActions
     private PlatformDescriptor platform;
     [SerializeField] private AutoSaveController saveController;
 
+    private Type[] disabledActionMaps = new Type[]
+    {
+        typeof(CMInput.ITimelineActions),
+    };
+
     public static bool IsPaused;
     private bool ShowsHelpText = true;
 
@@ -37,6 +42,7 @@ public class PauseManager : MonoBehaviour, CMInput.IPauseMenuActions
         IsPaused = !IsPaused;
         if (IsPaused)
         {
+            CMInputCallbackInstaller.DisableActionMaps(disabledActionMaps);
             previousUIModeType = uiMode.selectedMode;
             uiMode.SetUIMode(UIModeType.NORMAL, false);
             foreach (LightsManager e in platform.gameObject.GetComponentsInChildren<LightsManager>())
@@ -44,6 +50,7 @@ public class PauseManager : MonoBehaviour, CMInput.IPauseMenuActions
         }
         else
         {
+            CMInputCallbackInstaller.ClearDisabledActionMaps(disabledActionMaps);
             uiMode.SetUIMode(previousUIModeType, false);
         }
         StartCoroutine(TransitionMenu());

--- a/Assets/__Scripts/MapEditor/UI/SongTimelineController.cs
+++ b/Assets/__Scripts/MapEditor/UI/SongTimelineController.cs
@@ -40,10 +40,22 @@ public class SongTimelineController : MonoBehaviour, IPointerEnterHandler, IPoin
             atsc.CurrentSeconds < 0 ? "-" : "");
 	}
 
+    public void TriggerUpdate()
+    {
+        UpdateSongTimelineSlider(slider.value);
+    }
+
     public void UpdateSongTimelineSlider(float sliderValue)
     {
-        if (atsc.IsPlaying || Input.GetAxis("Mouse ScrollWheel") != 0 || NodeEditorController.IsActive || !IsClicked)
+        if (atsc.IsPlaying || Input.GetAxis("Mouse ScrollWheel") != 0 || !IsClicked)
+        {
             return; //Don't modify ATSC if some other things are happening.
+        }
+        else if (NodeEditorController.IsActive)
+        {
+            slider.value = lastSongTime / songLength;
+            return;
+        }
         atsc.MoveToTimeInSeconds(sliderValue * songLength);
         atsc.SnapToGrid();
     }

--- a/Assets/__Scripts/MapEditor/UI/SongTimelineHandleController.cs
+++ b/Assets/__Scripts/MapEditor/UI/SongTimelineHandleController.cs
@@ -12,6 +12,7 @@ public class SongTimelineHandleController : MonoBehaviour, IPointerUpHandler, IP
 
     public void OnPointerUp(PointerEventData fucku)
     {
+        timeline.TriggerUpdate();
         timeline.IsClicked = false;
     }
 }

--- a/Assets/__Scripts/MapEditor/UI/UIMode.cs
+++ b/Assets/__Scripts/MapEditor/UI/UIMode.cs
@@ -14,6 +14,7 @@ public class UIMode : MonoBehaviour, CMInput.IUIModeActions
     [SerializeField] private GameObject[] gameObjectsWithRenderersToToggle;
     [SerializeField] private Transform[] thingsThatRequireAMoveForPreview;
     [SerializeField] private RotationCallbackController _rotationCallbackController;
+    [SerializeField] private AudioTimeSyncController atsc;
 
     private List<Renderer> _renderers = new List<Renderer>();
     private List<Canvas> _canvases = new List<Canvas>();
@@ -138,6 +139,7 @@ public class UIMode : MonoBehaviour, CMInput.IUIModeActions
 
         if (fixTheCam) _cameraController.LockedOntoNoteGrid = true;
         //foreach (Renderer r in _verticalGridRenderers) r.enabled = showMainGrid;
+        atsc.RefreshGridSnapping();
     }
 
     private IEnumerator ShowUI()

--- a/Assets/__Scripts/UI/CM_InputBox.cs
+++ b/Assets/__Scripts/UI/CM_InputBox.cs
@@ -2,8 +2,10 @@
 using UnityEngine;
 using TMPro;
 using System.Collections;
+using UnityEngine.EventSystems;
+using UnityEngine.InputSystem;
 
-public class CM_InputBox : MonoBehaviour
+public class CM_InputBox : MenuBase
 {
     [SerializeField] private TMP_InputField InputField;
     [SerializeField] private TextMeshProUGUI UIMessage;
@@ -44,11 +46,19 @@ public class CM_InputBox : MonoBehaviour
         resultAction = result;
     }
 
+    public void EndEdit()
+    {
+        if (Input.GetKeyDown(KeyCode.Return) || Input.GetKeyDown(KeyCode.KeypadEnter))
+        {
+            SendResult(0);
+        }
+    }
+
     public void SendResult(int buttonID)
     {
         CMInputCallbackInstaller.ClearDisabledActionMaps(disabledActionMaps);
         UpdateGroup(false);
-        string res = (string.IsNullOrEmpty(InputField.text) || string.IsNullOrWhiteSpace(InputField.text)) ? "" : InputField.text;
+        string res = string.IsNullOrWhiteSpace(InputField.text) ? "" : InputField.text;
         resultAction?.Invoke(buttonID == 0 ? res : null);
     }
 
@@ -63,5 +73,23 @@ public class CM_InputBox : MonoBehaviour
     {
         yield return new WaitForSeconds(0.25f);
         group.interactable = visible;
+
+        // Set focus to input field
+        EventSystem.current.SetSelectedGameObject(InputField.gameObject, new BaseEventData(EventSystem.current));
+    }
+
+    public override void OnTab(InputAction.CallbackContext context)
+    {
+        if (IsEnabled) base.OnTab(context);
+    }
+
+    protected override GameObject GetDefault()
+    {
+        return InputField.gameObject;
+    }
+
+    public override void OnLeaveMenu(InputAction.CallbackContext context)
+    {
+        SendResult(1);
     }
 }

--- a/Assets/__Scripts/UI/MenuBase.cs
+++ b/Assets/__Scripts/UI/MenuBase.cs
@@ -11,7 +11,7 @@ public abstract class MenuBase : MonoBehaviour, CMInput.IMenusExtendedActions
 
     public abstract void OnLeaveMenu(CallbackContext context);
 
-    public void OnTab(CallbackContext context)
+    public virtual void OnTab(CallbackContext context)
     {
         if (!context.performed) return;
 

--- a/Assets/__Scripts/UI/PersistentUI.cs
+++ b/Assets/__Scripts/UI/PersistentUI.cs
@@ -87,6 +87,7 @@ public class PersistentUI : MonoBehaviour {
     private MessageDisplayer bottomDisplay;
 
     private void Start() {
+        CMInputCallbackInstaller.PersistentObject(transform);
         LocalizationSettings.SelectedLocale = Locale.CreateLocale(Settings.Instance.Language);
         AudioListener.volume = Settings.Instance.Volume;
         centerDisplay.host = this;


### PR DESCRIPTION
Enter / Escape now work in input boxes

Clicking the timeline without dragging now actually updates the song position. Clicking with the node editor open will move the slider back without changing position.

Removed all the empty space in the box in the pause menu, increased the scroll speed and disabled scrolling the song with the menu open

Fixed grid lines all being shown when pausing or changing UI mode