### PR TITLE
Add support for boost colour event

### DIFF
--- a/Assets/Locales/Mapper Shared Data.asset
+++ b/Assets/Locales/Mapper Shared Data.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5b11a58205ec3474ca216360e9fa74a8, type: 3}
   m_Name: Mapper Shared Data
   m_EditorClassIdentifier: 
-  m_NextAvailableId: 117
+  m_NextAvailableId: 119
   m_TableCollectionName: Mapper
   m_TableCollectionNameGuidString: 8944026aec77cf8479a89f2280c8e1ff
   m_Entries:
@@ -462,6 +462,14 @@ MonoBehaviour:
       m_Items: []
   - m_Id: 116
     m_Key: chroma.chromaobjects
+    m_Metadata:
+      m_Items: []
+  - m_Id: 117
+    m_Key: chroma.rightboost.tooltip
+    m_Metadata:
+      m_Items: []
+  - m_Id: 118
+    m_Key: chroma.leftboost.tooltip
     m_Metadata:
       m_Items: []
   m_Metadata:

--- a/Assets/Locales/Mapper_en.asset
+++ b/Assets/Locales/Mapper_en.asset
@@ -569,6 +569,14 @@ MonoBehaviour:
     m_Localized: Place Chroma Colored Objects
     m_Metadata:
       m_Items: []
+  - m_Id: 117
+    m_Localized: Set boost color for Blue Lighting Events
+    m_Metadata:
+      m_Items: []
+  - m_Id: 118
+    m_Localized: Set boost color for Red Lighting Events
+    m_Metadata:
+      m_Items: []
   references:
     version: 1
     00000000:

--- a/Assets/Locales/Mapper_es.asset
+++ b/Assets/Locales/Mapper_es.asset
@@ -538,6 +538,14 @@ MonoBehaviour:
     m_Localized: Place Chroma Colored Objects
     m_Metadata:
       m_Items: []
+  - m_Id: 117
+    m_Localized: Set boost color for Blue Lighting Events
+    m_Metadata:
+      m_Items: []
+  - m_Id: 118
+    m_Localized: Set boost color for Red Lighting Events
+    m_Metadata:
+      m_Items: []
   references:
     version: 1
     00000000:

--- a/Assets/Locales/Mapper_fr.asset
+++ b/Assets/Locales/Mapper_fr.asset
@@ -551,6 +551,14 @@ MonoBehaviour:
     m_Localized: Place Chroma Colored Objects
     m_Metadata:
       m_Items: []
+  - m_Id: 117
+    m_Localized: Set boost color for Blue Lighting Events
+    m_Metadata:
+      m_Items: []
+  - m_Id: 118
+    m_Localized: Set boost color for Red Lighting Events
+    m_Metadata:
+      m_Items: []
   references:
     version: 1
     00000000:

--- a/Assets/Locales/Mapper_ja.asset
+++ b/Assets/Locales/Mapper_ja.asset
@@ -536,6 +536,14 @@ MonoBehaviour:
     m_Localized: Place Chroma Colored Objects
     m_Metadata:
       m_Items: []
+  - m_Id: 117
+    m_Localized: Set boost color for Blue Lighting Events
+    m_Metadata:
+      m_Items: []
+  - m_Id: 118
+    m_Localized: Set boost color for Red Lighting Events
+    m_Metadata:
+      m_Items: []
   references:
     version: 1
     00000000:

--- a/Assets/Locales/Mapper_nl.asset
+++ b/Assets/Locales/Mapper_nl.asset
@@ -544,6 +544,14 @@ MonoBehaviour:
     m_Localized: Place Chroma Colored Objects
     m_Metadata:
       m_Items: []
+  - m_Id: 117
+    m_Localized: Set boost color for Blue Lighting Events
+    m_Metadata:
+      m_Items: []
+  - m_Id: 118
+    m_Localized: Set boost color for Red Lighting Events
+    m_Metadata:
+      m_Items: []
   references:
     version: 1
     00000000:

--- a/Assets/Locales/Mapper_sv.asset
+++ b/Assets/Locales/Mapper_sv.asset
@@ -538,6 +538,14 @@ MonoBehaviour:
     m_Localized: Place Chroma Colored Objects
     m_Metadata:
       m_Items: []
+  - m_Id: 117
+    m_Localized: Set boost color for Blue Lighting Events
+    m_Metadata:
+      m_Items: []
+  - m_Id: 118
+    m_Localized: Set boost color for Red Lighting Events
+    m_Metadata:
+      m_Items: []
   references:
     version: 1
     00000000:

--- a/Assets/_Prefabs/MapEditor/Platforms/Big Mirror.prefab
+++ b/Assets/_Prefabs/MapEditor/Platforms/Big Mirror.prefab
@@ -55,6 +55,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -66,6 +67,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -91,6 +93,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LightMaterial: {fileID: 0}
+  OverrideLightGroup: 0
+  OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &520528311886854812
 GameObject:
   m_ObjectHideFlags: 0
@@ -146,6 +152,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -157,6 +164,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -182,6 +190,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LightMaterial: {fileID: 0}
+  OverrideLightGroup: 0
+  OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &1318629925276109239
 GameObject:
   m_ObjectHideFlags: 0
@@ -237,6 +249,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -248,6 +261,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -273,6 +287,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LightMaterial: {fileID: 0}
+  OverrideLightGroup: 0
+  OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &1496699266183611568
 GameObject:
   m_ObjectHideFlags: 0
@@ -319,6 +337,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   multiplier: 20
   rotationSpeed: 0
+  zPositionModifier: 1
+  OverrideLightGroup: 0
+  OverrideLightGroupID: 0
+  UseZPositionForAngleOffset: 0
 --- !u!1 &2166082539776822301
 GameObject:
   m_ObjectHideFlags: 0
@@ -365,6 +387,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   multiplier: 20
   rotationSpeed: 0
+  zPositionModifier: 1
+  OverrideLightGroup: 0
+  OverrideLightGroupID: 0
+  UseZPositionForAngleOffset: 0
 --- !u!1 &2256496460832765177
 GameObject:
   m_ObjectHideFlags: 0
@@ -420,6 +446,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -431,6 +458,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -456,6 +484,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LightMaterial: {fileID: 0}
+  OverrideLightGroup: 0
+  OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &2440409431586819217
 GameObject:
   m_ObjectHideFlags: 0
@@ -511,6 +543,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -522,6 +555,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -547,6 +581,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LightMaterial: {fileID: 0}
+  OverrideLightGroup: 0
+  OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &2578642841309007804
 GameObject:
   m_ObjectHideFlags: 0
@@ -602,6 +640,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -613,6 +652,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -638,6 +678,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LightMaterial: {fileID: 0}
+  OverrideLightGroup: 0
+  OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &3727232652408287308
 GameObject:
   m_ObjectHideFlags: 0
@@ -684,6 +728,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   multiplier: 20
   rotationSpeed: 0
+  zPositionModifier: 1
+  OverrideLightGroup: 0
+  OverrideLightGroupID: 0
+  UseZPositionForAngleOffset: 0
 --- !u!1 &3800082766192672697
 GameObject:
   m_ObjectHideFlags: 0
@@ -739,6 +787,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -750,6 +799,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -775,6 +825,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LightMaterial: {fileID: 0}
+  OverrideLightGroup: 0
+  OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &3867199664550194409
 GameObject:
   m_ObjectHideFlags: 0
@@ -821,6 +875,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   multiplier: 20
   rotationSpeed: 0
+  zPositionModifier: 1
+  OverrideLightGroup: 0
+  OverrideLightGroupID: 0
+  UseZPositionForAngleOffset: 0
 --- !u!1 &5478733700857760314
 GameObject:
   m_ObjectHideFlags: 0
@@ -867,6 +925,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   multiplier: 20
   rotationSpeed: 0
+  zPositionModifier: 1
+  OverrideLightGroup: 0
+  OverrideLightGroupID: 0
+  UseZPositionForAngleOffset: 0
 --- !u!1 &5813458160598045598
 GameObject:
   m_ObjectHideFlags: 0
@@ -913,6 +975,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   multiplier: 20
   rotationSpeed: 0
+  zPositionModifier: 1
+  OverrideLightGroup: 0
+  OverrideLightGroupID: 0
+  UseZPositionForAngleOffset: 0
 --- !u!1 &6942400051539818447
 GameObject:
   m_ObjectHideFlags: 0
@@ -968,6 +1034,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -979,6 +1046,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -1004,6 +1072,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LightMaterial: {fileID: 0}
+  OverrideLightGroup: 0
+  OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &6942400051564212373
 GameObject:
   m_ObjectHideFlags: 0
@@ -1073,6 +1145,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1084,6 +1157,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -1109,6 +1183,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LightMaterial: {fileID: 0}
+  OverrideLightGroup: 0
+  OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &6942400051621595271
 GameObject:
   m_ObjectHideFlags: 0
@@ -1163,6 +1241,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1174,6 +1253,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -1241,6 +1321,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1252,6 +1333,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -1277,6 +1359,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LightMaterial: {fileID: 0}
+  OverrideLightGroup: 0
+  OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &6942400051755393368
 GameObject:
   m_ObjectHideFlags: 0
@@ -1364,6 +1450,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1375,6 +1462,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -1400,6 +1488,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LightMaterial: {fileID: 0}
+  OverrideLightGroup: 0
+  OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &6942400051924502740
 GameObject:
   m_ObjectHideFlags: 0
@@ -1479,7 +1571,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f7f2dcefc297b9b40a12ccbf3fe55817, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  CanBeTurnedOff: 1
+  disableCustomInitialization: 0
   ControllingLights: []
   RotatingLights: []
 --- !u!1 &6942400051946417065
@@ -1601,6 +1693,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1612,6 +1705,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -1637,6 +1731,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LightMaterial: {fileID: 0}
+  OverrideLightGroup: 0
+  OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &6942400052019739603
 GameObject:
   m_ObjectHideFlags: 0
@@ -1773,6 +1871,7 @@ MonoBehaviour:
   startupRotationStep: 5
   startupRotationPropagationSpeed: 1
   startupRotationFlexySpeed: 1
+  rotationStep: 90
 --- !u!114 &147130553587003560
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1785,7 +1884,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f7f2dcefc297b9b40a12ccbf3fe55817, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  CanBeTurnedOff: 1
+  disableCustomInitialization: 0
   ControllingLights: []
   RotatingLights: []
 --- !u!1 &6942400052097391635
@@ -1888,6 +1987,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1899,6 +1999,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -1924,6 +2025,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LightMaterial: {fileID: 0}
+  OverrideLightGroup: 0
+  OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &6942400052110667437
 GameObject:
   m_ObjectHideFlags: 0
@@ -1993,6 +2098,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -2004,6 +2110,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -2029,6 +2136,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LightMaterial: {fileID: 0}
+  OverrideLightGroup: 0
+  OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &6942400052132382997
 GameObject:
   m_ObjectHideFlags: 0
@@ -2084,6 +2195,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -2095,6 +2207,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -2120,6 +2233,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LightMaterial: {fileID: 0}
+  OverrideLightGroup: 0
+  OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &6942400052164710941
 GameObject:
   m_ObjectHideFlags: 0
@@ -2175,6 +2292,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -2186,6 +2304,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -2211,6 +2330,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LightMaterial: {fileID: 0}
+  OverrideLightGroup: 0
+  OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &6942400052202408494
 GameObject:
   m_ObjectHideFlags: 0
