### PR TITLE
Change ring update loop code to match chroma

### DIFF
--- a/Assets/__Scripts/Platforms/Track Rings/TrackLaneRingsRotationEffect.cs
+++ b/Assets/__Scripts/Platforms/Track Rings/TrackLaneRingsRotationEffect.cs
@@ -33,10 +33,10 @@ public class TrackLaneRingsRotationEffect : MonoBehaviour
         for (int i = activeEffects.Count - 1; i >= 0; i--)
         {
             RingRotationEffect effect = activeEffects[i];
-            float progress = effect.progressPos;
+            int progress = (int) effect.progressPos;
             while (progress < effect.progressPos + effect.rotationPropagationSpeed && progress < rings.Length)
             {
-                rings[Mathf.RoundToInt(progress)].SetRotation(effect.rotationAngle + progress * effect.rotationStep, effect.rotationFlexySpeed);
+                rings[progress].SetRotation(effect.rotationAngle + progress * effect.rotationStep, effect.rotationFlexySpeed);
                 progress++;
             }
             effect.progressPos += effect.rotationPropagationSpeed;


### PR DESCRIPTION
Updated to match chroma
See https://github.com/Aeroluna/Chroma/blob/master/Chroma/ChromaRingsRotationEffect.cs#L64

Fix for wonky rounding:

```        float a = 2.5f;
        for (int i = 0; i < 10; i++)
        {
            Debug.Log(Mathf.RoundToInt(a));
            a++;
        }
```

![image](https://user-images.githubusercontent.com/534069/98138505-15e55200-1ebb-11eb-9179-c5da47737c33.png)
