### PR TITLE
Bug fixes

### DIFF
--- a/Assets/_Graphics/Materials/Grids/Interface X.mat
+++ b/Assets/_Graphics/Materials/Grids/Interface X.mat
@@ -47,7 +47,7 @@ Material:
     - Vector1_694F4424: 0
     - Vector1_92D1193A: 0.5294118
     - _AlphaClip: 0
-    - _BaseAlpha: 0.075
+    - _BaseAlpha: 0.05
     - _Blend: 0
     - _BumpScale: 1
     - _Cull: 2

--- a/Assets/_Graphics/Materials/PlacementGridBase.mat
+++ b/Assets/_Graphics/Materials/PlacementGridBase.mat
@@ -113,7 +113,7 @@ Material:
     - _METALNESS: 0
     - _Metallic: 0
     - _Mode: 3
-    - _OPACITY: 0.2941177
+    - _OPACITY: 0.2
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _QueueOffset: 0

--- a/Assets/_Prefabs/MapEditor/Platforms/BTS.prefab
+++ b/Assets/_Prefabs/MapEditor/Platforms/BTS.prefab
@@ -3541,11 +3541,11 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2982530382356294737}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 13, z: 100}
-  m_LocalScale: {x: 2, y: 2, z: 100}
+  m_LocalPosition: {x: 0, y: 0.13, z: 1}
+  m_LocalScale: {x: 0.02, y: 0.02, z: 1}
   m_Children: []
-  m_Father: {fileID: 7900220059450266134}
-  m_RootOrder: 3
+  m_Father: {fileID: 1646935447309554250}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &664730430218860319
 SpriteRenderer:
@@ -9450,7 +9450,8 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 100, y: 100, z: 100}
-  m_Children: []
+  m_Children:
+  - {fileID: 5876161735123588083}
   m_Father: {fileID: 439380587807353497}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -9579,7 +9580,6 @@ Transform:
   - {fileID: 7038675593257449995}
   - {fileID: 2327170949591342179}
   - {fileID: 1425185832382880787}
-  - {fileID: 5876161735123588083}
   m_Father: {fileID: 439380587807353497}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/__Scenes/03_Mapper.unity
+++ b/Assets/__Scenes/03_Mapper.unity
@@ -21232,7 +21232,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &650082529
 Transform:
   m_ObjectHideFlags: 0
@@ -31069,8 +31069,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 13585791}
   m_HandleRect: {fileID: 13585789}
   m_Direction: 2
-  m_Value: 0.4999997
-  m_Size: 0.83333313
+  m_Value: 0.49999908
+  m_Size: 0.8333333
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -41747,9 +41747,9 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: -23.999985, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &1223292197
 RectTransform:

--- a/Assets/__Scripts/Map/Events/BeatmapEventContainer.cs
+++ b/Assets/__Scripts/Map/Events/BeatmapEventContainer.cs
@@ -145,7 +145,9 @@ public class BeatmapEventContainer : BeatmapObjectContainer {
 
     public void UpdateAlpha(float alpha)
     {
-        if (mat.First().GetFloat(MainAlpha) > 0) oldAlpha = mat.First().GetFloat(MainAlpha);
+        float oldAlphaTemp = mat.First().GetFloat(MainAlpha);
+        if (oldAlphaTemp > 0) oldAlpha = oldAlphaTemp;
+        if (oldAlpha == alpha) return;
 
         mat.ForEach(it =>
         {

--- a/Assets/__Scripts/Map/Notes/BeatmapNoteContainer.cs
+++ b/Assets/__Scripts/Map/Notes/BeatmapNoteContainer.cs
@@ -121,13 +121,18 @@ public class BeatmapNoteContainer : BeatmapObjectContainer {
         });
     }
 
+    private bool CurrentState = false;
     public void CheckTranslucent()
     {
-        noteRenderer.ForEach(it =>
-        {
-            if (it.material.HasProperty("_AlwaysTranslucent") && transform.parent != null)
-                it.material.SetFloat("_AlwaysTranslucent", (transform.localPosition.z + transform.parent.localPosition.z) < 0 ? 1 : 0);
-        });
+        bool newState = transform.parent != null && (transform.localPosition.z + transform.parent.localPosition.z) < 0;
+        if (newState != CurrentState) {
+            noteRenderer.ForEach(it =>
+            {
+                if (it.material.HasProperty("_AlwaysTranslucent"))
+                    it.material.SetFloat("_AlwaysTranslucent", newState ? 1 : 0);
+            });
+            CurrentState = newState;
+        }
     }
 
     public void SetColor(Color? color)

--- a/Assets/__Scripts/MapEditor/AudioTimeSyncController.cs
+++ b/Assets/__Scripts/MapEditor/AudioTimeSyncController.cs
@@ -184,6 +184,17 @@ public class AudioTimeSyncController : MonoBehaviour, CMInput.IPlaybackActions, 
         if (OnPlayToggle != null) OnPlayToggle(IsPlaying);
     }
 
+    public void SnapToGrid(float seconds)
+    {
+        if (IsPlaying) return;
+        var beatTime = GetBeatFromSeconds(seconds);
+        currentBeat = bpmChangesContainer.FindRoundedBPMTime(beatTime) + offsetBeat;
+        currentSeconds = GetSecondsFromBeat(currentBeat);
+        songAudioSource.time = CurrentSeconds + offsetMS;
+        ValidatePosition();
+        UpdateMovables();
+    }
+
     public void SnapToGrid(bool positionValidated = false) {
         currentBeat = bpmChangesContainer.FindRoundedBPMTime(currentBeat) + offsetBeat;
         currentSeconds = GetSecondsFromBeat(currentBeat);

--- a/Assets/__Scripts/MapEditor/UI/PastNotesWorker.cs
+++ b/Assets/__Scripts/MapEditor/UI/PastNotesWorker.cs
@@ -20,6 +20,7 @@ public class PastNotesWorker : MonoBehaviour
     private float scale = 0;
 
     private Dictionary<int, Dictionary<GameObject, Image>> InstantiatedNotes = new Dictionary<int, Dictionary<GameObject, Image>>();
+    private List<BeatmapObject> lastGroup = new List<BeatmapObject>();
 
     private void Start()
     {
@@ -53,9 +54,8 @@ public class PastNotesWorker : MonoBehaviour
     private void OnTimeChanged()
     {
         if (atsc.IsPlaying) return;
-
-        var lastGroup = new List<BeatmapObject>();
         var time = 0f;
+        lastGroup.Clear();
 
         foreach (var note in notesContainer.LoadedObjects)
         {

--- a/Assets/__Scripts/MapEditor/UI/PastNotesWorker.cs
+++ b/Assets/__Scripts/MapEditor/UI/PastNotesWorker.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.UI;
@@ -51,15 +50,29 @@ public class PastNotesWorker : MonoBehaviour
         Settings.ClearSettingNotifications("PastNotesGridScale");
     }
 
-    private bool _firstLoad = true;
-
     private void OnTimeChanged()
     {
         if (atsc.IsPlaying) return;
-        var grouping = notesContainer.LoadedObjects.GroupBy(x => x._time);
-        var lastGroup = grouping.LastOrDefault(x => x.Key < atsc.CurrentBeat);
-        if (lastGroup is null) return;
-        foreach (BeatmapObject note in lastGroup.Where(x => (x as BeatmapNote)._type != BeatmapNote.NOTE_TYPE_BOMB))
+
+        var lastGroup = new List<BeatmapObject>();
+        var time = 0f;
+
+        foreach (var note in notesContainer.LoadedObjects)
+        {
+            if (time < note._time && note._time < atsc.CurrentBeat)
+            {
+                time = note._time;
+                lastGroup.Clear();
+                if ((note as BeatmapNote)._type != BeatmapNote.NOTE_TYPE_BOMB)
+                    lastGroup.Add(note);
+            }
+            else if (time == note._time && (note as BeatmapNote)._type != BeatmapNote.NOTE_TYPE_BOMB)
+            {
+                lastGroup.Add(note);
+            }
+        }
+
+        foreach (BeatmapObject note in lastGroup)
         {
             NotePassedThreshold(false, 0, note);
         }

--- a/Assets/__Scripts/MapEditor/UI/SongTimelineController.cs
+++ b/Assets/__Scripts/MapEditor/UI/SongTimelineController.cs
@@ -56,8 +56,7 @@ public class SongTimelineController : MonoBehaviour, IPointerEnterHandler, IPoin
             slider.value = lastSongTime / songLength;
             return;
         }
-        atsc.MoveToTimeInSeconds(sliderValue * songLength);
-        atsc.SnapToGrid();
+        atsc.SnapToGrid(sliderValue * songLength);
     }
 
     public void OnPointerEnter(PointerEventData eventData)


### PR DESCRIPTION
BTS logo in correct lighting group
Re-enable the note tick object that I accidentally disabled, but less opacity

Bonus optimisations, cache state of a couple of values so we don't give unity work to do if they haven't changed.
PastNotesWorker.OnTimeChanged code is now 4x more lines but at least twice as fast if not more