@@ -2296,6 +2419,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -2307,6 +2431,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -2420,6 +2545,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -2431,6 +2557,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -2456,6 +2583,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LightMaterial: {fileID: 0}
+  OverrideLightGroup: 0
+  OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &6942400052354895343
 GameObject:
   m_ObjectHideFlags: 0
@@ -2537,7 +2668,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f7f2dcefc297b9b40a12ccbf3fe55817, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  CanBeTurnedOff: 1
+  disableCustomInitialization: 0
   ControllingLights: []
   RotatingLights: []
 --- !u!1 &6942400052381956297
@@ -2639,6 +2770,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -2650,6 +2782,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -2747,6 +2880,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -2758,6 +2892,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -2824,6 +2959,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -2835,6 +2971,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -2967,6 +3104,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -2978,6 +3116,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -3003,6 +3142,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LightMaterial: {fileID: 0}
+  OverrideLightGroup: 0
+  OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &6942400052707217018
 GameObject:
   m_ObjectHideFlags: 0
@@ -3072,6 +3215,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -3083,6 +3227,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -3108,6 +3253,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LightMaterial: {fileID: 0}
+  OverrideLightGroup: 0
+  OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &6942400052730268942
 GameObject:
   m_ObjectHideFlags: 0
@@ -3163,6 +3312,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -3174,6 +3324,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -3199,6 +3350,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LightMaterial: {fileID: 0}
+  OverrideLightGroup: 0
+  OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &6942400052734873553
 GameObject:
   m_ObjectHideFlags: 0
@@ -3281,7 +3436,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f7f2dcefc297b9b40a12ccbf3fe55817, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  CanBeTurnedOff: 1
+  disableCustomInitialization: 0
   ControllingLights: []
   RotatingLights: []
 --- !u!1 &6942400052819708616
@@ -3353,6 +3508,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -3364,6 +3520,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -3389,6 +3546,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LightMaterial: {fileID: 0}
+  OverrideLightGroup: 0
+  OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &6942400052876521071
 GameObject:
   m_ObjectHideFlags: 0
@@ -3443,6 +3604,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -3454,6 +3616,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -3535,6 +3698,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -3546,6 +3710,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -3571,6 +3736,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LightMaterial: {fileID: 0}
+  OverrideLightGroup: 0
+  OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &6942400052900894558
 GameObject:
   m_ObjectHideFlags: 0
@@ -3640,6 +3809,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -3651,6 +3821,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -3676,6 +3847,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LightMaterial: {fileID: 0}
+  OverrideLightGroup: 0
+  OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &6942400052929126725
 GameObject:
   m_ObjectHideFlags: 0
@@ -3745,6 +3920,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -3756,6 +3932,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -3781,6 +3958,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LightMaterial: {fileID: 0}
+  OverrideLightGroup: 0
+  OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &6942400052977514359
 GameObject:
   m_ObjectHideFlags: 0
@@ -3837,8 +4018,14 @@ MonoBehaviour:
   RotationController: {fileID: 0}
   RedColor: {r: 1, g: 0, b: 0, a: 1}
   BlueColor: {r: 0, g: 0.282353, b: 1, a: 1}
+  RedBoostColor: {r: 0, g: 0, b: 0, a: 0}
+  BlueBoostColor: {r: 0, g: 0, b: 0, a: 0}
+  RedNoteColor: {r: 0.7352942, g: 0, b: 0, a: 1}
+  BlueNoteColor: {r: 0, g: 0.3701827, b: 0.7352942, a: 1}
+  ObstacleColor: {r: 0.7352942, g: 0, b: 0, a: 1}
   SortMode: 0
   DisablableObjects: []
+  NormalMapScale: 2
 --- !u!1 &6942400053001139669
 GameObject:
   m_ObjectHideFlags: 0
@@ -3971,6 +4158,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -3982,6 +4170,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -4007,6 +4196,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LightMaterial: {fileID: 0}
+  OverrideLightGroup: 0
+  OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &6942400053126012179
 GameObject:
   m_ObjectHideFlags: 0
@@ -4120,6 +4313,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -4131,6 +4325,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -4156,6 +4351,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LightMaterial: {fileID: 0}
+  OverrideLightGroup: 0
+  OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &6942400053138846302
 GameObject:
   m_ObjectHideFlags: 0
@@ -4272,6 +4471,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -4283,6 +4483,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -4381,6 +4582,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -4392,6 +4594,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -4417,6 +4620,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LightMaterial: {fileID: 0}
+  OverrideLightGroup: 0
+  OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &6942400053276641143
 GameObject:
   m_ObjectHideFlags: 0
@@ -4520,6 +4727,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -4531,6 +4739,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -4556,6 +4765,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LightMaterial: {fileID: 0}
+  OverrideLightGroup: 0
+  OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &6942400053403445375
 GameObject:
   m_ObjectHideFlags: 0
@@ -4604,7 +4817,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f7f2dcefc297b9b40a12ccbf3fe55817, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  CanBeTurnedOff: 1
+  disableCustomInitialization: 0
   ControllingLights: []
   RotatingLights: []
 --- !u!1 &6942400053430414795
@@ -4661,6 +4874,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -4672,6 +4886,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -4770,6 +4985,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -4781,6 +4997,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -4806,6 +5023,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LightMaterial: {fileID: 0}
+  OverrideLightGroup: 0
+  OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &6942400053586113301
 GameObject:
   m_ObjectHideFlags: 0
@@ -4864,6 +5085,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -4875,6 +5097,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -4972,6 +5195,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -4983,6 +5207,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -5072,6 +5297,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   multiplier: 20
   rotationSpeed: 0
+  zPositionModifier: 1
+  OverrideLightGroup: 0
+  OverrideLightGroupID: 0
+  UseZPositionForAngleOffset: 0
 --- !u!1 &8599577607875856192
 GameObject:
   m_ObjectHideFlags: 0
@@ -5127,6 +5356,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -5138,6 +5368,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -5163,6 +5394,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LightMaterial: {fileID: 0}
+  OverrideLightGroup: 0
+  OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &8712250725221268375
 GameObject:
   m_ObjectHideFlags: 0
@@ -5209,3 +5444,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   multiplier: 20
   rotationSpeed: 0
+  zPositionModifier: 1
+  OverrideLightGroup: 0
+  OverrideLightGroupID: 0
+  UseZPositionForAngleOffset: 0

--- a/Assets/_Prefabs/MapEditor/Platforms/Default.prefab
+++ b/Assets/_Prefabs/MapEditor/Platforms/Default.prefab
@@ -3033,6 +3033,8 @@ MonoBehaviour:
   RotationController: {fileID: 0}
   RedColor: {r: 1, g: 0, b: 0, a: 1}
   BlueColor: {r: 0, g: 0.282353, b: 1, a: 1}
+  RedBoostColor: {r: 0, g: 0, b: 0, a: 0}
+  BlueBoostColor: {r: 0, g: 0, b: 0, a: 0}
   RedNoteColor: {r: 0.7352942, g: 0, b: 0, a: 1}
   BlueNoteColor: {r: 0, g: 0.3701827, b: 0.7352942, a: 1}
   ObstacleColor: {r: 0.7352942, g: 0, b: 0, a: 1}

--- a/Assets/_Prefabs/MapEditor/Platforms/FitBeat.prefab
+++ b/Assets/_Prefabs/MapEditor/Platforms/FitBeat.prefab
@@ -3879,6 +3879,8 @@ MonoBehaviour:
   RotationController: {fileID: 0}
   RedColor: {r: 0.4, g: 0.2784314, b: 0.2784314, a: 1}
   BlueColor: {r: 0.2784314, g: 0.2784314, b: 0.4, a: 1}
+  RedBoostColor: {r: 0, g: 0, b: 0, a: 0}
+  BlueBoostColor: {r: 0, g: 0, b: 0, a: 0}
   RedNoteColor: {r: 0.8, g: 0.60784316, b: 0.14901961, a: 1}
   BlueNoteColor: {r: 0.7921569, g: 0.16470589, b: 0.68235296, a: 1}
   ObstacleColor: {r: 0.2784314, g: 0.2784314, b: 0.4, a: 1}

--- a/Assets/_Prefabs/MapEditor/Platforms/Greenday.prefab
+++ b/Assets/_Prefabs/MapEditor/Platforms/Greenday.prefab
@@ -10098,6 +10098,8 @@ MonoBehaviour:
   RotationController: {fileID: 0}
   RedColor: {r: 0, g: 1, b: 0.89019614, a: 1}
   BlueColor: {r: 0.34901962, g: 1, b: 0, a: 1}
+  RedBoostColor: {r: 0, g: 0, b: 0, a: 0}
+  BlueBoostColor: {r: 0, g: 0, b: 0, a: 0}
   RedNoteColor: {r: 0, g: 0.74509805, b: 0.6627451, a: 1}
   BlueNoteColor: {r: 0.25882354, g: 0.745283, b: 0, a: 1}
   ObstacleColor: {r: 0.34901962, g: 1, b: 0, a: 1}

--- a/Assets/_Prefabs/MapEditor/Platforms/KDA.prefab
+++ b/Assets/_Prefabs/MapEditor/Platforms/KDA.prefab
@@ -95,6 +95,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &13815772407672375
 GameObject:
   m_ObjectHideFlags: 0
@@ -349,6 +351,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &267941596454442000
 GameObject:
   m_ObjectHideFlags: 0
@@ -559,6 +563,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &760597903517839888
 GameObject:
   m_ObjectHideFlags: 0
@@ -654,6 +660,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &908066069482740103
 GameObject:
   m_ObjectHideFlags: 0
@@ -781,7 +789,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableCustomInitialization: 0
-  CanBeTurnedOff: 1
   ControllingLights: []
   RotatingLights: []
 --- !u!1 &1232110310220603176
@@ -830,8 +837,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   multiplier: 20
   rotationSpeed: 0
+  zPositionModifier: 1
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseZPositionForAngleOffset: 0
 --- !u!1 &1232161478652687587
 GameObject:
   m_ObjectHideFlags: 0
@@ -972,8 +981,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   multiplier: 20
   rotationSpeed: 0
+  zPositionModifier: 1
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseZPositionForAngleOffset: 0
 --- !u!1 &1539887917391412177
 GameObject:
   m_ObjectHideFlags: 0
@@ -1021,7 +1032,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableCustomInitialization: 0
-  CanBeTurnedOff: 1
   ControllingLights: []
   RotatingLights: []
 --- !u!1 &1556967899417513662
@@ -1102,8 +1112,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   multiplier: 20
   rotationSpeed: 0
+  zPositionModifier: 1
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseZPositionForAngleOffset: 0
 --- !u!1 &1780448657103157106
 GameObject:
   m_ObjectHideFlags: 0
@@ -1154,7 +1166,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableCustomInitialization: 0
-  CanBeTurnedOff: 1
   ControllingLights: []
   RotatingLights: []
 --- !u!1 &1882952392559936481
@@ -1331,6 +1342,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &2076211754928481829
 GameObject:
   m_ObjectHideFlags: 0
@@ -1457,6 +1470,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &2095007007908745405
 GameObject:
   m_ObjectHideFlags: 0
@@ -1582,8 +1597,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   multiplier: 20
   rotationSpeed: 0
