### PR TITLE
More bugfixes

### DIFF
--- a/Assets/__Scripts/MapEditor/Grid/Collections/BeatmapObjectContainerCollection.cs
+++ b/Assets/__Scripts/MapEditor/Grid/Collections/BeatmapObjectContainerCollection.cs
@@ -250,10 +250,12 @@ public abstract class BeatmapObjectContainerCollection : MonoBehaviour
     public void DeleteObject(BeatmapObject obj, bool triggersAction = true, bool refreshesPool = true, string comment = "No comment.")
     {
         BeatmapObject toDelete = UnsortedObjects.Find(x => x.IsConflictingWith(obj, true));
-        if (toDelete != null && LoadedObjects.Remove(toDelete))
+        BeatmapObject toDelete2 = LoadedObjects.First(x => x.IsConflictingWith(obj, true));
+        if (toDelete != null && toDelete2 != null)
         {
             //Debug.Log($"Deleting container with hash code {toDelete.GetHashCode()}");
             UnsortedObjects.Remove(toDelete);
+            LoadedObjects.Remove(toDelete2);
             SelectionController.Deselect(toDelete);
             if (triggersAction) BeatmapActionContainer.AddAction(new BeatmapObjectDeletionAction(toDelete, comment));
             RecycleContainer(toDelete);

--- a/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/PlacementController.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/PlacementController.cs
@@ -215,12 +215,19 @@ public abstract class PlacementController<BO, BOC, BOCC> : MonoBehaviour, CMInpu
     {
         if (!(isDraggingObject || isDraggingObjectAtTime)) return;
         //First, find and delete anything that's overlapping our dragged object.
+        var selected = SelectionController.IsObjectSelected(draggedObjectData);
         objectContainerCollection.RemoveConflictingObjects(new[] { draggedObjectData }, out List<BeatmapObject> conflicting);
         if (conflicting.Contains(draggedObjectData))
         {
             objectContainerCollection.SpawnObject(draggedObjectData, false, true);
             conflicting.Remove(draggedObjectData);
+
+            if (selected)
+            {
+                SelectionController.Select(draggedObjectData);
+            }
         }
+        
         queuedData = BeatmapObject.GenerateCopy(originalQueued);
         BeatmapAction action;
         // Don't queue an action if we didn't actually change anything

--- a/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/PlacementController.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/PlacementController.cs
@@ -157,7 +157,7 @@ public abstract class PlacementController<BO, BOC, BOCC> : MonoBehaviour, CMInpu
     public void OnInitiateClickandDrag(InputAction.CallbackContext context)
     {
         if (UsePrecisionPlacement) return;
-        if (context.performed && CanClickAndDrag)
+        if (context.performed && CanClickAndDrag && !KeybindsController.ShiftHeld)
         {
             Ray dragRay = mainCamera.ScreenPointToRay(mousePosition);
             if (Physics.Raycast(dragRay, out RaycastHit dragHit, 999f, 1 << 9))

--- a/Assets/__Scripts/MapEditor/Mapping/Selection/SelectionController.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/Selection/SelectionController.cs
@@ -361,6 +361,13 @@ public class SelectionController : MonoBehaviour, CMInput.ISelectingActions, CMI
             {
                 con.UpdateGridPosition();
             }
+
+            if (collection is NotesContainer notesContainer)
+            {
+                notesContainer.RefreshSpecialAngles(original, false, false);
+                notesContainer.RefreshSpecialAngles(data, false, false);
+            }
+
             allActions.Add(new BeatmapObjectModifiedAction(BeatmapObject.GenerateCopy(data), original));
         }
         BeatmapActionContainer.AddAction(new ActionCollectionAction(allActions, false, "Shifted a selection of objects."));


### PR DESCRIPTION
Shift + up and down won't refresh window-aligned notes
Don't know if the same as:
https://discordapp.com/channels/702230714585710602/702232127755780197/768040651383635969

Alt+Shift+Left click shouldn't move blocks
https://discordapp.com/channels/702230714585710602/702232127755780197/767186327682678825

alt+left click and alt+right click will deselect a note that was previously selected
https://discordapp.com/channels/702230714585710602/702232127755780197/767890235005730847

Fixed some undo bugs by using IsConflictingWith, I don't know how objects are getting confused here but they certainly were. I couldn't work out how to reproduce it every time either...