### PR TITLE
Fixes metronome drift

### DIFF
--- a/Assets/__Scripts/MapEditor/Audio/MetronomeHandler.cs
+++ b/Assets/__Scripts/MapEditor/Audio/MetronomeHandler.cs
@@ -62,7 +62,7 @@ public class MetronomeHandler : MonoBehaviour
             if (!metronomeUI.activeInHierarchy) metronomeUI.SetActive(true);
             if (beatProgress >= 1)
             {
-                beatProgress = 0;
+                beatProgress %= 1;
                 audioUtil.PlayOneShotSound(CowBell ? cowbellSound : metronomeSound, Settings.Instance.MetronomeVolume);
                 RunAnimation();
             }


### PR DESCRIPTION
This is a minor fix for the metronome.
In the current implementation the ticking will drift from the target bmp depending on the fps.
So about 118/120bpm or 150/155bpm at 60fps in my testing.
The change preserves the already elapsed time into the new frame.

I also tried to find a constant high precision timer for unity since the current one still only fires at each frame at max. But it seems unity cannot do that. Unless maybe with a own thread for that, however that seems overkill.