+  zPositionModifier: 1
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseZPositionForAngleOffset: 0
 --- !u!1 &2415332573483711399
 GameObject:
   m_ObjectHideFlags: 0
@@ -1868,6 +1885,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &2803975274851132607
 GameObject:
   m_ObjectHideFlags: 0
@@ -1946,8 +1965,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   multiplier: 20
   rotationSpeed: 0
+  zPositionModifier: 1
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseZPositionForAngleOffset: 0
 --- !u!1 &3057444922553215166
 GameObject:
   m_ObjectHideFlags: 0
@@ -1994,8 +2015,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   multiplier: 20
   rotationSpeed: 0
+  zPositionModifier: 1
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseZPositionForAngleOffset: 0
 --- !u!1 &3134593529866485758
 GameObject:
   m_ObjectHideFlags: 0
@@ -2091,6 +2114,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &3145325757835232756
 GameObject:
   m_ObjectHideFlags: 0
@@ -2186,6 +2211,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &3349435801491561759
 GameObject:
   m_ObjectHideFlags: 0
@@ -2281,6 +2308,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &3459555731494397772
 GameObject:
   m_ObjectHideFlags: 0
@@ -2454,7 +2483,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableCustomInitialization: 0
-  CanBeTurnedOff: 1
   ControllingLights: []
   RotatingLights: []
 --- !u!1 &3649848796905944883
@@ -2566,6 +2594,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &3730129544149060668
 GameObject:
   m_ObjectHideFlags: 0
@@ -2675,6 +2705,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &3731349846546334217
 GameObject:
   m_ObjectHideFlags: 0
@@ -2731,6 +2763,8 @@ MonoBehaviour:
   RotationController: {fileID: 0}
   RedColor: {r: 1, g: 0.396, b: 0.243, a: 1}
   BlueColor: {r: 0.761, g: 0.125, b: 0.867, a: 1}
+  RedBoostColor: {r: 0, g: 0, b: 0, a: 0}
+  BlueBoostColor: {r: 0, g: 0, b: 0, a: 0}
   RedNoteColor: {r: 0.659, g: 0.263, b: 0.161, a: 1}
   BlueNoteColor: {r: 0.502, g: 0.082, b: 0.573, a: 1}
   ObstacleColor: {r: 1, g: 0.396, b: 0.243, a: 1}
@@ -2832,6 +2866,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &4061206134861046906
 GameObject:
   m_ObjectHideFlags: 0
@@ -2927,6 +2963,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &4180084392161678958
 GameObject:
   m_ObjectHideFlags: 0
@@ -3273,8 +3311,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   multiplier: 20
   rotationSpeed: 0
+  zPositionModifier: 1
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseZPositionForAngleOffset: 0
 --- !u!1 &4468377458801211546
 GameObject:
   m_ObjectHideFlags: 0
@@ -3370,6 +3410,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &4518043958057388686
 GameObject:
   m_ObjectHideFlags: 0
@@ -3560,7 +3602,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableCustomInitialization: 0
-  CanBeTurnedOff: 1
   ControllingLights: []
   RotatingLights: []
 --- !u!1 &4862827840616651877
@@ -3658,6 +3699,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &5067107877328175190
 GameObject:
   m_ObjectHideFlags: 0
@@ -3784,6 +3827,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &5182222823409001669
 GameObject:
   m_ObjectHideFlags: 0
@@ -3989,6 +4034,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &5544828730213102349
 GameObject:
   m_ObjectHideFlags: 0
@@ -4196,6 +4243,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &5838464521857199805
 GameObject:
   m_ObjectHideFlags: 0
@@ -4322,6 +4371,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &6319468886780944063
 GameObject:
   m_ObjectHideFlags: 0
@@ -4478,6 +4529,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &6622272525267384230
 GameObject:
   m_ObjectHideFlags: 0
@@ -4713,8 +4766,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   multiplier: 20
   rotationSpeed: 0
+  zPositionModifier: 1
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseZPositionForAngleOffset: 0
 --- !u!1 &7375762616685912606
 GameObject:
   m_ObjectHideFlags: 0
@@ -5060,6 +5115,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &8436084715461386452
 GameObject:
   m_ObjectHideFlags: 0
@@ -5248,6 +5305,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &8844315766948792079
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/_Prefabs/MapEditor/Platforms/Monstercat.prefab
+++ b/Assets/_Prefabs/MapEditor/Platforms/Monstercat.prefab
@@ -5191,6 +5191,8 @@ MonoBehaviour:
   RotationController: {fileID: 0}
   RedColor: {r: 1, g: 0, b: 0, a: 1}
   BlueColor: {r: 0, g: 0.282353, b: 1, a: 1}
+  RedBoostColor: {r: 0, g: 0, b: 0, a: 0}
+  BlueBoostColor: {r: 0, g: 0, b: 0, a: 0}
   RedNoteColor: {r: 0.7352942, g: 0, b: 0, a: 1}
   BlueNoteColor: {r: 0, g: 0.3701827, b: 0.7352942, a: 1}
   ObstacleColor: {r: 0.7352942, g: 0, b: 0, a: 1}

--- a/Assets/_Prefabs/MapEditor/Platforms/Nice.prefab
+++ b/Assets/_Prefabs/MapEditor/Platforms/Nice.prefab
@@ -6585,6 +6585,8 @@ MonoBehaviour:
   RotationController: {fileID: 0}
   RedColor: {r: 1, g: 0, b: 0, a: 1}
   BlueColor: {r: 0, g: 0.282353, b: 1, a: 1}
+  RedBoostColor: {r: 0, g: 0, b: 0, a: 0}
+  BlueBoostColor: {r: 0, g: 0, b: 0, a: 0}
   RedNoteColor: {r: 0.7352942, g: 0, b: 0, a: 1}
   BlueNoteColor: {r: 0, g: 0.3701827, b: 0.7352942, a: 1}
   ObstacleColor: {r: 0.7352942, g: 0, b: 0, a: 1}

--- a/Assets/_Prefabs/MapEditor/Platforms/Origins.prefab
+++ b/Assets/_Prefabs/MapEditor/Platforms/Origins.prefab
@@ -46,8 +46,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   multiplier: 20
   rotationSpeed: 0
+  zPositionModifier: 1
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseZPositionForAngleOffset: 0
 --- !u!1 &1438292258656298130
 GameObject:
   m_ObjectHideFlags: 0
@@ -143,6 +145,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &1489468675434295139
 GameObject:
   m_ObjectHideFlags: 0
@@ -189,8 +193,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   multiplier: 20
   rotationSpeed: 0
+  zPositionModifier: 1
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseZPositionForAngleOffset: 0
 --- !u!1 &1728493899152625983
 GameObject:
   m_ObjectHideFlags: 0
@@ -237,8 +243,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   multiplier: 20
   rotationSpeed: 0
+  zPositionModifier: 1
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseZPositionForAngleOffset: 0
 --- !u!1 &2667734996679821600
 GameObject:
   m_ObjectHideFlags: 0
@@ -285,8 +293,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   multiplier: 20
   rotationSpeed: 0
+  zPositionModifier: 1
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseZPositionForAngleOffset: 0
 --- !u!1 &3293210426948203426
 GameObject:
   m_ObjectHideFlags: 0
@@ -382,6 +392,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &4165182752011473092
 GameObject:
   m_ObjectHideFlags: 0
@@ -428,8 +440,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   multiplier: 20
   rotationSpeed: 0
+  zPositionModifier: 1
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseZPositionForAngleOffset: 0
 --- !u!1 &4328595591812305873
 GameObject:
   m_ObjectHideFlags: 0
@@ -525,6 +539,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &4878772957672397873
 GameObject:
   m_ObjectHideFlags: 0
@@ -651,6 +667,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &5323112639711933175
 GameObject:
   m_ObjectHideFlags: 0
@@ -746,6 +764,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &5395228980608846715
 GameObject:
   m_ObjectHideFlags: 0
@@ -824,8 +844,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   multiplier: 20
   rotationSpeed: 0
+  zPositionModifier: 1
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseZPositionForAngleOffset: 0
 --- !u!1 &5592570001241296273
 GameObject:
   m_ObjectHideFlags: 0
@@ -921,6 +943,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &5715591432027673563
 GameObject:
   m_ObjectHideFlags: 0
@@ -967,8 +991,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   multiplier: 20
   rotationSpeed: 0
+  zPositionModifier: 1
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseZPositionForAngleOffset: 0
 --- !u!1 &5795665473553019059
 GameObject:
   m_ObjectHideFlags: 0
@@ -1064,6 +1090,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &6117182272004730742
 GameObject:
   m_ObjectHideFlags: 0
@@ -1110,8 +1138,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   multiplier: 20
   rotationSpeed: 0
+  zPositionModifier: 1
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseZPositionForAngleOffset: 0
 --- !u!1 &6424699824819403895
 GameObject:
   m_ObjectHideFlags: 0
@@ -1207,6 +1237,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &6631837517265279225
 GameObject:
   m_ObjectHideFlags: 0
@@ -1381,6 +1413,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7124746349586290853
 GameObject:
   m_ObjectHideFlags: 0
@@ -1427,8 +1461,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   multiplier: 20
   rotationSpeed: 0
+  zPositionModifier: 1
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseZPositionForAngleOffset: 0
 --- !u!1 &7165034838404737927
 GameObject:
   m_ObjectHideFlags: 0
@@ -1509,8 +1545,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   multiplier: 20
   rotationSpeed: 0
+  zPositionModifier: 1
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseZPositionForAngleOffset: 0
 --- !u!1 &7409078448314689547
 GameObject:
   m_ObjectHideFlags: 0
@@ -1606,6 +1644,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7409078448457445088
 GameObject:
   m_ObjectHideFlags: 0
@@ -1731,7 +1771,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableCustomInitialization: 0
-  CanBeTurnedOff: 1
   ControllingLights: []
   RotatingLights: []
 --- !u!1 &7409078449091973037
@@ -2023,6 +2062,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7409078450052634555
 GameObject:
   m_ObjectHideFlags: 0
@@ -2118,6 +2159,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7409078450099887975
 GameObject:
   m_ObjectHideFlags: 0
@@ -2227,6 +2270,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7409078450340885688
 GameObject:
   m_ObjectHideFlags: 0
@@ -2373,8 +2418,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   multiplier: 20
   rotationSpeed: 0
+  zPositionModifier: 1
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseZPositionForAngleOffset: 0
 --- !u!1 &7884604706370514437
 GameObject:
   m_ObjectHideFlags: 0
@@ -2549,6 +2596,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &8142587270139567248
 GameObject:
   m_ObjectHideFlags: 0
@@ -2644,6 +2693,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &8236414846052662301
 GameObject:
   m_ObjectHideFlags: 0
@@ -2779,6 +2830,8 @@ MonoBehaviour:
   RotationController: {fileID: 0}
   RedColor: {r: 0.277, g: 0.431, b: 0.528, a: 1}
   BlueColor: {r: 0.038, g: 0.622, b: 0.906, a: 1}
+  RedBoostColor: {r: 0, g: 0, b: 0, a: 0}
+  BlueBoostColor: {r: 0, g: 0, b: 0, a: 0}
   RedNoteColor: {r: 0.6784314, g: 0.57254905, b: 0, a: 1}
   BlueNoteColor: {r: 0.70980394, g: 0, b: 0.5372549, a: 1}
   ObstacleColor: {r: 0.062, g: 0.287, b: 0.396, a: 1}
