### PR TITLE
Prop shift optimisations

### DIFF
--- a/Assets/__Scripts/BeatmapActions/Beatmap Actions/BeatmapObjectModifiedAction.cs
+++ b/Assets/__Scripts/BeatmapActions/Beatmap Actions/BeatmapObjectModifiedAction.cs
@@ -4,11 +4,12 @@
     private BeatmapObject editedData;
     private BeatmapObjectContainerCollection collection;
 
-    public BeatmapObjectModifiedAction(BeatmapObject edited, BeatmapObject original, string comment = "No comment.") : base(null, comment)
+    public BeatmapObjectModifiedAction(BeatmapObject edited, BeatmapObject original, string comment = "No comment.", bool rewrapOriginal = true) : base(null, comment)
     {
         collection = BeatmapObjectContainerCollection.GetCollectionForType(original.beatmapType);
         editedData = BeatmapObject.GenerateCopy(edited);
-        originalData = BeatmapObject.GenerateCopy(original);
+
+        originalData = rewrapOriginal ? BeatmapObject.GenerateCopy(original) : original;
     }
 
     public override void Undo(BeatmapActionContainer.BeatmapActionParams param)
@@ -28,4 +29,6 @@
         collection.SpawnObject(editedData, false);
         SelectionController.Select(editedData, false, true, false);
     }
+
+    public BeatmapObject GetEdited() => editedData;
 }


### PR DESCRIPTION
So first we call UpdateGridPosition, then set PropagationEditing which updates the locations of all the objects and then we call RefreshPool(true) which recycles all the containers we just made sure were in the right places. Seems efficient.

This is worst when in prop view as the locations of all the events are updated _for each event being moved_

Moved to a plinq which may be slower for small number of events, but fast enough for action from user input.

Also cut down on calls to generate copy, as after this recent commit two calls here are superfluous https://github.com/Caeden117/ChroMapper/commit/0a177c1c3abb1045efdc783be3d648f1fa8774e1