### PR TITLE
Small fix/optimisation

### DIFF
--- a/Assets/__Scripts/MapEditor/Grid/CreateEventTypeLabels.cs
+++ b/Assets/__Scripts/MapEditor/Grid/CreateEventTypeLabels.cs
@@ -12,7 +12,8 @@ public class CreateEventTypeLabels : MonoBehaviour {
     public Transform[] EventGrid;
     [SerializeField] private DarkThemeSO darkTheme;
     public RotationCallbackController RotationCallback;
-    [HideInInspector] public int NoRotationLaneOffset => RotationCallback.IsActive ? 0 : -2;
+    private bool loadedWithRotationEvents = false;
+    [HideInInspector] public int NoRotationLaneOffset => loadedWithRotationEvents || RotationCallback.IsActive ? 0 : -2;
 
     private LightsManager[] LightingManagers;
 
@@ -20,6 +21,7 @@ public class CreateEventTypeLabels : MonoBehaviour {
 
 	// Use this for initialization
 	void Start () {
+        loadedWithRotationEvents = BeatSaberSongContainer.Instance.map._events.Any(i => i.IsRotationEvent);
         LoadInitialMap.PlatformLoadedEvent += PlatformLoaded;
 	}
 


### PR DESCRIPTION
Show rotation lanes even outside of 360/90 maps if rotation events exist

Removed some more linq because it is "slow" and called 100s of times when scrolling through the map and cache the result of 1/pow(10, 3) ~0.15ms -> 0.05ms in deep profiling