@@ -2894,6 +2947,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &8236414846147724769
 GameObject:
   m_ObjectHideFlags: 0
@@ -2971,7 +3026,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableCustomInitialization: 0
-  CanBeTurnedOff: 1
   ControllingLights: []
   RotatingLights: []
 --- !u!1 &8236414846320329111
@@ -3147,6 +3201,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &8236414846648656837
 GameObject:
   m_ObjectHideFlags: 0
@@ -3287,6 +3343,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &8236414846731400046
 GameObject:
   m_ObjectHideFlags: 0
@@ -3569,6 +3627,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &8236414847064158227
 GameObject:
   m_ObjectHideFlags: 0
@@ -3672,6 +3732,7 @@ MonoBehaviour:
   startupRotationStep: 5
   startupRotationPropagationSpeed: 1
   startupRotationFlexySpeed: 1
+  rotationStep: 90
 --- !u!114 &727936777757031511
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3685,7 +3746,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableCustomInitialization: 0
-  CanBeTurnedOff: 1
   ControllingLights: []
   RotatingLights: []
 --- !u!1 &8236414847124506703
@@ -3813,7 +3873,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableCustomInitialization: 0
-  CanBeTurnedOff: 1
   ControllingLights: []
   RotatingLights: []
 --- !u!1 &8236414847206370905
@@ -4100,6 +4159,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &8236414847547681141
 GameObject:
   m_ObjectHideFlags: 0
@@ -4195,6 +4256,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &8236414847626359699
 GameObject:
   m_ObjectHideFlags: 0
@@ -4302,7 +4365,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableCustomInitialization: 0
-  CanBeTurnedOff: 1
   ControllingLights: []
   RotatingLights: []
 --- !u!1 &8236414847746273930
@@ -4445,6 +4507,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &8236414847810274676
 GameObject:
   m_ObjectHideFlags: 0
@@ -4791,6 +4855,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &8236414848034814588
 GameObject:
   m_ObjectHideFlags: 0
@@ -4952,6 +5018,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &8802742244214580619
 GameObject:
   m_ObjectHideFlags: 0
@@ -4998,5 +5066,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   multiplier: 20
   rotationSpeed: 0
+  zPositionModifier: 1
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseZPositionForAngleOffset: 0

--- a/Assets/_Prefabs/MapEditor/Platforms/Panic.prefab
+++ b/Assets/_Prefabs/MapEditor/Platforms/Panic.prefab
@@ -5463,6 +5463,8 @@ MonoBehaviour:
   RotationController: {fileID: 0}
   RedColor: {r: 1, g: 0, b: 0, a: 1}
   BlueColor: {r: 0, g: 0.282353, b: 1, a: 1}
+  RedBoostColor: {r: 0, g: 0, b: 0, a: 0}
+  BlueBoostColor: {r: 0, g: 0, b: 0, a: 0}
   RedNoteColor: {r: 0.7352942, g: 0, b: 0, a: 1}
   BlueNoteColor: {r: 0, g: 0.3701827, b: 0.7352942, a: 1}
   ObstacleColor: {r: 0.7352942, g: 0, b: 0, a: 1}

--- a/Assets/_Prefabs/MapEditor/Platforms/Rocket.prefab
+++ b/Assets/_Prefabs/MapEditor/Platforms/Rocket.prefab
@@ -95,6 +95,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &345466861614610517
 GameObject:
   m_ObjectHideFlags: 0
@@ -345,6 +347,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &2324527574255212665
 GameObject:
   m_ObjectHideFlags: 0
@@ -471,6 +475,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &3297839808442410408
 GameObject:
   m_ObjectHideFlags: 0
@@ -566,6 +572,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &3471908199111316212
 GameObject:
   m_ObjectHideFlags: 0
@@ -692,6 +700,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &5047280231396903981
 GameObject:
   m_ObjectHideFlags: 0
@@ -787,6 +797,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &5825798124242595206
 GameObject:
   m_ObjectHideFlags: 0
@@ -975,6 +987,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &6439610641099922192
 GameObject:
   m_ObjectHideFlags: 0
@@ -1070,6 +1084,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7067244480837971266
 GameObject:
   m_ObjectHideFlags: 0
@@ -1165,6 +1181,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7357491534218210396
 GameObject:
   m_ObjectHideFlags: 0
@@ -1322,6 +1340,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122629
 GameObject:
   m_ObjectHideFlags: 0
@@ -1448,6 +1468,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122633
 GameObject:
   m_ObjectHideFlags: 0
@@ -1684,6 +1706,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122638
 GameObject:
   m_ObjectHideFlags: 0
@@ -1841,6 +1865,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122643
 GameObject:
   m_ObjectHideFlags: 0
@@ -1967,6 +1993,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122645
 GameObject:
   m_ObjectHideFlags: 0
@@ -2236,6 +2264,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122651
 GameObject:
   m_ObjectHideFlags: 0
@@ -2393,6 +2423,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122654
 GameObject:
   m_ObjectHideFlags: 0
@@ -2519,6 +2551,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122656
 GameObject:
   m_ObjectHideFlags: 0
@@ -2645,6 +2679,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122658
 GameObject:
   m_ObjectHideFlags: 0
@@ -2740,6 +2776,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122660
 GameObject:
   m_ObjectHideFlags: 0
@@ -2862,6 +2900,8 @@ MonoBehaviour:
   RotationController: {fileID: 0}
   RedColor: {r: 0.675, g: 0.365, b: 0.243, a: 1}
   BlueColor: {r: 0.188, g: 0.618, b: 1, a: 1}
+  RedBoostColor: {r: 0, g: 0, b: 0, a: 0}
+  BlueBoostColor: {r: 0, g: 0, b: 0, a: 0}
   RedNoteColor: {r: 1, g: 0.498, b: 0, a: 1}
   BlueNoteColor: {r: 0, g: 0.529, b: 1, a: 1}
   ObstacleColor: {r: 0.318, g: 0.612, b: 0.725, a: 1}
@@ -2966,6 +3006,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122666
 GameObject:
   m_ObjectHideFlags: 0
@@ -3123,6 +3165,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122669
 GameObject:
   m_ObjectHideFlags: 0
@@ -3218,6 +3262,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122672
 GameObject:
   m_ObjectHideFlags: 0
@@ -3344,6 +3390,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122677
 GameObject:
   m_ObjectHideFlags: 0
@@ -3439,6 +3487,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122678
 GameObject:
   m_ObjectHideFlags: 0
@@ -3596,6 +3646,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122685
 GameObject:
   m_ObjectHideFlags: 0
@@ -3722,6 +3774,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122705
 GameObject:
   m_ObjectHideFlags: 0
@@ -3972,6 +4026,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122714
 GameObject:
   m_ObjectHideFlags: 0
@@ -4067,6 +4123,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122716
 GameObject:
   m_ObjectHideFlags: 0
@@ -4162,6 +4220,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122717
 GameObject:
   m_ObjectHideFlags: 0
@@ -4257,6 +4317,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122718
 GameObject:
   m_ObjectHideFlags: 0
@@ -4418,6 +4480,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122724
 GameObject:
   m_ObjectHideFlags: 0
@@ -4513,6 +4577,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122725
 GameObject:
   m_ObjectHideFlags: 0
@@ -4639,6 +4705,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122729
 GameObject:
   m_ObjectHideFlags: 0
@@ -4877,6 +4945,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122742
 GameObject:
   m_ObjectHideFlags: 0
@@ -4972,6 +5042,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122743
 GameObject:
   m_ObjectHideFlags: 0
@@ -5098,6 +5170,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122745
 GameObject:
   m_ObjectHideFlags: 0
@@ -5193,6 +5267,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122748
 GameObject:
   m_ObjectHideFlags: 0
@@ -5288,6 +5364,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122749
 GameObject:
   m_ObjectHideFlags: 0
@@ -5383,6 +5461,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122751
 GameObject:
   m_ObjectHideFlags: 0
@@ -5790,6 +5870,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122773
 GameObject:
   m_ObjectHideFlags: 0
@@ -5996,6 +6078,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122816
 GameObject:
   m_ObjectHideFlags: 0
@@ -6042,6 +6126,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   multiplier: 20
   rotationSpeed: 0
+  zPositionModifier: 1
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
   UseZPositionForAngleOffset: 0
@@ -6091,6 +6176,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   multiplier: 20
   rotationSpeed: 0
+  zPositionModifier: 1
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
   UseZPositionForAngleOffset: 0
@@ -6140,6 +6226,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   multiplier: 20
   rotationSpeed: 0
+  zPositionModifier: 1
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
   UseZPositionForAngleOffset: 0
@@ -6189,6 +6276,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   multiplier: 20
   rotationSpeed: 0
+  zPositionModifier: 1
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
   UseZPositionForAngleOffset: 0
@@ -6362,6 +6450,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   multiplier: 20
   rotationSpeed: 0
+  zPositionModifier: 1
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
   UseZPositionForAngleOffset: 0
@@ -6442,6 +6531,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   multiplier: 20
   rotationSpeed: 0
+  zPositionModifier: 1
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
   UseZPositionForAngleOffset: 0
@@ -6491,6 +6581,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   multiplier: 20
   rotationSpeed: 0
+  zPositionModifier: 1
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
   UseZPositionForAngleOffset: 0
@@ -6589,6 +6680,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122833
 GameObject:
   m_ObjectHideFlags: 0
@@ -6684,6 +6777,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122834
 GameObject:
   m_ObjectHideFlags: 0
@@ -6779,6 +6874,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122835
 GameObject:
   m_ObjectHideFlags: 0
@@ -6874,6 +6971,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122838
 GameObject:
   m_ObjectHideFlags: 0
@@ -6920,6 +7019,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   multiplier: 20
   rotationSpeed: 0
+  zPositionModifier: 1
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
   UseZPositionForAngleOffset: 0
@@ -7018,6 +7118,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122846
 GameObject:
   m_ObjectHideFlags: 0
@@ -7113,6 +7215,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122847
 GameObject:
   m_ObjectHideFlags: 0
@@ -7208,6 +7312,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122856
 GameObject:
   m_ObjectHideFlags: 0
@@ -7254,6 +7360,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   multiplier: 20
   rotationSpeed: 0
+  zPositionModifier: 1
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
   UseZPositionForAngleOffset: 0
@@ -7303,6 +7410,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   multiplier: 20
   rotationSpeed: 0
+  zPositionModifier: 1
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
   UseZPositionForAngleOffset: 0
@@ -7352,6 +7460,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   multiplier: 20
   rotationSpeed: 0
+  zPositionModifier: 1
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
   UseZPositionForAngleOffset: 0
@@ -7401,6 +7510,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   multiplier: 20
   rotationSpeed: 0
+  zPositionModifier: 1
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
   UseZPositionForAngleOffset: 0
@@ -7450,6 +7560,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   multiplier: 20
   rotationSpeed: 0
+  zPositionModifier: 1
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
   UseZPositionForAngleOffset: 0
@@ -7499,6 +7610,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   multiplier: 20
   rotationSpeed: 0
+  zPositionModifier: 1
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
   UseZPositionForAngleOffset: 0
@@ -7676,6 +7788,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122865
 GameObject:
   m_ObjectHideFlags: 0
@@ -7771,6 +7885,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122866
 GameObject:
   m_ObjectHideFlags: 0
