### PR TITLE
Bug fixes

### DIFF
--- a/Assets/__Scripts/MapEditor/AudioTimeSyncController.cs
+++ b/Assets/__Scripts/MapEditor/AudioTimeSyncController.cs
@@ -236,17 +236,23 @@ public class AudioTimeSyncController : MonoBehaviour, CMInput.IPlaybackActions, 
                 BeatmapBPMChange currentBpmChange = bpmChangesContainer.FindLastBPM(CurrentBeat, true);
                 float beatShift = beatShiftRaw;
                 // This new beatShift value will move us 1 BPM-modified beat forward or backward
-                if (currentBpmChange != null) beatShift = beatShift / song.beatsPerMinute * currentBpmChange._BPM;
+                if (currentBpmChange != null) beatShift *= (song.beatsPerMinute / currentBpmChange._BPM);
 
                 // Now we check if the BPM Change after the shift is different.
                 BeatmapBPMChange lastBpmChange = bpmChangesContainer.FindLastBPM(CurrentBeat + beatShift, true);
-                if (lastBpmChange != currentBpmChange && lastBpmChange != null && currentBpmChange != null)
+
+                if (lastBpmChange != currentBpmChange && currentBpmChange != null)
                 {
-                    if (beatShiftRaw < 0)
+                    if (currentBpmChange._time == CurrentBeat) // We're on top of a BPM change, move using previous BPM
+                    {
+                        beatShift = lastBpmChange == null ? beatShiftRaw : (beatShiftRaw * (song.beatsPerMinute / lastBpmChange._BPM));
+                        MoveToTimeInBeats(CurrentBeat + beatShift);
+                    }
+                    else if (beatShiftRaw < 0)
                     {
                         MoveToTimeInBeats(currentBpmChange._time); // If we're going backward, snap to our current bpm change.
                     }
-                    else
+                    else if (lastBpmChange != null)
                     {
                         MoveToTimeInBeats(lastBpmChange._time); // If we're going forward, snap to that bpm change.
                     }

--- a/Assets/__Scripts/Platforms/LightsManager.cs
+++ b/Assets/__Scripts/Platforms/LightsManager.cs
@@ -134,16 +134,12 @@ public class LightsManager : MonoBehaviour
 
         if (previousValue <= 3)
         {
-            (a, b) = (b, a);
+            a = b;
         }
 
         foreach (LightingEvent light in ControllingLights)
         {
-            if (light.UseInvertedPlatformColors)
-            {
-                SetTargets(light, b);
-            }
-            else
+            if (!light.UseInvertedPlatformColors)
             {
                 SetTargets(light, a);
             }

--- a/Assets/__Scripts/Platforms/PlatformDescriptor.cs
+++ b/Assets/__Scripts/Platforms/PlatformDescriptor.cs
@@ -227,12 +227,12 @@ public class PlatformDescriptor : MonoBehaviour {
         if (value <= 3)
         {
             mainColor = ColorBoost ? BlueBoostColor : BlueColor;
-            invertedColor = ColorBoost ? RedBoostColor : RedColor;
+            invertedColor = RedColor;
         }
         else if (value <= 7)
         {
             mainColor = ColorBoost ? RedBoostColor : RedColor;
-            invertedColor = ColorBoost ? BlueBoostColor : BlueColor;
+            invertedColor = BlueColor;
         }
 
         //Check if it is a PogU new Chroma event


### PR DESCRIPTION
Some of the things I've seen from discord

Scrolling was really wonky after bpm changes, but I don't think that was even reported over the fact that scrolling past them didn't even work as it was just trying to jump back to the current one so I've added the special case for when scrolling at a bpm change.

Gridlines using highest prime factor:

![image](https://user-images.githubusercontent.com/534069/92316068-ddbeb180-efe6-11ea-841f-38efeee01e53.png)

Fixed boost handling to match the fact you can actually get three colours at once if you make use of inverted lights:
![image](https://user-images.githubusercontent.com/534069/92316064-cd0e3b80-efe6-11ea-9ffb-914b115c506b.png)
