### PR TITLE
Make box select great again

### DIFF
--- a/Assets/__Scenes/03_Mapper.unity
+++ b/Assets/__Scenes/03_Mapper.unity
@@ -29959,8 +29959,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 13585791}
   m_HandleRect: {fileID: 13585789}
   m_Direction: 2
-  m_Value: 0.5000012
-  m_Size: 0.833333
+  m_Value: 0.49999756
+  m_Size: 0.8333333
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -40019,9 +40019,9 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
+  m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: -23.999985, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &1223292197
 RectTransform:
@@ -54448,6 +54448,12 @@ MonoBehaviour:
   gridChild: {fileID: 0}
   noteGridTransform: {fileID: 0}
   IsActive: 0
+  bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  customCollection: {fileID: 25550677}
+  eventsContainer: {fileID: 25550674}
+  labels: {fileID: 322207091}
 --- !u!1 &1524114567
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/__Scripts/Map/Events/BeatmapEventContainer.cs
+++ b/Assets/__Scripts/Map/Events/BeatmapEventContainer.cs
@@ -58,45 +58,17 @@ public class BeatmapEventContainer : BeatmapObjectContainer {
 
     public override void UpdateGridPosition()
     {
-        if (eventsContainer.PropagationEditing)
+        var position = eventData.GetPosisition(labels, eventsContainer.PropagationEditing ? eventsContainer.EventTypeToPropagate : -1);
+
+        if (position == null)
         {
-            if (eventData._type == eventsContainer.EventTypeToPropagate)
-            {
-                if (eventData._customData != null &&
-                    eventData._customData.Count > 0 &&
-                    eventData._customData.HasKey("_propID")
-                    && eventData._customData["_propID"].IsNumber)
-                {
-                    transform.localPosition = new Vector3(
-                        eventData._customData["_propID"] + 1.5f,
-                        0.5f,
-                        eventData._time * EditorScaleController.EditorScale
-                    );
-                }
-                else
-                {
-                    transform.localPosition = new Vector3(
-                        0.5f,
-                        0.5f,
-                        eventData._time * EditorScaleController.EditorScale
-                    );
-                }
-            }
-            else
-            {
-                SafeSetActive(false);
-                transform.localPosition = new Vector3(
-                    -0.5f,
-                    0.5f,
-                    eventData._time * EditorScaleController.EditorScale
-                );
-            }
+            SafeSetActive(false);
         }
         else
         {
             transform.localPosition = new Vector3(
-                labels.EventTypeToLaneId(eventData._type) + 0.5f,
-                0.5f,
+                position?.x ?? 0,
+                position?.y ?? 0,
                 eventData._time * EditorScaleController.EditorScale
             );
         }

--- a/Assets/__Scripts/Map/Events/BeatmapEventContainer.cs
+++ b/Assets/__Scripts/Map/Events/BeatmapEventContainer.cs
@@ -58,7 +58,7 @@ public class BeatmapEventContainer : BeatmapObjectContainer {
 
     public override void UpdateGridPosition()
     {
-        var position = eventData.GetPosisition(labels, eventsContainer.PropagationEditing ? eventsContainer.EventTypeToPropagate : -1);
+        var position = eventData.GetPosition(labels, eventsContainer.PropagationEditing ? eventsContainer.EventTypeToPropagate : -1);
 
         if (position == null)
         {

--- a/Assets/__Scripts/Map/Events/MapEvent.cs
+++ b/Assets/__Scripts/Map/Events/MapEvent.cs
@@ -76,7 +76,7 @@ public class MapEvent : BeatmapObject {
         return null;
     }
 
-    public Vector2? GetPosisition(CreateEventTypeLabels labels, int prop)
+    public Vector2? GetPosition(CreateEventTypeLabels labels, int prop)
     {
         if (prop >= 0)
         {

--- a/Assets/__Scripts/Map/Events/MapEvent.cs
+++ b/Assets/__Scripts/Map/Events/MapEvent.cs
@@ -76,6 +76,41 @@ public class MapEvent : BeatmapObject {
         return null;
     }
 
+    public Vector2? GetPosisition(CreateEventTypeLabels labels, int prop)
+    {
+        if (prop >= 0)
+        {
+            if (_type == prop)
+            {
+                if (_customData != null &&
+                    _customData.Count > 0 &&
+                    _customData.HasKey("_propID")
+                    && _customData["_propID"].IsNumber)
+                {
+                    return new Vector2(
+                        _customData["_propID"] + 1.5f,
+                        0.5f
+                    );
+                }
+                else
+                {
+                    return new Vector2(
+                        0.5f,
+                        0.5f
+                    );
+                }
+            }
+            return null;
+        }
+        else
+        {
+            return new Vector2(
+                labels.EventTypeToLaneId(_type) + 0.5f,
+                0.5f
+            );
+        }
+    }
+
     public bool IsRotationEvent => _type == EVENT_TYPE_EARLY_ROTATION || _type == EVENT_TYPE_LATE_ROTATION;
     public bool IsRingEvent => _type == EVENT_TYPE_RINGS_ROTATE || _type == EVENT_TYPE_RINGS_ZOOM;
     public bool IsLaserSpeedEvent => _type == EVENT_TYPE_LEFT_LASERS_SPEED || _type == EVENT_TYPE_RIGHT_LASERS_SPEED;

--- a/Assets/__Scripts/Map/IBeatmapObjectBounds.cs
+++ b/Assets/__Scripts/Map/IBeatmapObjectBounds.cs
@@ -1,0 +1,6 @@
+﻿using UnityEngine;
+
+public interface IBeatmapObjectBounds
+{
+    Vector2 GetCenter();
+}

--- a/Assets/__Scripts/Map/IBeatmapObjectBounds.cs.meta
+++ b/Assets/__Scripts/Map/IBeatmapObjectBounds.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 12268c052fab0c4478605fe410816fcb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/__Scripts/Map/Notes/BeatmapNote.cs
+++ b/Assets/__Scripts/Map/Notes/BeatmapNote.cs
@@ -3,7 +3,7 @@ using System;
 using UnityEngine;
 
 [Serializable]
-public class BeatmapNote : BeatmapObject
+public class BeatmapNote : BeatmapObject, IBeatmapObjectBounds
 {
 
     public const int LINE_INDEX_FAR_LEFT = 0;
@@ -92,6 +92,11 @@ public class BeatmapNote : BeatmapObject
         }
 
         return new Vector2(position, layer);
+    }
+
+    public Vector2 GetCenter()
+    {
+        return GetPosition() + new Vector2(0.5f, 0.5f);
     }
 
     protected override bool IsConflictingWithObjectAtSameTime(BeatmapObject other, bool deletion)

--- a/Assets/__Scripts/Map/Obstacles/BeatmapObstacle.cs
+++ b/Assets/__Scripts/Map/Obstacles/BeatmapObstacle.cs
@@ -3,7 +3,7 @@ using System;
 using UnityEngine;
 
 [Serializable]
-public class BeatmapObstacle : BeatmapObject
+public class BeatmapObstacle : BeatmapObject, IBeatmapObjectBounds
 {
 
     //These are uhh, assumptions...

--- a/Assets/__Scripts/Map/Obstacles/BeatmapObstacle.cs
+++ b/Assets/__Scripts/Map/Obstacles/BeatmapObstacle.cs
@@ -10,6 +10,9 @@ public class BeatmapObstacle : BeatmapObject, IBeatmapObjectBounds
     public const int VALUE_FULL_BARRIER = 0;
     public const int VALUE_HIGH_BARRIER = 1;
 
+    public static readonly float MAPPINGEXTENSIONS_START_HEIGHT_MULTIPLIER = 1.35f;
+    public static readonly float MAPPINGEXTENSIONS_UNITS_TO_FULL_HEIGHT_WALL = 1000 / 3.5f;
+
     /*
      * Obstacle Logic
      */
@@ -94,13 +97,13 @@ public class BeatmapObstacle : BeatmapObject, IBeatmapObjectBounds
         else if (_type >= 1000 && _type <= 4000)
         {
             startHeight = 0; //start height = floor
-            height = ((float)_type - 1000) / BeatmapObstacleContainer.MAPPINGEXTENSIONS_UNITS_TO_FULL_HEIGHT_WALL; //1000 = no height, 2000 = full height
+            height = ((float)_type - 1000) / MAPPINGEXTENSIONS_UNITS_TO_FULL_HEIGHT_WALL; //1000 = no height, 2000 = full height
         }
         else if (_type > 4000)
         {
             float modifiedType = _type - 4001;
-            startHeight = modifiedType % 1000 / BeatmapObstacleContainer.MAPPINGEXTENSIONS_UNITS_TO_FULL_HEIGHT_WALL * BeatmapObstacleContainer.MAPPINGEXTENSIONS_START_HEIGHT_MULTIPLIER;
-            height = modifiedType / 1000 / BeatmapObstacleContainer.MAPPINGEXTENSIONS_UNITS_TO_FULL_HEIGHT_WALL;
+            startHeight = modifiedType % 1000 / MAPPINGEXTENSIONS_UNITS_TO_FULL_HEIGHT_WALL * MAPPINGEXTENSIONS_START_HEIGHT_MULTIPLIER;
+            height = modifiedType / 1000 / MAPPINGEXTENSIONS_UNITS_TO_FULL_HEIGHT_WALL;
         }
 
         // NE

--- a/Assets/__Scripts/Map/Obstacles/BeatmapObstacleContainer.cs
+++ b/Assets/__Scripts/Map/Obstacles/BeatmapObstacleContainer.cs
@@ -3,8 +3,8 @@ using UnityEngine;
 
 public class BeatmapObstacleContainer : BeatmapObjectContainer {
 
-    private static readonly float MAPPINGEXTENSIONS_START_HEIGHT_MULTIPLIER = 1.35f;
-    private static readonly float MAPPINGEXTENSIONS_UNITS_TO_FULL_HEIGHT_WALL = 1000 / 3.5f;
+    public static readonly float MAPPINGEXTENSIONS_START_HEIGHT_MULTIPLIER = 1.35f;
+    public static readonly float MAPPINGEXTENSIONS_UNITS_TO_FULL_HEIGHT_WALL = 1000 / 3.5f;
 
     public override BeatmapObject objectData { get => obstacleData; set => obstacleData = (BeatmapObstacle)value; }
 
@@ -26,11 +26,6 @@ public class BeatmapObstacleContainer : BeatmapObjectContainer {
 
     public override void UpdateGridPosition()
     {
-        //Defining initial values here.
-        float position = obstacleData._lineIndex - 2f; //Line index
-        float startHeight = obstacleData._type == BeatmapObstacle.VALUE_FULL_BARRIER ? 0 : 1.5f;
-        float height = obstacleData._type == BeatmapObstacle.VALUE_FULL_BARRIER ? 3.5f : 2;
-        float width = obstacleData._width;
         float duration = obstacleData._duration;
         Vector3 localRotation = Vector3.zero;
 
@@ -54,45 +49,10 @@ public class BeatmapObstacleContainer : BeatmapObjectContainer {
 
         duration *= EditorScaleController.EditorScale; // Apply Editor Scale here since it can be overwritten by NE _scale Z
 
-        //Kyle can go hyuck himself for this weird ME custom walls format (It aint even accurate on GitHub LULW)
-        if (obstacleData._lineIndex >= 1000)
-            position = (((float)obstacleData._lineIndex - 1000) / 1000f) - 2f;
-        else if (obstacleData._lineIndex <= -1000)
-            position = ((float)obstacleData._lineIndex - 1000) / 1000f;
-
-        if (obstacleData._width >= 1000) width = ((float)obstacleData._width - 1000) / 1000;
-        if (obstacleData._type > 1 && obstacleData._type < 1000)
-        {
-            startHeight = obstacleData._type / (750 / 3.5f); //start height 750 == standard wall height
-            height = 3.5f;
-        }
-        else if (obstacleData._type >= 1000 && obstacleData._type <= 4000)
-        {
-            startHeight = 0; //start height = floor
-            height = ((float)obstacleData._type - 1000) / MAPPINGEXTENSIONS_UNITS_TO_FULL_HEIGHT_WALL; //1000 = no height, 2000 = full height
-        }
-        else if (obstacleData._type > 4000)
-        {
-            float modifiedType = obstacleData._type - 4001;
-            startHeight = modifiedType % 1000 / MAPPINGEXTENSIONS_UNITS_TO_FULL_HEIGHT_WALL * MAPPINGEXTENSIONS_START_HEIGHT_MULTIPLIER;
-            height = modifiedType / 1000 / MAPPINGEXTENSIONS_UNITS_TO_FULL_HEIGHT_WALL;
-        }
-
-        //Just look at the difference in code complexity for Mapping Extensions support and Noodle Extensions support.
-        //Hot damn.
         if (obstacleData._customData != null)
         {
-            if (obstacleData._customData.HasKey("_position"))
-            {
-                Vector2 wallPos = obstacleData._customData["_position"]?.ReadVector2() ?? Vector2.zero;
-                position = wallPos.x;
-                startHeight = wallPos.y;
-            }
             if (obstacleData._customData.HasKey("_scale"))
             {
-                Vector2 wallSize = obstacleData._customData["_scale"]?.ReadVector2() ?? Vector2.one;
-                width = wallSize.x;
-                height = wallSize.y;
                 if (obstacleData._customData["_scale"].Count > 2) //Apparently scale supports Z now, ok
                 {
                     duration = obstacleData._customData["_scale"]?.ReadVector3().z ?? duration;
@@ -118,20 +78,22 @@ public class BeatmapObstacleContainer : BeatmapObjectContainer {
             }
         }
 
+        var bounds = obstacleData.GetShape();
+
         transform.localPosition = new Vector3(
-            position,
-            startHeight,
+            bounds.Position,
+            bounds.StartHeight,
             obstacleData._time * EditorScaleController.EditorScale
             );
         transform.localScale = new Vector3(
-            width,
-            height,
+            bounds.Width,
+            bounds.Height,
             duration
             );
         if (localRotation != Vector3.zero)
         {
             transform.localEulerAngles = Vector3.zero;
-            Vector3 side = transform.right.normalized * (width / 2);
+            Vector3 side = transform.right.normalized * (bounds.Width / 2);
             Vector3 rectWorldPos = transform.position + side;
 
             transform.RotateAround(rectWorldPos, transform.right, localRotation.x);

--- a/Assets/__Scripts/Map/Obstacles/BeatmapObstacleContainer.cs
+++ b/Assets/__Scripts/Map/Obstacles/BeatmapObstacleContainer.cs
@@ -3,9 +3,6 @@ using UnityEngine;
 
 public class BeatmapObstacleContainer : BeatmapObjectContainer {
 
-    public static readonly float MAPPINGEXTENSIONS_START_HEIGHT_MULTIPLIER = 1.35f;
-    public static readonly float MAPPINGEXTENSIONS_UNITS_TO_FULL_HEIGHT_WALL = 1000 / 3.5f;
-
     public override BeatmapObject objectData { get => obstacleData; set => obstacleData = (BeatmapObstacle)value; }
 
     [SerializeField] private TracksManager manager;

--- a/Assets/__Scripts/Map/Obstacles/ObstacleBounds.cs
+++ b/Assets/__Scripts/Map/Obstacles/ObstacleBounds.cs
@@ -1,0 +1,15 @@
+﻿public class ObstacleBounds
+{
+    public float Width { get; private set; }
+    public float Height { get; private set; }
+    public float Position { get; private set; }
+    public float StartHeight { get; private set; }
+
+    public ObstacleBounds(float width, float height, float position, float startHeight)
+    {
+        Width = width;
+        Height = height;
+        Position = position;
+        StartHeight = startHeight;
+    }
+}

--- a/Assets/__Scripts/Map/Obstacles/ObstacleBounds.cs.meta
+++ b/Assets/__Scripts/Map/Obstacles/ObstacleBounds.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e4b452e25ce040243a457d0d333e9253
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/__Scripts/MapEditor/Mapping/Selection/BoxSelectionPlacementController.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/Selection/BoxSelectionPlacementController.cs
@@ -142,7 +142,7 @@ public class BoxSelectionPlacementController : PlacementController<MapEvent, Bea
                 }
                 else if (bo is MapEvent evt)
                 {
-                    var position = evt.GetPosisition(labels, eventsContainer.PropagationEditing ? eventsContainer.EventTypeToPropagate : -1);
+                    var position = evt.GetPosition(labels, eventsContainer.PropagationEditing ? eventsContainer.EventTypeToPropagate : -1);
 
                     // Not visible = notselectable
                     if (position == null) return;

--- a/Assets/__Scripts/MapEditor/Mapping/Selection/BoxSelectionPlacementController.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/Selection/BoxSelectionPlacementController.cs
@@ -32,21 +32,56 @@ public class BoxSelectionPlacementController : PlacementController<MapEvent, Bea
 
     public override int PlacementXMax => int.MaxValue;
 
+    public Bounds bounds = default;
+    public CustomEventsContainer customCollection;
+    public EventsContainer eventsContainer;
+    public CreateEventTypeLabels labels;
+
+    // And I thought generics would make this method cleaner
+    private void TestForType<T, BO, BOC, BOCC>(RaycastHit hit, BeatmapObject.Type type) where T : PlacementController<BO, BOC, BOCC> where BO : BeatmapObject where BOC : BeatmapObjectContainer where BOCC : BeatmapObjectContainerCollection
+    {
+        var evtPlacement = hit.transform.GetComponentInParent<T>();
+        if (evtPlacement != null)
+        {
+            SelectedTypes.Add(type);
+
+            var gridChild = evtPlacement.GetComponent<GridChild>();
+
+            var boundLocal = evtPlacement.GetComponentsInChildren<Renderer>().FirstOrDefault(it => it.name == "Grid X").bounds;
+            if (bounds == default)
+            {
+                bounds = boundLocal;
+            }
+            else
+            {
+                // Probably a bad idea but why not drag between lanes
+                bounds.Encapsulate(boundLocal);
+            }
+        }
+    }
+
     public override void OnPhysicsRaycast(RaycastHit hit, Vector3 transformedPoint)
     {
         previousHit = hit;
         transformed = transformedPoint;
+
         Vector3 roundedHit = parentTrack.InverseTransformPoint(hit.point);
-        roundedHit = new Vector3(Mathf.Ceil(roundedHit.x), Mathf.Ceil(roundedHit.y), roundedHit.z);
+        roundedHit = new Vector3(
+            Mathf.Ceil(Math.Min(Math.Max(roundedHit.x, bounds.min.x + 0.01f), bounds.max.x)),
+            Mathf.Ceil(Math.Min(Math.Max(roundedHit.y, 0.01f), 3f)),
+            roundedHit.z
+        );
         instantiatedContainer.transform.localPosition = roundedHit - new Vector3(0.5f, 1, 0);
         if (!IsSelecting)
         {
+            bounds = default;
             SelectedTypes.Clear();
-            if (hit.transform.GetComponentInParent<EventPlacement>()) SelectedTypes.Add(BeatmapObject.Type.EVENT);
-            if (hit.transform.GetComponentInParent<NotePlacement>()) SelectedTypes.Add(BeatmapObject.Type.NOTE);
-            if (hit.transform.GetComponentInParent<ObstaclePlacement>()) SelectedTypes.Add(BeatmapObject.Type.OBSTACLE);
-            if (hit.transform.GetComponentInParent<CustomEventPlacement>()) SelectedTypes.Add(BeatmapObject.Type.CUSTOM_EVENT);
-            if (hit.transform.GetComponentInParent<BPMChangePlacement>()) SelectedTypes.Add(BeatmapObject.Type.BPM_CHANGE);
+            TestForType<EventPlacement, MapEvent, BeatmapEventContainer, EventsContainer>(hit, BeatmapObject.Type.EVENT);
+            TestForType<NotePlacement, BeatmapNote, BeatmapNoteContainer, NotesContainer>(hit, BeatmapObject.Type.NOTE);
+            TestForType<ObstaclePlacement, BeatmapObstacle, BeatmapObstacleContainer, ObstaclesContainer>(hit, BeatmapObject.Type.OBSTACLE);
+            TestForType<CustomEventPlacement, BeatmapCustomEvent, BeatmapCustomEventContainer, CustomEventsContainer>(hit, BeatmapObject.Type.CUSTOM_EVENT);
+            TestForType<BPMChangePlacement, BeatmapBPMChange, BeatmapBPMChangeContainer, BPMChangesContainer>(hit, BeatmapObject.Type.BPM_CHANGE);
+
             instantiatedContainer.transform.localScale = Vector3.right + Vector3.up;
             Vector3 localScale = instantiatedContainer.transform.localScale;
             Vector3 localpos = instantiatedContainer.transform.localPosition;
@@ -83,13 +118,55 @@ public class BoxSelectionPlacementController : PlacementController<MapEvent, Bea
             newLocalScale = new Vector3(newLocalScale.x, newLocalScaleY, newLocalScale.z);
             instantiatedContainer.transform.localScale = newLocalScale;
 
-            OverlapBox((containerBoye) =>
+            float startBeat = instantiatedContainer.transform.localPosition.z / EditorScaleController.EditorScale;
+            float endBeat = (instantiatedContainer.transform.localPosition.z + newLocalScale.z) / EditorScaleController.EditorScale;
+            if (startBeat > endBeat) (startBeat, endBeat) = (endBeat, startBeat);
+
+            SelectionController.ForEachObjectBetweenTimeByGroup(startBeat, endBeat, true, true, true, (bocc, bo) =>
             {
-                if (!alreadySelected.Contains(containerBoye.objectData) && selected.Add(containerBoye.objectData))
+                if (!SelectedTypes.Contains(bo.beatmapType)) return; // Must be a type we can select
+
+                var left = instantiatedContainer.transform.localPosition.x + instantiatedContainer.transform.localScale.x;
+                var right = instantiatedContainer.transform.localPosition.x;
+                if (right < left) (left, right) = (right, left);
+
+                var top = instantiatedContainer.transform.localPosition.y + instantiatedContainer.transform.localScale.y;
+                var bottom = instantiatedContainer.transform.localPosition.y;
+                if (top < bottom) (top, bottom) = (bottom, top);
+
+                if (bo is BeatmapNote note)
                 {
-                    SelectionController.Select(containerBoye.objectData, true, false, false);
+                    var p = note.GetPosition();
+                    p += new Vector2(0.5f, 0.5f);
+                    if (p.x < left || p.x > right || p.y < bottom || p.y >= top) return;
+                }
+                else if (bo is BeatmapObstacle wall)
+                {
+                    var p = wall.GetCenter();
+                    if (p.x < left || p.x > right || p.y < bottom || p.y >= top) return;
+                }
+                else if (bo is MapEvent evt)
+                {
+                    var position = evt.GetPosisition(labels, eventsContainer.PropagationEditing ? eventsContainer.EventTypeToPropagate : -1);
+
+                    // Not visible = notselectable
+                    if (position == null) return;
+
+                    var p = new Vector2(position?.x + bounds.min.x ?? 0, position?.y ?? 0);
+                    if (p.x < left || p.x > right || p.y < bottom || p.y >= top) return;
+                }
+                else if (bo is BeatmapCustomEvent custom)
+                {
+                    var p = new Vector2(customCollection.CustomEventTypes.IndexOf(custom._type) + bounds.min.x + 0.5f, 0.5f);
+                    if (p.x < left || p.x > right || p.y < bottom || p.y >= top) return;
+                }
+
+                if (!alreadySelected.Contains(bo) && selected.Add(bo))
+                {
+                    SelectionController.Select(bo, true, false, false);
                 }
             });
+
             foreach (BeatmapObject combinedObj in SelectionController.SelectedObjects.ToArray())
             {
                 if (!selected.Contains(combinedObj) && !alreadySelected.Contains(combinedObj))
@@ -125,27 +202,6 @@ public class BoxSelectionPlacementController : PlacementController<MapEvent, Bea
             StartCoroutine(WaitABitFuckOffOtherPlacementControllers());
             SelectionController.RefreshSelectionMaterial(selected.Any());
             OnPhysicsRaycast(previousHit, transformed);
-        }
-    }
-
-    private void OverlapBox(Action<BeatmapObjectContainer> action)
-    {
-        //Big brain boye does big brain things with big brain box
-        BoxCollider boxyBoy = instantiatedContainer.GetComponent<BoxCollider>();
-        Bounds bounds = new Bounds();
-        bounds.center = boxyBoy.bounds.center;
-        Vector3 absoluteLossyScale = new Vector3(
-            Mathf.Abs(instantiatedContainer.transform.lossyScale.x),
-            Mathf.Abs(instantiatedContainer.transform.lossyScale.y),
-            Mathf.Abs(instantiatedContainer.transform.lossyScale.z)
-            );
-        bounds.size = absoluteLossyScale / 2f;
-        Collider[] boxyBoyHitsStuffTM = Physics.OverlapBox(bounds.center, bounds.size, instantiatedContainer.transform.rotation, 1 << 9);
-        foreach (Collider collider in boxyBoyHitsStuffTM)
-        {
-            BeatmapObjectContainer containerBoye = collider.gameObject.GetComponentInParent<BeatmapObjectContainer>();
-            if (!SelectedTypes.Contains(containerBoye.objectData.beatmapType)) continue;
-            action?.Invoke(containerBoye);
         }
     }
 

--- a/Assets/__Scripts/MapEditor/Mapping/Selection/BoxSelectionPlacementController.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/Selection/BoxSelectionPlacementController.cs
@@ -40,14 +40,12 @@ public class BoxSelectionPlacementController : PlacementController<MapEvent, Bea
     // And I thought generics would make this method cleaner
     private void TestForType<T>(RaycastHit hit, BeatmapObject.Type type) where T : MonoBehaviour
     {
-        var evtPlacement = hit.transform.GetComponentInParent<T>();
-        if (evtPlacement != null)
+        var placementObj = hit.transform.GetComponentInParent<T>();
+        if (placementObj != null)
         {
             SelectedTypes.Add(type);
 
-            var gridChild = evtPlacement.GetComponent<GridChild>();
-
-            var boundLocal = evtPlacement.GetComponentsInChildren<Renderer>().FirstOrDefault(it => it.name == "Grid X").bounds;
+            var boundLocal = placementObj.GetComponentsInChildren<Renderer>().FirstOrDefault(it => it.name == "Grid X").bounds;
             if (bounds == default)
             {
                 bounds = boundLocal;

--- a/Assets/__Scripts/Platforms/PlatformColors.cs.meta
+++ b/Assets/__Scripts/Platforms/PlatformColors.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fabef0716cf6f7a44800c21ab104b1ad
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Refactor selection box to not use a BoxColider as now that objects are not loaded all the time this has funky results.

Instead I've implemented ways of working out where the centre of most objects are and a not terrible way of working out if they are within the bounding box.

The bounding box is also itself bounded to the track being selected, no more can you move your cursor across tracks only to find the filter doesn't allow that anyway.

The biggest impact here is that, instead of selecting things if any part of them is within the bounding area, things are only selected when over half of them is in. I think this only really affects precision placement. Thoughts welcome.