@@ -7866,6 +7982,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122867
 GameObject:
   m_ObjectHideFlags: 0
@@ -7961,6 +8079,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122869
 GameObject:
   m_ObjectHideFlags: 0
@@ -8166,6 +8286,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122878
 GameObject:
   m_ObjectHideFlags: 0
@@ -8261,6 +8383,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7570078286708122879
 GameObject:
   m_ObjectHideFlags: 0
@@ -8356,6 +8480,8 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
 --- !u!1 &7705728508095569111
 GameObject:
   m_ObjectHideFlags: 0
@@ -8487,7 +8613,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableCustomInitialization: 0
-  CanBeTurnedOff: 1
   ControllingLights: []
   RotatingLights: []
 --- !u!1 &8272722940902446568
@@ -8541,7 +8666,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableCustomInitialization: 0
-  CanBeTurnedOff: 1
   ControllingLights: []
   RotatingLights: []
 --- !u!1 &8272722941263695994
@@ -8594,7 +8718,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableCustomInitialization: 0
-  CanBeTurnedOff: 1
   ControllingLights: []
   RotatingLights: []
 --- !u!1 &8272722941606179860
@@ -8648,7 +8771,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableCustomInitialization: 0
-  CanBeTurnedOff: 1
   ControllingLights: []
   RotatingLights: []
 --- !u!1 &8272722942243315884
@@ -8705,7 +8827,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableCustomInitialization: 0
-  CanBeTurnedOff: 1
   ControllingLights: []
   RotatingLights: []
 --- !u!1 &8285776927393967671
@@ -8803,3 +8924,5 @@ MonoBehaviour:
   LightMaterial: {fileID: 0}
   OverrideLightGroup: 0
   OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1

--- a/Assets/_Prefabs/MapEditor/Platforms/Triangle.prefab
+++ b/Assets/_Prefabs/MapEditor/Platforms/Triangle.prefab
@@ -3417,6 +3417,8 @@ MonoBehaviour:
   RotationController: {fileID: 0}
   RedColor: {r: 1, g: 0, b: 0, a: 1}
   BlueColor: {r: 0, g: 0.282353, b: 1, a: 1}
+  RedBoostColor: {r: 0, g: 0, b: 0, a: 0}
+  BlueBoostColor: {r: 0, g: 0, b: 0, a: 0}
   RedNoteColor: {r: 0.7352942, g: 0, b: 0, a: 1}
   BlueNoteColor: {r: 0, g: 0.3701827, b: 0.7352942, a: 1}
   ObstacleColor: {r: 0.7352942, g: 0, b: 0, a: 1}

--- a/Assets/__Scenes/03_Mapper.unity
+++ b/Assets/__Scenes/03_Mapper.unity
@@ -6541,7 +6541,7 @@ RectTransform:
   m_Children:
   - {fileID: 2090183981}
   m_Father: {fileID: 269440733}
-  m_RootOrder: 5
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -7415,6 +7415,8 @@ RectTransform:
   - {fileID: 780049534}
   - {fileID: 1969197302}
   - {fileID: 1659179734}
+  - {fileID: 1989018775}
+  - {fileID: 1519535568}
   - {fileID: 1280504202}
   - {fileID: 247555805}
   - {fileID: 1323165530}
@@ -7489,6 +7491,8 @@ MonoBehaviour:
   blueNote: {fileID: 708281869}
   redLight: {fileID: 95064754}
   blueLight: {fileID: 1958912665}
+  redBoost: {fileID: 1961635460}
+  blueBoost: {fileID: 426046113}
   obstacle: {fileID: 1534043197}
   noteAppearance: {fileID: 11400000, guid: 2e49cb79fe1ae9e448bc9363be6040c5, type: 2}
   obstacles: {fileID: 25550678}
@@ -8257,7 +8261,7 @@ RectTransform:
   m_Children:
   - {fileID: 1604884700}
   m_Father: {fileID: 269440733}
-  m_RootOrder: 7
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -11512,6 +11516,80 @@ Canvas:
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
+--- !u!1 &426046112
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 426046115}
+  - component: {fileID: 426046114}
+  - component: {fileID: 426046113}
+  m_Layer: 5
+  m_Name: Static
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &426046113
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 426046112}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0.282353, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300018, guid: b6cbb1b9e5aaba74a8dbd0ce1f54f5bf, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &426046114
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 426046112}
+  m_CullTransparentMesh: 0
+--- !u!224 &426046115
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 426046112}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1519535568}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 13, y: 13}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &429509862
 GameObject:
   m_ObjectHideFlags: 0
@@ -15380,83 +15458,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectParentTransform: {fileID: 565602430}
   RotationValue: {x: 0, y: 0, z: 0}
---- !u!21 &566287520
-Material:
-  serializedVersion: 6
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: Inherited From Round Corners
-  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
-  m_ShaderKeywords: 
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _BumpMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _EmissionMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _MetallicGlossMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _OcclusionMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _SpecGlossMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Floats:
-    - _AlphaClip: 0
-    - _Blend: 0
-    - _BumpScale: 1
-    - _ColorMask: 15
-    - _Cull: 2
-    - _Cutoff: 0.5
-    - _DstBlend: 0
-    - _GlossMapScale: 1
-    - _Glossiness: 0.5
-    - _GlossyReflections: 1
-    - _Metallic: 0
-    - _OcclusionStrength: 1
-    - _ReceiveShadows: 1
-    - _SmoothnessTextureChannel: 0
-    - _SpecularHighlights: 1
-    - _SrcBlend: 1
-    - _Stencil: 0
-    - _StencilComp: 8
-    - _StencilOp: 0
-    - _StencilReadMask: 255
-    - _StencilWriteMask: 255
-    - _Surface: 0
-    - _UseUIAlphaClip: 0
-    - _WorkflowMode: 1
-    - _ZWrite: 1
-    m_Colors:
-    - _Color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
-    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
-    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
-    - _WidthHeightRadius: {r: 750, g: 100, b: 105, a: 0}
-    - _halfSize: {r: 29, g: 10, b: 0, a: 0}
-    - _r: {r: 3, g: 3, b: 3, a: 3}
-    - _rect2props: {r: 0.0000019073486, g: -0.0000038146973, b: 25.455845, a: 25.455845}
 --- !u!1 &570484800
 GameObject:
   m_ObjectHideFlags: 0
@@ -16188,6 +16189,83 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+--- !u!21 &608232278
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Inherited From Round Corners
+  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _AlphaClip: 0
+    - _Blend: 0
+    - _BumpScale: 1
+    - _ColorMask: 15
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _ReceiveShadows: 1
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _Surface: 0
+    - _UseUIAlphaClip: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+    - _WidthHeightRadius: {r: 750, g: 100, b: 105, a: 0}
+    - _halfSize: {r: 29, g: 10, b: 0, a: 0}
+    - _r: {r: 3, g: 3, b: 3, a: 3}
+    - _rect2props: {r: 0.0000019073486, g: -0.0000038146973, b: 25.455845, a: 25.455845}
 --- !u!1 &612896976
 GameObject:
   m_ObjectHideFlags: 0
@@ -20915,7 +20993,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   material: {fileID: 2100000, guid: 68b9a414913410a46abcdd5a10666679, type: 2}
-  mat: {fileID: 566287520}
+  mat: {fileID: 608232278}
   cloneMaterial: 1
   radius: 105
 --- !u!114 &756850815
@@ -20969,7 +21047,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Material: {fileID: 566287520}
+  m_Material: {fileID: 608232278}
   m_Color: {r: 0.18867922, g: 0.18867922, b: 0.18867922, a: 1}
   m_RaycastTarget: 0
   m_Maskable: 1
@@ -33475,9 +33553,9 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: -23.999985, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &1223292197
 RectTransform:
@@ -40554,7 +40632,7 @@ RectTransform:
   m_Children:
   - {fileID: 1534043196}
   m_Father: {fileID: 269440733}
-  m_RootOrder: 4
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -41338,7 +41416,7 @@ RectTransform:
   m_Children:
   - {fileID: 1613983678}
   m_Father: {fileID: 269440733}
-  m_RootOrder: 6
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -45592,6 +45670,157 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9a7cddbc87011dc4099087f26db110f2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &1519535567
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1519535568}
+  - component: {fileID: 1519535572}
+  - component: {fileID: 1519535571}
+  - component: {fileID: 1519535570}
+  - component: {fileID: 1519535569}
+  m_Layer: 5
+  m_Name: Right Boost
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1519535568
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1519535567}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.538462, y: 1.538462, z: 1}
+  m_Children:
+  - {fileID: 426046115}
+  m_Father: {fileID: 269440733}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1519535569
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1519535567}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ec9d0964fc5c07c4d988ebacfd236eb8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  tooltip:
+    m_TableReference:
+      m_TableCollectionName: GUID:8944026aec77cf8479a89f2280c8e1ff
+    m_TableEntryReference:
+      m_KeyId: 117
+      m_Key: 
+  tooltipOverride: 
+  advancedTooltip: 
+--- !u!114 &1519535570
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1519535567}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1519535571}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 269440736}
+        m_MethodName: UpdateBlueBoost
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &1519535571
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1519535567}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.1981132, g: 0.1981132, b: 0.1981132, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1519535572
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1519535567}
+  m_CullTransparentMesh: 0
 --- !u!1 &1521809537
 GameObject:
   m_ObjectHideFlags: 0
@@ -57979,6 +58208,80 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1958912663}
   m_CullTransparentMesh: 0
+--- !u!1 &1961635459
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1961635462}
+  - component: {fileID: 1961635461}
+  - component: {fileID: 1961635460}
+  m_Layer: 5
+  m_Name: Static
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1961635460
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1961635459}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300018, guid: b6cbb1b9e5aaba74a8dbd0ce1f54f5bf, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1961635461
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1961635459}
+  m_CullTransparentMesh: 0
+--- !u!224 &1961635462
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1961635459}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1989018775}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 13, y: 13}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1965796627
 GameObject:
   m_ObjectHideFlags: 0
@@ -58992,6 +59295,157 @@ Transform:
   m_Father: {fileID: 1645535436}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1989018774
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1989018775}
+  - component: {fileID: 1989018779}
+  - component: {fileID: 1989018778}
+  - component: {fileID: 1989018777}
+  - component: {fileID: 1989018776}
+  m_Layer: 5
+  m_Name: Left Boost
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1989018775
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1989018774}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.538462, y: 1.538462, z: 1}
+  m_Children:
+  - {fileID: 1961635462}
+  m_Father: {fileID: 269440733}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1989018776
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1989018774}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ec9d0964fc5c07c4d988ebacfd236eb8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  tooltip:
+    m_TableReference:
+      m_TableCollectionName: GUID:8944026aec77cf8479a89f2280c8e1ff
+    m_TableEntryReference:
+      m_KeyId: 118
+      m_Key: 
+  tooltipOverride: 
+  advancedTooltip: 
+--- !u!114 &1989018777
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1989018774}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1989018778}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 269440736}
+        m_MethodName: UpdateRedBoost
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &1989018778
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1989018774}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.1981132, g: 0.1981132, b: 0.1981132, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1989018779
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1989018774}
+  m_CullTransparentMesh: 0
 --- !u!1 &1992148424
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/__Scripts/BeatSaberSong.cs
+++ b/Assets/__Scripts/BeatSaberSong.cs
@@ -34,6 +34,8 @@ public class BeatSaberSong
         public Color? colorRight = null;
         public Color? envColorLeft = null;
         public Color? envColorRight = null;
