### PR TITLE
Lane refactor

### DIFF
--- a/Assets/__Scenes/03_Mapper.unity
+++ b/Assets/__Scenes/03_Mapper.unity
@@ -10753,6 +10753,7 @@ MonoBehaviour:
   - {fileID: 120631927}
   - {fileID: 1578136732}
   darkTheme: {fileID: 0}
+  RotationCallback: {fileID: 226696885}
 --- !u!1 &325388639
 GameObject:
   m_ObjectHideFlags: 0
@@ -41664,9 +41665,9 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: -23.999985, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &1223292197
 RectTransform:
@@ -49230,6 +49231,7 @@ MonoBehaviour:
   eventPlacementUI: {fileID: 376516736}
   redEventToggle: {fileID: 1090196559}
   dropdown: {fileID: 81479822}
+  labels: {fileID: 322207091}
   PlacePrecisionRotation: 0
   PrecisionRotationValue: 0
 --- !u!114 &1277691437
@@ -56330,6 +56332,7 @@ MonoBehaviour:
   copiedColor: {r: 0, g: 1, b: 0, a: 1}
   tracksManager: {fileID: 25550679}
   eventPlacement: {fileID: 1277691436}
+  labels: {fileID: 322207091}
 --- !u!114 &1524038336
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/__Scripts/Map/Events/BeatmapEventContainer.cs
+++ b/Assets/__Scripts/Map/Events/BeatmapEventContainer.cs
@@ -33,6 +33,8 @@ public class BeatmapEventContainer : BeatmapObjectContainer {
     private List<Material> mat;
     private float oldAlpha = -1;
 
+    [SerializeField] private CreateEventTypeLabels labels;
+
     /// <summary>
     /// Different modes to sort events in the editor.
     /// </summary>
@@ -43,12 +45,13 @@ public class BeatmapEventContainer : BeatmapObjectContainer {
         mat = eventRenderer.Select(it => it.materials[0]).ToList();
     }
 
-    public static BeatmapEventContainer SpawnEvent(EventsContainer eventsContainer, MapEvent data, ref GameObject prefab, ref EventAppearanceSO eventAppearanceSO)
+    public static BeatmapEventContainer SpawnEvent(EventsContainer eventsContainer, MapEvent data, ref GameObject prefab, ref EventAppearanceSO eventAppearanceSO, ref CreateEventTypeLabels labels)
     {
         BeatmapEventContainer container = Instantiate(prefab).GetComponent<BeatmapEventContainer>();
         container.eventData = data;
         container.eventsContainer = eventsContainer;
         container.eventAppearance = eventAppearanceSO;
+        container.labels = labels;
         container.transform.localEulerAngles = Vector3.zero;
         return container;
     }
@@ -92,7 +95,7 @@ public class BeatmapEventContainer : BeatmapObjectContainer {
         else
         {
             transform.localPosition = new Vector3(
-                EventTypeToModifiedType(eventData._type) + 0.5f,
+                labels.EventTypeToLaneId(eventData._type) + 0.5f,
                 0.5f,
                 eventData._time * EditorScaleController.EditorScale
             );
@@ -107,87 +110,12 @@ public class BeatmapEventContainer : BeatmapObjectContainer {
         }
     }
 
-
-    private static int[] ModifiedToEventArray = { 14, 15, 0, 1, 2, 3, 4, 8, 9, 12, 13, 5, 6, 7, 10, 11 };
-    private static int[] EventToModifiedArray = { 2, 3, 4, 5, 6, 11, 12, 13, 7, 8, 14, 15, 9, 10, 0, 1 };
     private static readonly int ColorBase = Shader.PropertyToID("_ColorBase");
     private static readonly int ColorTint = Shader.PropertyToID("_ColorTint");
     private static readonly int Position = Shader.PropertyToID("_Position");
     private static readonly int MainAlpha = Shader.PropertyToID("_MainAlpha");
     private static readonly int FadeSize = Shader.PropertyToID("_FadeSize");
     private static readonly int SpotlightSize = Shader.PropertyToID("_SpotlightSize");
-
-    /// <summary>
-    /// Turns an eventType to a modified type for organizational purposes in the Events Grid.
-    /// </summary>
-    /// <param name="eventType">Type usually found in a MapEvent object.</param>
-    /// <returns></returns>
-    public static int EventTypeToModifiedType(int eventType)
-    {
-        if (ModifyTypeMode == -1) return eventType;
-        if (ModifyTypeMode == 0)
-        {
-            if (!EventToModifiedArray.Contains(eventType))
-            {
-                Debug.LogWarning($"Event Type {eventType} does not have a modified type");
-                return eventType;
-            }
-            return EventToModifiedArray[eventType];
-        }
-        else if (ModifyTypeMode == 1)
-            switch (eventType)
-            {
-                case 5: return 1;
-                case 1: return 2;
-                case 6: return 3;
-                case 2: return 4;
-                case 7: return 5;
-                case 3: return 6;
-                case 10: return 7;
-                case 4: return 8;
-                case 11: return 9;
-                case 8: return 10;
-                case 9: return 11;
-                default: return eventType;
-            }
-        return -1;
-    }
-
-    /// <summary>
-    /// Turns a modified type to an event type to be stored in a MapEvent object.
-    /// </summary>
-    /// <param name="modifiedType">Modified type (Usually from EventPreview)</param>
-    /// <returns></returns>
-    public static int ModifiedTypeToEventType(int modifiedType)
-    {
-        if (ModifyTypeMode == -1) return modifiedType;
-        if (ModifyTypeMode == 0)
-        {
-            if (!ModifiedToEventArray.Contains(modifiedType))
-            {
-                Debug.LogWarning($"Event Type {modifiedType} does not have a valid event type! WTF!?!?");
-                return modifiedType;
-            }
-            return ModifiedToEventArray[modifiedType];
-        }
-        else if (ModifyTypeMode == 1)
-            switch (modifiedType)
-            {
-                case 1: return 5;
-                case 2: return 1;
-                case 3: return 6;
-                case 4: return 2;
-                case 5: return 7;
-                case 6: return 3;
-                case 7: return 10;
-                case 8: return 4;
-                case 9: return 11;
-                case 10: return 8;
-                case 11: return 9;
-                default: return modifiedType;
-            }
-        return -1;
-    }
 
     public void ChangeColor(Color color)
     {

--- a/Assets/__Scripts/MapEditor/Grid/Collections/EventsContainer.cs
+++ b/Assets/__Scripts/MapEditor/Grid/Collections/EventsContainer.cs
@@ -21,7 +21,7 @@ public class EventsContainer : BeatmapObjectContainerCollection, CMInput.IEventG
 
     public int EventTypeToPropagate = MapEvent.EVENT_TYPE_RING_LIGHTS;
     public int EventTypePropagationSize = 0;
-    private readonly int SpecialEventTypeCount = 7;
+    private int SpecialEventTypeCount => 7 + labels.NoRotationLaneOffset;
 
     public List<MapEvent> AllRotationEvents = new List<MapEvent>();
     public List<MapEvent> AllBoostEvents = new List<MapEvent>();
@@ -237,7 +237,7 @@ public class EventsContainer : BeatmapObjectContainerCollection, CMInput.IEventG
         PropagationEditing = true;
     }
 
-    public override BeatmapObjectContainer CreateContainer() => BeatmapEventContainer.SpawnEvent(this, null, ref eventPrefab, ref eventAppearanceSO);
+    public override BeatmapObjectContainer CreateContainer() => BeatmapEventContainer.SpawnEvent(this, null, ref eventPrefab, ref eventAppearanceSO, ref labels);
 
     protected override void UpdateContainerData(BeatmapObjectContainer con, BeatmapObject obj)
     {

--- a/Assets/__Scripts/MapEditor/Grid/CreateEventTypeLabels.cs
+++ b/Assets/__Scripts/MapEditor/Grid/CreateEventTypeLabels.cs
@@ -2,7 +2,6 @@
 using TMPro;
 using System.Linq;
 using System.Collections.Generic;
-using System;
 
 public class CreateEventTypeLabels : MonoBehaviour {
 
@@ -224,26 +223,5 @@ public class CreateEventTypeLabels : MonoBehaviour {
     public int MaxLaneId()
     {
         return laneObjs.Count - 1;
-    }
-}
-
-public class LaneInfo : System.IComparable
-{
-    public int Type { get; private set; }
-    private int sortOrder;
-    public string Name;
-
-    public LaneInfo(int i, int v)
-    {
-        sortOrder = v;
-        Type = i;
-    }
-
-    public int CompareTo(object obj)
-    {
-        if (obj is LaneInfo other) {
-            return sortOrder - other.sortOrder;
-        }
-        return 0;
     }
 }

--- a/Assets/__Scripts/MapEditor/Grid/CreateEventTypeLabels.cs
+++ b/Assets/__Scripts/MapEditor/Grid/CreateEventTypeLabels.cs
@@ -1,5 +1,8 @@
 ﻿using UnityEngine;
 using TMPro;
+using System.Linq;
+using System.Collections.Generic;
+using System;
 
 public class CreateEventTypeLabels : MonoBehaviour {
 
@@ -9,8 +12,12 @@ public class CreateEventTypeLabels : MonoBehaviour {
     public GameObject LayerInstantiate;
     public Transform[] EventGrid;
     [SerializeField] private DarkThemeSO darkTheme;
+    public RotationCallbackController RotationCallback;
+    [HideInInspector] public int NoRotationLaneOffset => RotationCallback.IsActive ? 0 : -2;
 
     private LightsManager[] LightingManagers;
+
+    private readonly List<LaneInfo> laneObjs = new List<LaneInfo>();
 
 	// Use this for initialization
 	void Start () {
@@ -24,13 +31,20 @@ public class CreateEventTypeLabels : MonoBehaviour {
             if (children.gameObject.activeSelf)
                 Destroy(children.gameObject);
         }
+        laneObjs.Clear();
 
         for (int i = 0; i < lanes; i++)
         {
-            int modified = BeatmapEventContainer.EventTypeToModifiedType(i);
+            int modified = EventTypeToModifiedType(i) + NoRotationLaneOffset;
+            if (modified < 0 && !isPropagation) continue;
+
+            var laneInfo = new LaneInfo(i, isPropagation ? i : modified);
+
             GameObject instantiate = Instantiate(LayerInstantiate, LayerInstantiate.transform.parent);
             instantiate.SetActive(true);
             instantiate.transform.localPosition = new Vector3(isPropagation ? i : modified, 0, 0);
+            laneObjs.Add(laneInfo);
+
             try
             {
                 TextMeshProUGUI textMesh = instantiate.GetComponentInChildren<TextMeshProUGUI>();
@@ -93,6 +107,7 @@ public class CreateEventTypeLabels : MonoBehaviour {
                             else
                             {
                                 Destroy(textMesh);
+                                laneObjs.Remove(laneInfo);
                             }
                             break;
                     }
@@ -101,9 +116,12 @@ public class CreateEventTypeLabels : MonoBehaviour {
                         textMesh.font = darkTheme.TekoReplacement;
                     }
                 }
+                laneInfo.Name = textMesh.text;
             }
             catch { }
         }
+
+        laneObjs.Sort();
     }
 
     void PlatformLoaded(PlatformDescriptor descriptor)
@@ -118,4 +136,114 @@ public class CreateEventTypeLabels : MonoBehaviour {
         LoadInitialMap.PlatformLoadedEvent -= PlatformLoaded;
     }
 
+    public int LaneIdToEventType(int laneId)
+    {
+        return laneObjs[laneId].Type;
+    }
+
+    public int EventTypeToLaneId(int eventType)
+    {
+        return laneObjs.FindIndex(it => it.Type == eventType);
+    }
+
+    private static int[] ModifiedToEventArray = { 14, 15, 0, 1, 2, 3, 4, 8, 9, 12, 13, 5, 6, 7, 10, 11 };
+    private static int[] EventToModifiedArray = { 2, 3, 4, 5, 6, 11, 12, 13, 7, 8, 14, 15, 9, 10, 0, 1 };
+
+    /// <summary>
+    /// Turns an eventType to a modified type for organizational purposes in the Events Grid.
+    /// </summary>
+    /// <param name="eventType">Type usually found in a MapEvent object.</param>
+    /// <returns></returns>
+    public static int EventTypeToModifiedType(int eventType)
+    {
+        if (BeatmapEventContainer.ModifyTypeMode == -1) return eventType;
+        if (BeatmapEventContainer.ModifyTypeMode == 0)
+        {
+            if (!EventToModifiedArray.Contains(eventType))
+            {
+                Debug.LogWarning($"Event Type {eventType} does not have a modified type");
+                return eventType;
+            }
+            return EventToModifiedArray[eventType];
+        }
+        else if (BeatmapEventContainer.ModifyTypeMode == 1)
+            switch (eventType)
+            {
+                case 5: return 1;
+                case 1: return 2;
+                case 6: return 3;
+                case 2: return 4;
+                case 7: return 5;
+                case 3: return 6;
+                case 10: return 7;
+                case 4: return 8;
+                case 11: return 9;
+                case 8: return 10;
+                case 9: return 11;
+                default: return eventType;
+            }
+        return -1;
+    }
+
+    /// <summary>
+    /// Turns a modified type to an event type to be stored in a MapEvent object.
+    /// </summary>
+    /// <param name="modifiedType">Modified type (Usually from EventPreview)</param>
+    /// <returns></returns>
+    public static int ModifiedTypeToEventType(int modifiedType)
+    {
+        if (BeatmapEventContainer.ModifyTypeMode == -1) return modifiedType;
+        if (BeatmapEventContainer.ModifyTypeMode == 0)
+        {
+            if (!ModifiedToEventArray.Contains(modifiedType))
+            {
+                Debug.LogWarning($"Event Type {modifiedType} does not have a valid event type! WTF!?!?");
+                return modifiedType;
+            }
+            return ModifiedToEventArray[modifiedType];
+        }
+        else if (BeatmapEventContainer.ModifyTypeMode == 1)
+            switch (modifiedType)
+            {
+                case 1: return 5;
+                case 2: return 1;
+                case 3: return 6;
+                case 4: return 2;
+                case 5: return 7;
+                case 6: return 3;
+                case 7: return 10;
+                case 8: return 4;
+                case 9: return 11;
+                case 10: return 8;
+                case 11: return 9;
+                default: return modifiedType;
+            }
+        return -1;
+    }
+
+    public int MaxLaneId()
+    {
+        return laneObjs.Count - 1;
+    }
+}
+
+public class LaneInfo : System.IComparable
+{
+    public int Type { get; private set; }
+    private int sortOrder;
+    public string Name;
+
+    public LaneInfo(int i, int v)
+    {
+        sortOrder = v;
+        Type = i;
+    }
+
+    public int CompareTo(object obj)
+    {
+        if (obj is LaneInfo other) {
+            return sortOrder - other.sortOrder;
+        }
+        return 0;
+    }
 }

--- a/Assets/__Scripts/MapEditor/Grid/LaneInfo.cs
+++ b/Assets/__Scripts/MapEditor/Grid/LaneInfo.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+public class LaneInfo : IComparable
+{
+    public int Type { get; private set; }
+    private int sortOrder;
+    public string Name;
+
+    public LaneInfo(int i, int v)
+    {
+        sortOrder = v;
+        Type = i;
+    }
+
+    public int CompareTo(object obj)
+    {
+        if (obj is LaneInfo other) {
+            return sortOrder - other.sortOrder;
+        }
+        return 0;
+    }
+}

--- a/Assets/__Scripts/MapEditor/Grid/LaneInfo.cs.meta
+++ b/Assets/__Scripts/MapEditor/Grid/LaneInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 91df446b093f5c045b2f57255e25dbd5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/EventPlacement.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/EventPlacement.cs
@@ -26,6 +26,7 @@ public class EventPlacement : PlacementController<MapEvent, BeatmapEventContaine
     [SerializeField] private EventPlacementUI eventPlacementUI;
     [SerializeField] private Toggle redEventToggle;
     [SerializeField] private ToggleColourDropdown dropdown;
+    [SerializeField] private CreateEventTypeLabels labels;
 
     private int queuedValue = MapEvent.LIGHT_VALUE_RED_ON;
     private bool negativeRotations = false;
@@ -75,7 +76,7 @@ public class EventPlacement : PlacementController<MapEvent, BeatmapEventContaine
             instantiatedContainer.transform.localPosition.z);
         if (!objectContainerCollection.PropagationEditing)
         {
-            queuedData._type = BeatmapEventContainer.ModifiedTypeToEventType(Mathf.FloorToInt(instantiatedContainer.transform.localPosition.x) );
+            queuedData._type = labels.LaneIdToEventType(Mathf.FloorToInt(instantiatedContainer.transform.localPosition.x));
             queuedData._customData?.Remove("_propID");
         }
         else

--- a/Assets/__Scripts/MapEditor/Mapping/Selection/SelectionController.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/Selection/SelectionController.cs
@@ -29,6 +29,8 @@ public class SelectionController : MonoBehaviour, CMInput.ISelectingActions, CMI
     [SerializeField] private TracksManager tracksManager;
     [SerializeField] private EventPlacement eventPlacement;
 
+    [SerializeField] private CreateEventTypeLabels labels;
+
     private static SelectionController instance;
 
     // Use this for initialization
@@ -473,11 +475,12 @@ public class SelectionController : MonoBehaviour, CMInput.ISelectingActions, CMI
                     }
                     else
                     {
-                        int modified = BeatmapEventContainer.EventTypeToModifiedType(e._type);
+                        int modified = labels.EventTypeToLaneId(e._type);
                         modified += leftRight;
                         if (modified < 0) modified = 0;
-                        if (modified > 15) modified = 15;
-                        e._type = BeatmapEventContainer.ModifiedTypeToEventType(modified);
+                        int laneCount = labels.MaxLaneId();
+                        if (modified > laneCount) modified = laneCount;
+                        e._type = labels.LaneIdToEventType(modified);
                     }
                 }
             }


### PR DESCRIPTION
Refactor lanes, hold what's being displayed in list in memory and use that to map between co-ordinates and types instead of static array lookups that break when we start hiding lanes.

Hide 360/90 when not in a 360 map so that we don't get random warnings all the time
Fix shifting events off the edge of the world