+        public Color? boostColorLeft = null;
+        public Color? boostColorRight = null;
         public Color? obstacleColor = null;
         public JSONNode customData;
         [NonSerialized] public DifficultyBeatmapSet parentBeatmapSet;
@@ -322,14 +324,31 @@ public class BeatSaberSong
 
                     if (diff.colorLeft != null)
                         subNode["_customData"]["_colorLeft"] = diff.colorLeft;
+                    else subNode["_customData"].Remove("_colorLeft");
+
                     if (diff.colorRight != null)
                         subNode["_customData"]["_colorRight"] = diff.colorRight;
+                    else subNode["_customData"].Remove("_colorRight");
+
                     if (diff.envColorLeft != null && diff.envColorLeft != diff.colorLeft)
                         subNode["_customData"]["_envColorLeft"] = diff.envColorLeft;
+                    else subNode["_customData"].Remove("_envColorLeft");
+
                     if (diff.envColorRight != null && diff.envColorRight != diff.colorRight)
                         subNode["_customData"]["_envColorRight"] = diff.envColorRight;
+                    else subNode["_customData"].Remove("_envColorRight");
+
+                    if (diff.boostColorLeft != null && diff.boostColorLeft != (diff.envColorLeft ?? diff.colorLeft))
+                        subNode["_customData"]["_envColorLeftBoost"] = diff.boostColorLeft;
+                    else subNode["_customData"].Remove("_envColorLeftBoost");
+
+                    if (diff.boostColorRight != null && diff.boostColorRight != (diff.envColorRight ?? diff.colorRight))
+                        subNode["_customData"]["_envColorRightBoost"] = diff.boostColorRight;
+                    else subNode["_customData"].Remove("_envColorRightBoost");
+
                     if (diff.obstacleColor != null)
                         subNode["_customData"]["_obstacleColor"] = diff.obstacleColor;
+                    else subNode["_customData"].Remove("_obstacleColor");
 
                     JSONNode.ColorContainerType = JSONContainerType.Array;
 
@@ -470,12 +489,22 @@ public class BeatSaberSong
                                     beatmap.colorLeft = d["_customData"]["_colorLeft"].ReadColor();
                                 if (d["_customData"]["_colorRight"] != null)
                                     beatmap.colorRight = d["_customData"]["_colorRight"].ReadColor();
+
                                 if (d["_customData"]["_envColorLeft"] != null)
                                     beatmap.envColorLeft = d["_customData"]["_envColorLeft"].ReadColor();
-                                else if (d["_customData"]["_colorLeft"] != null) beatmap.envColorLeft = beatmap.colorLeft;
+                                else beatmap.envColorLeft = beatmap.colorLeft;
                                 if (d["_customData"]["_envColorRight"] != null)
                                     beatmap.envColorRight = d["_customData"]["_envColorRight"].ReadColor();
-                                else if (d["_customData"]["_colorRight"] != null) beatmap.envColorRight = beatmap.colorRight;
+                                else beatmap.envColorRight = beatmap.colorRight;
+
+                                if (d["_customData"]["_envColorLeftBoost"] != null)
+                                    beatmap.boostColorLeft = d["_customData"]["_envColorLeftBoost"].ReadColor();
+                                else beatmap.boostColorLeft = beatmap.envColorLeft;
+
+                                if (d["_customData"]["_envColorRightBoost"] != null)
+                                    beatmap.boostColorRight = d["_customData"]["_envColorRightBoost"].ReadColor();
+                                else beatmap.boostColorRight = beatmap.envColorRight;
+
                                 if (d["_customData"]["_obstacleColor"] != null)
                                     beatmap.obstacleColor = d["_customData"]["_obstacleColor"].ReadColor();
                                 beatmap.UpdateName(d["_beatmapFilename"]);

--- a/Assets/__Scripts/Extensions/ColorExtensions.cs
+++ b/Assets/__Scripts/Extensions/ColorExtensions.cs
@@ -1,0 +1,9 @@
+﻿using UnityEngine;
+
+static class ColorExtensions
+{
+    public static Color WithAlpha(this Color color, int alpha)
+    {
+        return new Color(color.r, color.g, color.b, alpha);
+    }
+}

--- a/Assets/__Scripts/Extensions/ColorExtensions.cs.meta
+++ b/Assets/__Scripts/Extensions/ColorExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 35a94043cfcb9414fa27e1474bbdcf4b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/__Scripts/Map/Events/EventAppearanceSO.cs
+++ b/Assets/__Scripts/Map/Events/EventAppearanceSO.cs
@@ -42,6 +42,7 @@ public class EventAppearanceSO : ScriptableObject
         if (e.eventData.IsUtilityEvent)
         {
             if (e.eventData.IsRingEvent) e.ChangeColor(RingEventsColor);
+            else if (e.eventData._type == MapEvent.EVENT_TYPE_BOOST_LIGHTS) e.ChangeColor(e.eventData._value == 1 ? OtherColor : OffColor);
             else e.ChangeColor(OtherColor);
             e.UpdateOffset(Vector3.zero);
             e.UpdateGradientRendering();

--- a/Assets/__Scripts/Map/Events/MapEvent.cs
+++ b/Assets/__Scripts/Map/Events/MapEvent.cs
@@ -15,7 +15,7 @@ public class MapEvent : BeatmapObject {
     public const int EVENT_TYPE_LEFT_LASERS = 2;
     public const int EVENT_TYPE_RIGHT_LASERS = 3;
     public const int EVENT_TYPE_ROAD_LIGHTS = 4;
-    public const int EVENT_TYPE_CUSTOM_LIGHT_1 = 5;
+    public const int EVENT_TYPE_BOOST_LIGHTS = 5;
     public const int EVENT_TYPE_CUSTOM_LIGHT_2 = 6;
     public const int EVENT_TYPE_CUSTOM_LIGHT_3 = 7;
     public const int EVENT_TYPE_RINGS_ROTATE = 8;
@@ -79,7 +79,7 @@ public class MapEvent : BeatmapObject {
     public bool IsRotationEvent => _type == EVENT_TYPE_EARLY_ROTATION || _type == EVENT_TYPE_LATE_ROTATION;
     public bool IsRingEvent => _type == EVENT_TYPE_RINGS_ROTATE || _type == EVENT_TYPE_RINGS_ZOOM;
     public bool IsLaserSpeedEvent => _type == EVENT_TYPE_LEFT_LASERS_SPEED || _type == EVENT_TYPE_RIGHT_LASERS_SPEED;
-    public bool IsUtilityEvent => IsRotationEvent || IsRingEvent || IsLaserSpeedEvent;
+    public bool IsUtilityEvent => IsRotationEvent || IsRingEvent || IsLaserSpeedEvent || _type == EVENT_TYPE_BOOST_LIGHTS;
     public bool IsChromaEvent => _value >= ColourManager.RGB_INT_OFFSET || (_customData?.HasKey("_color") ?? false);
 
     public override JSONNode ConvertToJSON() {

--- a/Assets/__Scripts/MapEditor/Grid/Collections/EventsContainer.cs
+++ b/Assets/__Scripts/MapEditor/Grid/Collections/EventsContainer.cs
@@ -21,6 +21,7 @@ public class EventsContainer : BeatmapObjectContainerCollection, CMInput.IEventG
 
     public int EventTypeToPropagate = MapEvent.EVENT_TYPE_RING_LIGHTS;
     public int EventTypePropagationSize = 0;
+    private readonly int SpecialEventTypeCount = 7;
 
     public List<MapEvent> AllRotationEvents = new List<MapEvent>();
 
@@ -32,7 +33,7 @@ public class EventsContainer : BeatmapObjectContainerCollection, CMInput.IEventG
             propagationEditing = value;
             int propagationLength = platformDescriptor.LightingManagers[EventTypeToPropagate]?.LightsGroupedByZ?.Length ?? 0;
             labels.UpdateLabels(value, EventTypeToPropagate, value ? propagationLength + 1 : 16);
-            eventPlacement.SetGridSize(value ? propagationLength + 1 : 6 + platformDescriptor.LightingManagers.Count(s => s != null));
+            eventPlacement.SetGridSize(value ? propagationLength + 1 : SpecialEventTypeCount + platformDescriptor.LightingManagers.Count(s => s != null));
             EventTypePropagationSize = propagationLength;
             UpdatePropagationMode();
         }
@@ -48,7 +49,7 @@ public class EventsContainer : BeatmapObjectContainerCollection, CMInput.IEventG
     {
         platformDescriptor = descriptor;
         labels.UpdateLabels(false, MapEvent.EVENT_TYPE_RING_LIGHTS, 16);
-        eventPlacement.SetGridSize(6 + descriptor.LightingManagers.Count(s => s != null));
+        eventPlacement.SetGridSize(SpecialEventTypeCount + descriptor.LightingManagers.Count(s => s != null));
     }
 
     void OnDestroy()

--- a/Assets/__Scripts/MapEditor/Grid/CreateEventTypeLabels.cs
+++ b/Assets/__Scripts/MapEditor/Grid/CreateEventTypeLabels.cs
@@ -79,6 +79,10 @@ public class CreateEventTypeLabels : MonoBehaviour {
                             textMesh.text = "Rotation (Exclude)";
                             textMesh.font = UtilityAsset;
                             break;
+                        case MapEvent.EVENT_TYPE_BOOST_LIGHTS:
+                            textMesh.text = "Boost Lights";
+                            textMesh.font = UtilityAsset;
+                            break;
                         default:
                             if (LightingManagers.Length > i)
                             {

--- a/Assets/__Scripts/MapEditor/Loading/CustomPlatformsLoader.cs
+++ b/Assets/__Scripts/MapEditor/Loading/CustomPlatformsLoader.cs
@@ -183,19 +183,19 @@ public class CustomPlatformsLoader : MonoBehaviour
             switch (tubeLight.lightsID)
             {
                 case LightsID.Unused5:
-                    maxSize = MapEvent.EVENT_TYPE_CUSTOM_LIGHT_1 + 1;
+                    maxSize = Math.Max(maxSize, MapEvent.EVENT_TYPE_BOOST_LIGHTS + 1);
                     break;
                 case LightsID.Unused6:
-                    maxSize = MapEvent.EVENT_TYPE_CUSTOM_LIGHT_2 + 1;
+                    maxSize = Math.Max(maxSize, MapEvent.EVENT_TYPE_CUSTOM_LIGHT_2 + 1);
                     break;
                 case LightsID.Unused7:
-                    maxSize = MapEvent.EVENT_TYPE_CUSTOM_LIGHT_3 + 1;
+                    maxSize = Math.Max(maxSize, MapEvent.EVENT_TYPE_CUSTOM_LIGHT_3 + 1);
                     break;
                 case LightsID.Unused10:
-                    maxSize = MapEvent.EVENT_TYPE_CUSTOM_LIGHT_4 + 1;
+                    maxSize = Math.Max(maxSize, MapEvent.EVENT_TYPE_CUSTOM_LIGHT_4 + 1);
                     break;
                 case LightsID.Unused11:
-                    maxSize = MapEvent.EVENT_TYPE_CUSTOM_LIGHT_5 + 1;
+                    maxSize = Math.Max(maxSize, MapEvent.EVENT_TYPE_CUSTOM_LIGHT_5 + 1);
                     break;
                 default:
                     break;
@@ -204,7 +204,7 @@ public class CustomPlatformsLoader : MonoBehaviour
 
         if (maxSize != platformDescriptor.LightingManagers.Length)
         {
-            Array.Resize<LightsManager>(ref platformDescriptor.LightingManagers, maxSize);
+            Array.Resize(ref platformDescriptor.LightingManagers, maxSize);
         }
     }
 
@@ -248,7 +248,7 @@ public class CustomPlatformsLoader : MonoBehaviour
                 case LightsID.RingSpeedRight:
                     break;
                 case LightsID.Unused5:
-                    eventId = MapEvent.EVENT_TYPE_CUSTOM_LIGHT_1;
+                    eventId = MapEvent.EVENT_TYPE_BOOST_LIGHTS;
                     break;
                 case LightsID.Unused6:
                     eventId = MapEvent.EVENT_TYPE_CUSTOM_LIGHT_2;
@@ -698,7 +698,7 @@ public class CustomPlatformsLoader : MonoBehaviour
                     eventId = MapEvent.EVENT_TYPE_ROAD_LIGHTS;
                     break;
                 case LightsID.Unused5:
-                    eventId = MapEvent.EVENT_TYPE_CUSTOM_LIGHT_1;
+                    eventId = MapEvent.EVENT_TYPE_BOOST_LIGHTS;
                     break;
                 case LightsID.Unused6:
                     eventId = MapEvent.EVENT_TYPE_CUSTOM_LIGHT_2;

--- a/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/EventPlacement.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/EventPlacement.cs
@@ -94,16 +94,24 @@ public class EventPlacement : PlacementController<MapEvent, BeatmapEventContaine
             }
             else queuedData._customData?.Remove("_propID");
         }
-        queuedData._value = queuedValue;
+
+        UpdateQueuedValue(queuedValue);
+        UpdateAppearance();
+    }
+
+    public void UpdateQueuedValue(int value)
+    {
+        queuedData._value = value;
         if (queuedData.IsLaserSpeedEvent)
             if (int.TryParse(laserSpeedInputField.text, out int laserSpeed)) queuedData._value = laserSpeed;
-        UpdateAppearance();
+        if (queuedData._type == MapEvent.EVENT_TYPE_BOOST_LIGHTS)
+            queuedData._value = queuedData._value > 0 ? 1 : 0;
     }
 
     public void UpdateValue(int value)
     {
         queuedValue = value;
-        queuedData._value = value;
+        UpdateQueuedValue(queuedValue);
         UpdateAppearance();
     }
 
@@ -162,9 +170,7 @@ public class EventPlacement : PlacementController<MapEvent, BeatmapEventContaine
 
         if (!PlacePrecisionRotation)
         {
-            queuedData._value = queuedValue;
-            if (queuedData.IsLaserSpeedEvent)
-                if (int.TryParse(laserSpeedInputField.text, out int laserSpeed)) queuedData._value = laserSpeed;
+            UpdateQueuedValue(queuedValue);
         }
         else if (queuedData.IsRotationEvent) queuedData._value = 1360 + PrecisionRotationValue;
 

--- a/Assets/__Scripts/MapEditor/UI/Chroma/CustomColorsUIController.cs
+++ b/Assets/__Scripts/MapEditor/UI/Chroma/CustomColorsUIController.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 using UnityEngine.UI;
 
 //TODO for the love of god please refactor this to not use BeatmapObjectContainerCollection.LoadedContainers.Values
@@ -13,6 +10,8 @@ public class CustomColorsUIController : MonoBehaviour
     [SerializeField] private Image blueNote;
     [SerializeField] private Image redLight;
     [SerializeField] private Image blueLight;
+    [SerializeField] private Image redBoost;
+    [SerializeField] private Image blueBoost;
     [SerializeField] private Image obstacle;
     [Space]
     [SerializeField] private NoteAppearanceSO noteAppearance;
@@ -25,6 +24,9 @@ public class CustomColorsUIController : MonoBehaviour
     private Color oldPlatformColorR;
     private Color oldPlatformColorB;
 
+    private Color oldPlatformBoostColorR;
+    private Color oldPlatformBoostColorB;
+
     // Start is called before the first frame update
     void Start()
     {
@@ -36,27 +38,30 @@ public class CustomColorsUIController : MonoBehaviour
         platform = obj;
         oldPlatformColorR = platform.RedColor;
         oldPlatformColorB = platform.BlueColor;
-        if (redNote.color == BeatSaberSong.DEFAULT_LEFTNOTE) SetColorIfNotEqual(ref redNote, platform.RedNoteColor);
-        if (blueNote.color == BeatSaberSong.DEFAULT_RIGHTNOTE) SetColorIfNotEqual(ref blueNote, platform.BlueNoteColor);
-        if (redLight.color == BeatSaberSong.DEFAULT_LEFTCOLOR) SetColorIfNotEqual(ref redLight, platform.RedColor);
-        if (blueLight.color == BeatSaberSong.DEFAULT_RIGHTCOLOR) SetColorIfNotEqual(ref blueLight, platform.BlueColor);
-        if (obstacle.color == BeatSaberSong.DEFAULT_LEFTCOLOR) SetColorIfNotEqual(ref obstacle, platform.ObstacleColor);
 
-        redNote.color = BeatSaberSongContainer.Instance.difficultyData.colorLeft ?? redNote.color;
-        blueNote.color = BeatSaberSongContainer.Instance.difficultyData.colorRight ?? blueNote.color;
-        redLight.color = BeatSaberSongContainer.Instance.difficultyData.envColorLeft ?? redLight.color;
-        blueLight.color = BeatSaberSongContainer.Instance.difficultyData.envColorRight ?? blueLight.color;
-        obstacle.color = BeatSaberSongContainer.Instance.difficultyData.obstacleColor ?? obstacle.color;
+        oldPlatformBoostColorR = platform.RedBoostColor;
+        oldPlatformBoostColorB = platform.BlueBoostColor;
+
+        SetColorIfNotEqual(ref redNote, platform.RedNoteColor, BeatSaberSong.DEFAULT_LEFTNOTE, BeatSaberSongContainer.Instance.difficultyData.colorLeft);
+        SetColorIfNotEqual(ref blueNote, platform.BlueNoteColor, BeatSaberSong.DEFAULT_RIGHTNOTE, BeatSaberSongContainer.Instance.difficultyData.colorRight);
+        SetColorIfNotEqual(ref redLight, platform.RedColor, BeatSaberSong.DEFAULT_LEFTCOLOR, BeatSaberSongContainer.Instance.difficultyData.envColorLeft);
+        SetColorIfNotEqual(ref blueLight, platform.BlueColor, BeatSaberSong.DEFAULT_RIGHTCOLOR, BeatSaberSongContainer.Instance.difficultyData.envColorRight);
+        SetColorIfNotEqual(ref redBoost, platform.RedBoostColor, BeatSaberSong.DEFAULT_LEFTCOLOR, BeatSaberSongContainer.Instance.difficultyData.boostColorLeft);
+        SetColorIfNotEqual(ref blueBoost, platform.BlueBoostColor, BeatSaberSong.DEFAULT_RIGHTCOLOR, BeatSaberSongContainer.Instance.difficultyData.boostColorRight);
+        SetColorIfNotEqual(ref obstacle, platform.ObstacleColor, BeatSaberSong.DEFAULT_LEFTCOLOR, BeatSaberSongContainer.Instance.difficultyData.obstacleColor);
 
         noteAppearance.UpdateColor(redNote.color, blueNote.color);
         platform.RedColor = eventAppearance.RedColor = redLight.color;
         platform.BlueColor = eventAppearance.BlueColor = blueLight.color;
+        platform.RedBoostColor = redBoost.color;
+        platform.BlueBoostColor = blueBoost.color;
         obstacleAppearance.defaultObstacleColor = obstacle.color;
     }
 
-    private void SetColorIfNotEqual(ref Image a, Color b)
+    private void SetColorIfNotEqual(ref Image uiElement, Color platformDefault, Color _default, Color? savedColor)
     {
-        if (a.color != b) a.color = new Color(b.r, b.g, b.b, 1);
+        if (uiElement.color == _default && uiElement.color != platformDefault) uiElement.color = platformDefault.WithAlpha(1);
+        uiElement.color = savedColor ?? uiElement.color;
     }
 
     private void OnDestroy()
@@ -66,7 +71,7 @@ public class CustomColorsUIController : MonoBehaviour
 
     public void UpdateRedNote()
     {
-        redNote.color = picker.CurrentColor;
+        redNote.color = picker.CurrentColor.WithAlpha(1);
         BeatSaberSongContainer.Instance.difficultyData.colorLeft = picker.CurrentColor;
         noteAppearance.UpdateColor(picker.CurrentColor, blueNote.color);
         BeatmapObjectContainerCollection.GetCollectionForType(BeatmapObject.Type.NOTE).RefreshPool(true);
@@ -74,7 +79,7 @@ public class CustomColorsUIController : MonoBehaviour
 
     public void UpdateBlueNote()
     {
-        blueNote.color = picker.CurrentColor;
+        blueNote.color = picker.CurrentColor.WithAlpha(1);
         BeatSaberSongContainer.Instance.difficultyData.colorRight = picker.CurrentColor;
         noteAppearance.UpdateColor(redNote.color, picker.CurrentColor);
         BeatmapObjectContainerCollection.GetCollectionForType(BeatmapObject.Type.NOTE).RefreshPool(true);
@@ -83,20 +88,36 @@ public class CustomColorsUIController : MonoBehaviour
     public void UpdateRedLight()
     {
         BeatSaberSongContainer.Instance.difficultyData.envColorLeft = picker.CurrentColor;
-        eventAppearance.RedColor = redLight.color = platform.RedColor = picker.CurrentColor;
+        eventAppearance.RedColor = platform.RedColor = picker.CurrentColor;
+        redLight.color = picker.CurrentColor.WithAlpha(1);
         BeatmapObjectContainerCollection.GetCollectionForType(BeatmapObject.Type.EVENT).RefreshPool(true);
     }
 
     public void UpdateBlueLight()
     {
         BeatSaberSongContainer.Instance.difficultyData.envColorRight = picker.CurrentColor;
-        eventAppearance.BlueColor = blueLight.color = platform.BlueColor = picker.CurrentColor;
+        eventAppearance.BlueColor = platform.BlueColor = picker.CurrentColor;
+        blueLight.color = picker.CurrentColor.WithAlpha(1);
         BeatmapObjectContainerCollection.GetCollectionForType(BeatmapObject.Type.EVENT).RefreshPool(true);
+    }
+
+    public void UpdateRedBoost()
+    {
+        BeatSaberSongContainer.Instance.difficultyData.boostColorLeft = picker.CurrentColor;
+        platform.RedBoostColor = picker.CurrentColor;
+        redBoost.color = picker.CurrentColor.WithAlpha(1);
+    }
+
+    public void UpdateBlueBoost()
+    {
+        BeatSaberSongContainer.Instance.difficultyData.boostColorRight = picker.CurrentColor;
+        platform.BlueBoostColor = picker.CurrentColor;
+        blueBoost.color = picker.CurrentColor.WithAlpha(1);
     }
 
     public void UpdateObstacles()
     {
-        obstacle.color = picker.CurrentColor;
+        obstacle.color = picker.CurrentColor.WithAlpha(1);
         BeatSaberSongContainer.Instance.difficultyData.obstacleColor = picker.CurrentColor;
         obstacleAppearance.defaultObstacleColor = picker.CurrentColor;
         BeatmapObjectContainerCollection.GetCollectionForType(BeatmapObject.Type.OBSTACLE).RefreshPool(true);
@@ -106,8 +127,8 @@ public class CustomColorsUIController : MonoBehaviour
     {
         BeatSaberSongContainer.Instance.difficultyData.colorLeft = null;
         BeatSaberSongContainer.Instance.difficultyData.colorRight = null;
-        blueNote.color = platform.BlueNoteColor;
-        redNote.color = platform.RedNoteColor;
+        blueNote.color = platform.BlueNoteColor.WithAlpha(1);
+        redNote.color = platform.RedNoteColor.WithAlpha(1);
         noteAppearance.UpdateColor(redNote.color, blueNote.color);
         BeatmapObjectContainerCollection.GetCollectionForType(BeatmapObject.Type.NOTE).RefreshPool(true);
     }
@@ -115,19 +136,29 @@ public class CustomColorsUIController : MonoBehaviour
     public void ResetLights()
     {
         BeatSaberSongContainer.Instance.difficultyData.envColorLeft = null;
-        eventAppearance.RedColor = redLight.color = platform.RedColor = oldPlatformColorR;
-        
+        redLight.color = oldPlatformColorR.WithAlpha(1);
+        eventAppearance.RedColor = platform.RedColor = oldPlatformColorR;
+
         BeatSaberSongContainer.Instance.difficultyData.envColorRight = null;
-        eventAppearance.BlueColor = blueLight.color = platform.BlueColor = oldPlatformColorB;
+        blueLight.color = oldPlatformColorB;
+        eventAppearance.BlueColor = platform.BlueColor = oldPlatformColorB.WithAlpha(1);
+
+        BeatSaberSongContainer.Instance.difficultyData.boostColorLeft = null;
+        platform.RedBoostColor = oldPlatformBoostColorR;
+        redBoost.color = oldPlatformBoostColorR.WithAlpha(1);
+
+        BeatSaberSongContainer.Instance.difficultyData.boostColorRight = null;
+        platform.BlueBoostColor = oldPlatformBoostColorB;
+        blueBoost.color = oldPlatformBoostColorB.WithAlpha(1);
 
         BeatmapObjectContainerCollection.GetCollectionForType(BeatmapObject.Type.EVENT).RefreshPool(true);
     }
 
     public void ResetObstacles()
     {
-        obstacle.color = BeatSaberSong.DEFAULT_LEFTCOLOR;
+        obstacle.color = platform.ObstacleColor.WithAlpha(1);
         BeatSaberSongContainer.Instance.difficultyData.obstacleColor = null;
-        obstacleAppearance.defaultObstacleColor = BeatSaberSong.DEFAULT_LEFTCOLOR;
+        obstacleAppearance.defaultObstacleColor = platform.ObstacleColor;
         BeatmapObjectContainerCollection.GetCollectionForType(BeatmapObject.Type.OBSTACLE).RefreshPool(true);
     }
 }

--- a/Assets/__Scripts/MapEditor/UI/Placement Controller UI/EventPlacementUI.cs
+++ b/Assets/__Scripts/MapEditor/UI/Placement Controller UI/EventPlacementUI.cs
@@ -69,10 +69,12 @@ public class EventPlacementUI : MonoBehaviour, CMInput.IEventUIActions
     private void UpdateValue(int value)
     {
         //if (!customStandaloneInputModule.IsPointerOverGameObject<GraphicRaycaster>(-1, true)) return; // again idk what this is
-        if (!eventPlacement.queuedData.IsUtilityEvent)
-        {
-            eventPlacement.UpdateValue(value);
-        }
+
+        // We can't limit this as most of the time to get to the selection bar the user will have hovered
+        // over a utility track and we still need to update the value otherwise the UI gets out of sync
+        //if (!eventPlacement.queuedData.IsUtilityEvent)
+
+        eventPlacement.UpdateValue(value);
     }
 
     public void UpdatePrecisionRotationValue()

--- a/Assets/__Scripts/Platforms/LightingEvent.cs
+++ b/Assets/__Scripts/Platforms/LightingEvent.cs
@@ -71,6 +71,17 @@ public class LightingEvent : MonoBehaviour {
         if (timeToTransition == 0) currentAlpha = target;
     }
 
+    public void UpdateCurrentColor(Color color)
+    {
+        currentColor = color;
+    }
+
+    public void UpdateTargetAlpha(float target)
+    {
+        if (!CanBeTurnedOff) return;
+        TargetAlpha = target;
+    }
+
     private void SetEmission(bool enabled)
     {
         if (enabled)

--- a/Assets/__Scripts/Platforms/LightsManager.cs
+++ b/Assets/__Scripts/Platforms/LightsManager.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
-using UnityEngine.SceneManagement;
 
 public class LightsManager : MonoBehaviour
 {
@@ -10,6 +9,7 @@ public class LightsManager : MonoBehaviour
     public static readonly float HDR_Intensity = 2.4169f;
 
     public bool disableCustomInitialization = false;
+    private int previousValue = 0;
 
     [HideInInspector] public List<LightingEvent> ControllingLights = new List<LightingEvent>();
     [HideInInspector] public LightingEvent[][] LightsGroupedByZ = new LightingEvent[][] { };
@@ -119,6 +119,48 @@ public class LightsManager : MonoBehaviour
             light.UpdateTargetAlpha(color.a, 0);
             light.UpdateTargetColor(color * Mathf.GammaToLinearSpace(Mathf.Ceil(HDR_Intensity)), 0);
             light.UpdateTargetColor(color * Mathf.GammaToLinearSpace(HDR_Intensity), FadeTime);
+        }
+    }
+
+    public void SetValue(int value)
+    {
+        previousValue = value;
+    }
+
+    public void Boost(Color a, Color b)
+    {
+        // Off
+        if (previousValue == 0) return;
+
+        if (previousValue <= 3)
+        {
+            (a, b) = (b, a);
+        }
+
+        foreach (LightingEvent light in ControllingLights)
+        {
+            if (light.UseInvertedPlatformColors)
+            {
+                SetTargets(light, b);
+            }
+            else
+            {
+                SetTargets(light, a);
+            }
+        }
+    }
+
+    private void SetTargets(LightingEvent light, Color a)
+    {
+        if (previousValue == MapEvent.LIGHT_VALUE_BLUE_FADE || previousValue == MapEvent.LIGHT_VALUE_RED_FADE)
+        {
+            light.UpdateCurrentColor(a * Mathf.GammaToLinearSpace(HDR_Intensity));
+            light.UpdateTargetAlpha(0);
+        }
+        else
+        {
+            light.UpdateTargetColor(a * Mathf.GammaToLinearSpace(HDR_Intensity), 0);
+            light.UpdateTargetAlpha(a.a);
         }
     }
 }

--- a/Assets/__Scripts/Platforms/PlatformDescriptor.cs
+++ b/Assets/__Scripts/Platforms/PlatformDescriptor.cs
@@ -20,6 +20,8 @@ public class PlatformDescriptor : MonoBehaviour {
     public GridRotationController RotationController;
     public Color RedColor = BeatSaberSong.DEFAULT_LEFTCOLOR;
     public Color BlueColor = BeatSaberSong.DEFAULT_RIGHTCOLOR;
+    public Color RedBoostColor = BeatSaberSong.DEFAULT_LEFTCOLOR;
+    public Color BlueBoostColor = BeatSaberSong.DEFAULT_RIGHTCOLOR;
     public Color RedNoteColor = BeatSaberSong.DEFAULT_LEFTNOTE;
     public Color BlueNoteColor = BeatSaberSong.DEFAULT_RIGHTNOTE;
     public Color ObstacleColor = BeatSaberSong.DEFAULT_LEFTNOTE;
@@ -32,6 +34,8 @@ public class PlatformDescriptor : MonoBehaviour {
 
     public bool SoloAnEventType { get; private set; } = false;
     public int SoloEventType { get; private set; } = 0;
+
+    public bool ColorBoost { get; private set; } = false;
 
     private BeatmapObjectCallbackController callbackController;
     private RotationCallbackController rotationCallback;
@@ -163,6 +167,14 @@ public class PlatformDescriptor : MonoBehaviour {
                 foreach (RotatingLights r in LightingManagers[MapEvent.EVENT_TYPE_RIGHT_LASERS].RotatingLights)
                     r.UpdateOffset(e._value, rng.Next(0, 180), rng.Next(0, 1) == 1, obj._customData);
                 break;
+            case 5:
+                ColorBoost = e._value == 1;
+                foreach (var manager in LightingManagers)
+                {
+                    manager.Boost(ColorBoost ? RedBoostColor : RedColor,
+                        ColorBoost ? BlueBoostColor : BlueColor);
+                }
+                break;
             default:
                 if (e._type < LightingManagers.Length && LightingManagers[e._type] != null)
                     HandleLights(LightingManagers[e._type], e._value, e);
@@ -214,13 +226,13 @@ public class PlatformDescriptor : MonoBehaviour {
         //Set initial light values
         if (value <= 3)
         {
-            mainColor = BlueColor;
-            invertedColor = RedColor;
+            mainColor = ColorBoost ? BlueBoostColor : BlueColor;
+            invertedColor = ColorBoost ? RedBoostColor : RedColor;
         }
         else if (value <= 7)
         {
-            mainColor = RedColor;
-            invertedColor = BlueColor;
+            mainColor = ColorBoost ? RedBoostColor : RedColor;
+            invertedColor = ColorBoost ? BlueBoostColor : BlueColor;
         }
 
         //Check if it is a PogU new Chroma event
@@ -282,6 +294,7 @@ public class PlatformDescriptor : MonoBehaviour {
             group.Fade(mainColor, lights);
             group.Fade(invertedColor, invertedLights);
         }
+        group.SetValue(value);
     }
 
     private IEnumerator GradientRoutine(MapEvent gradientEvent, LightsManager group)


### PR DESCRIPTION
But this is ChromaMapper?

Still seems worth it to include support for features available without mods. You can now create more colourful light shows than before by using the new boost colour event.

Essentially each lighting manager now remembers what the *value* was of the last lighting event it saw and when the boost event happens it uses that to apply new colours based on the global palette. If the value of the boost event is 1, it will apply the boost colours otherwise it will apply the normal lighting colours.

This means that if you previously used chroma events the boost event will set the colour to whatever the original values mean it would have been and if you used an event with propID even though you only changed one prop you will have changed what the previous lighting event was for the entire lighting manager so if you have a boost event it will remove all your individual lighting.

This should all work in this PR as it does in the game.

I'm not sure how this interacts with custom platforms that used event type 5 for lights and as the plugin isn't available for the latest patch yet, I'll try and work out what to do about this when I get to fixing a few of the remaining bugs in it. I'll probably have to remove it as a lighting channel for future platforms at least.

https://streamable.com/hkqixv

I've also fixed:
 - The environment colours being wrong in the chroma panel for environments with non-default schemes.
 - Being able to change lighting event types when having hovered over utility tracks (hopefully doesn't create weirdness placing these other events, rotation events are the weirdest)
 - Not removing colour overrides from Info.dat when they get reset
 - The wrong number of lighting controllers could be created for custom platforms.