### PR TITLE
Bug fix train has arrived

### DIFF
--- a/Assets/HSVPicker/UI/HexColorField.cs
+++ b/Assets/HSVPicker/UI/HexColorField.cs
@@ -31,7 +31,7 @@ public class HexColorField : MonoBehaviour
     private void TextValueChanged(string arg0)
     {
         if (!hexInputField.isFocused) return;
-        CMInputCallbackInstaller.DisableActionMaps(typeof(CMInput).GetNestedTypes().Where(x => x.IsInterface));
+        CMInputCallbackInstaller.DisableActionMaps(typeof(HexColorField), typeof(CMInput).GetNestedTypes().Where(x => x.IsInterface));
     }
 
     private void UpdateHex(Color newColor)
@@ -41,7 +41,7 @@ public class HexColorField : MonoBehaviour
 
     private void UpdateColor(string newHex)
     {
-        CMInputCallbackInstaller.ClearDisabledActionMaps(typeof(CMInput).GetNestedTypes().Where(x => x.IsInterface));
+        CMInputCallbackInstaller.ClearDisabledActionMaps(typeof(HexColorField), typeof(CMInput).GetNestedTypes().Where(x => x.IsInterface));
         Color color;
         if (!newHex.StartsWith("#"))
             newHex = "#"+newHex;

--- a/Assets/__Scripts/Input/ChroMapper/CMInputCallbackInstaller.cs
+++ b/Assets/__Scripts/Input/ChroMapper/CMInputCallbackInstaller.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.InputSystem;
 using UnityEngine.SceneManagement;
@@ -27,8 +26,8 @@ public class CMInputCallbackInstaller : MonoBehaviour
 
     //Because I would like all actions to fully complete before being disabled,
     //we will use a queue that will then be cleared and processed on the next frame.
-    private List<Type> queuedToDisable = new List<Type>();
-    private List<Type> queuedToEnable = new List<Type>();
+    private List<QueueInfo> queuedToDisable = new List<QueueInfo>();
+    private List<QueueInfo> queuedToEnable = new List<QueueInfo>();
 
     private List<Transform> persistentObjects = new List<Transform>();
 
@@ -38,16 +37,16 @@ public class CMInputCallbackInstaller : MonoBehaviour
     private CMInput input; //Singular CMInput object that will be shared to every class that requires it.
     private BindingFlags bindingFlags = BindingFlags.Public | BindingFlags.Instance | BindingFlags.InvokeMethod;
 
-    public static void DisableActionMaps(IEnumerable<Type> interfaceTypesToDisable)
+    public static void DisableActionMaps(Type you, IEnumerable<Type> interfaceTypesToDisable)
     {
         //To preserve actions occuring on the same frame, we
         //add it to a queue thats cleared and processed on the next frame.
-        instance.queuedToDisable.AddRange(interfaceTypesToDisable);
+        instance.queuedToDisable.Add(new QueueInfo(you, interfaceTypesToDisable));
     }
 
-    public static void ClearDisabledActionMaps(IEnumerable<Type> interfaceTypesToEnable)
+    public static void ClearDisabledActionMaps(Type you, IEnumerable<Type> interfaceTypesToEnable)
     {
-        instance.queuedToEnable.AddRange(interfaceTypesToEnable);
+        instance.queuedToEnable.Add(new QueueInfo(you, interfaceTypesToEnable));
     }
 
     public static bool IsActionMapDisabled(Type actionMap) => instance.disabledEventHandlers.Any(x => x.InterfaceType == actionMap);
@@ -101,29 +100,34 @@ public class CMInputCallbackInstaller : MonoBehaviour
     {
         if (queuedToDisable.Any())
         {
-            foreach (Type interfaceType in queuedToDisable)
+            foreach (QueueInfo queueInfo in queuedToDisable)
             {
-                foreach (EventHandler eventHandler in allEventHandlers.Where(x => x.InterfaceType == interfaceType))
+                foreach (Type interfaceType in queueInfo.toChange)
                 {
-                    eventHandler.NumberOfBlockers++;
-                    if (eventHandler.IsDisabled) continue;
-                    eventHandler.DisableEventHandler();
-                    disabledEventHandlers.Add(eventHandler);
+                    foreach (EventHandler eventHandler in allEventHandlers.Where(x => x.InterfaceType == interfaceType))
+                    {
+                        eventHandler.Blockers.Add(queueInfo.owner);
+                        if (eventHandler.IsDisabled) continue;
+                        eventHandler.DisableEventHandler();
+                        disabledEventHandlers.Add(eventHandler);
+                    }
                 }
             }
             queuedToDisable.Clear();
         }
         if (queuedToEnable.Any())
         {
-            foreach (Type interfaceType in queuedToEnable)
+            foreach (QueueInfo queueInfo in queuedToEnable)
             {
-                foreach (EventHandler eventHandler in allEventHandlers.Where(x => x.InterfaceType == interfaceType && x.IsDisabled))
+                foreach (Type interfaceType in queueInfo.toChange)
                 {
-                    eventHandler.NumberOfBlockers--;
-                    if (eventHandler.NumberOfBlockers > 0) continue;
-                    eventHandler.NumberOfBlockers = 0;
-                    eventHandler.EnableEventHandler();
-                    disabledEventHandlers.Remove(eventHandler);
+                    foreach (EventHandler eventHandler in allEventHandlers.Where(x => x.InterfaceType == interfaceType && x.IsDisabled))
+                    {
+                        eventHandler.Blockers.Remove(queueInfo.owner);
+                        if (eventHandler.Blockers.Count > 0) continue;
+                        eventHandler.EnableEventHandler();
+                        disabledEventHandlers.Remove(eventHandler);
+                    }
                 }
             }
             queuedToEnable.Clear();
@@ -276,7 +280,7 @@ public class CMInputCallbackInstaller : MonoBehaviour
         public object EventObject;
         public Delegate Handler;
         public Type InterfaceType;
-        public int NumberOfBlockers = 0;
+        public HashSet<Type> Blockers = new HashSet<Type>();
 
         public EventHandler(EventInfo eventInfo, object eventObject, Delegate handler, Type interfaceType)
         {
@@ -301,6 +305,18 @@ public class CMInputCallbackInstaller : MonoBehaviour
         public override int GetHashCode()
         {
             return InterfaceType.GetHashCode();
+        }
+    }
+
+    private class QueueInfo
+    {
+        public Type owner;
+        public IEnumerable<Type> toChange;
+
+        public QueueInfo(Type owner, IEnumerable<Type> toChange)
+        {
+            this.owner = owner;
+            this.toChange = toChange;
         }
     }
 }

--- a/Assets/__Scripts/MapEditor/CameraController.cs
+++ b/Assets/__Scripts/MapEditor/CameraController.cs
@@ -163,11 +163,11 @@ public class CameraController : MonoBehaviour, CMInput.ICameraActions {
         canMoveCamera = context.performed;
         if (canMoveCamera)
         {
-            CMInputCallbackInstaller.DisableActionMaps(actionMapsDisabledWhileMoving);
+            CMInputCallbackInstaller.DisableActionMaps(typeof(CameraController), actionMapsDisabledWhileMoving);
         }
         else if (context.canceled)
         {
-            CMInputCallbackInstaller.ClearDisabledActionMaps(actionMapsDisabledWhileMoving);
+            CMInputCallbackInstaller.ClearDisabledActionMaps(typeof(CameraController), actionMapsDisabledWhileMoving);
         }
     }
 

--- a/Assets/__Scripts/MapEditor/Input/BeatmapInputController.cs
+++ b/Assets/__Scripts/MapEditor/Input/BeatmapInputController.cs
@@ -51,7 +51,7 @@ public class BeatmapInputController<T> : MonoBehaviour, CMInput.IBeatmapObjectsA
     protected void RaycastFirstObject(out T firstObject)
     {
         Ray ray = mainCamera.ScreenPointToRay(mousePosition);
-        if (Physics.Raycast(ray, out RaycastHit hit, 99, 1 << 9))
+        if (Physics.Raycast(ray, out RaycastHit hit, 99, 1 << 9 | 1 << 11))
         {
             T obj = hit.transform.GetComponentInParent<T>();
             if (obj != null)

--- a/Assets/__Scripts/MapEditor/Mapping/KeybindsController.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/KeybindsController.cs
@@ -63,11 +63,11 @@ public class KeybindsController : MonoBehaviour, CMInput.IUtilsActions
             IEnumerable<Type> cmtypes = typeof(CMInput).GetNestedTypes().Where(x => x.IsInterface && x != typeof(CMInput.IUtilsActions));
             if (mouseInWindow)
             {
-                CMInputCallbackInstaller.ClearDisabledActionMaps(cmtypes);
+                CMInputCallbackInstaller.ClearDisabledActionMaps(typeof(KeybindsController), cmtypes);
             }
             else
             {
-                CMInputCallbackInstaller.DisableActionMaps(cmtypes);
+                CMInputCallbackInstaller.DisableActionMaps(typeof(KeybindsController), cmtypes);
             }
             IsMouseInWindow = mouseInWindow;
         }

--- a/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/PlacementController.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/PlacementController.cs
@@ -243,6 +243,7 @@ public abstract class PlacementController<BO, BOC, BOCC> : MonoBehaviour, CMInpu
             }
             BeatmapActionContainer.AddAction(action);
         }
+        draggedObjectContainer = null;
         ClickAndDragFinished();
         isDraggingObject = isDraggingObjectAtTime = false;
     }

--- a/Assets/__Scripts/MapEditor/Mapping/Selection/SelectionController.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/Selection/SelectionController.cs
@@ -144,8 +144,13 @@ public class SelectionController : MonoBehaviour, CMInput.ISelectingActions, CMI
     public static void Select(BeatmapObject obj, bool AddsToSelection = false, bool AutomaticallyRefreshes = true, bool AddActionEvent = true)
     {
         if (!AddsToSelection) DeselectAll(); //This SHOULD deselect every object unless you otherwise specify, but it aint working.
+        var collection = BeatmapObjectContainerCollection.GetCollectionForType(obj.beatmapType);
+
+        if (!collection.LoadedObjects.Contains(obj))
+            return;
+
         SelectedObjects.Add(obj);
-        if (BeatmapObjectContainerCollection.GetCollectionForType(obj.beatmapType).LoadedContainers.TryGetValue(obj, out BeatmapObjectContainer container))
+        if (collection.LoadedContainers.TryGetValue(obj, out BeatmapObjectContainer container))
         {
             container.SetOutlineColor(instance.selectedColor);
         }

--- a/Assets/__Scripts/MapEditor/UI/Bookmarks/BookmarkManager.cs
+++ b/Assets/__Scripts/MapEditor/UI/Bookmarks/BookmarkManager.cs
@@ -21,14 +21,14 @@ public class BookmarkManager : MonoBehaviour, CMInput.IBookmarksActions
     private IEnumerator Start()
     {
         yield return new WaitForSeconds(0.1f); //Wait for time
-        foreach(BeatmapBookmark bookmark in BeatSaberSongContainer.Instance.map._bookmarks)
+        bookmarkContainers = BeatSaberSongContainer.Instance.map._bookmarks.Select(bookmark =>
         {
             BookmarkContainer container = Instantiate(bookmarkContainerPrefab, transform).GetComponent<BookmarkContainer>();
             container.name = bookmark._name;
             container.Init(this, bookmark);
             container.RefreshPosition(timelineCanvas.sizeDelta.x + CANVAS_WIDTH_OFFSET);
-            bookmarkContainers.Add(container);
-        }   
+            return container;
+        }).OrderBy(it => it.data._time).ToList();
     }
 
     public void OnCreateNewBookmark(InputAction.CallbackContext context)
@@ -47,7 +47,8 @@ public class BookmarkManager : MonoBehaviour, CMInput.IBookmarksActions
         container.name = newBookmark._name;
         container.Init(this, newBookmark);
         container.RefreshPosition(timelineCanvas.sizeDelta.x + CANVAS_WIDTH_OFFSET);
-        bookmarkContainers.Add(container);
+
+        bookmarkContainers = bookmarkContainers.Append(container).OrderBy(it => it.data._time).ToList();
         BeatSaberSongContainer.Instance.map._bookmarks = bookmarkContainers.Select(x => x.data).ToList();
     }
 

--- a/Assets/__Scripts/MapEditor/UI/Node Editor/NodeEditorController.cs
+++ b/Assets/__Scripts/MapEditor/UI/Node Editor/NodeEditorController.cs
@@ -150,8 +150,8 @@ public class NodeEditorController : MonoBehaviour, CMInput.INodeEditorActions
             if (!nodeEditorInputField.isFocused) return;
             if (!CMInputCallbackInstaller.IsActionMapDisabled(actionMapsDisabled[0]))
             {
-                CMInputCallbackInstaller.DisableActionMaps(new[] { typeof(CMInput.INodeEditorActions) });
-                CMInputCallbackInstaller.ClearDisabledActionMaps(actionMapsDisabled);
+                CMInputCallbackInstaller.DisableActionMaps(typeof(NodeEditorController), new[] { typeof(CMInput.INodeEditorActions) });
+                CMInputCallbackInstaller.DisableActionMaps(typeof(NodeEditorController), actionMapsDisabled);
             }
             BeatmapAction lastAction = BeatmapActionContainer.GetLastAction();
             if (lastAction != null && lastAction is NodeEditorTextChangedAction textChangedAction)
@@ -174,8 +174,8 @@ public class NodeEditorController : MonoBehaviour, CMInput.INodeEditorActions
 
     public void NodeEditor_EndEdit(string nodeText)
     {
-        CMInputCallbackInstaller.ClearDisabledActionMaps(new[] { typeof(CMInput.INodeEditorActions) });
-        CMInputCallbackInstaller.ClearDisabledActionMaps(actionMapsDisabled);
+        CMInputCallbackInstaller.ClearDisabledActionMaps(typeof(NodeEditorController), new[] { typeof(CMInput.INodeEditorActions) });
+        CMInputCallbackInstaller.ClearDisabledActionMaps(typeof(NodeEditorController), actionMapsDisabled);
         try
         {
             if (!isEditing || !IsActive || SelectionController.SelectedObjects.Count != 1) return;
@@ -226,8 +226,8 @@ public class NodeEditorController : MonoBehaviour, CMInput.INodeEditorActions
 
     public void Close()
     {
-        CMInputCallbackInstaller.ClearDisabledActionMaps(new[] { typeof(CMInput.INodeEditorActions) });
-        CMInputCallbackInstaller.ClearDisabledActionMaps(actionMapsDisabled);
+        CMInputCallbackInstaller.ClearDisabledActionMaps(typeof(NodeEditorController), new[] { typeof(CMInput.INodeEditorActions) });
+        CMInputCallbackInstaller.ClearDisabledActionMaps(typeof(NodeEditorController), actionMapsDisabled);
         StartCoroutine(UpdateGroup(false, transform as RectTransform));
         isEditing = false;
     }
@@ -240,14 +240,14 @@ public class NodeEditorController : MonoBehaviour, CMInput.INodeEditorActions
             StopAllCoroutines();
             if (IsActive)
             {
-                CMInputCallbackInstaller.ClearDisabledActionMaps(new[] { typeof(CMInput.INodeEditorActions) });
-                CMInputCallbackInstaller.ClearDisabledActionMaps(actionMapsDisabled);
+                CMInputCallbackInstaller.ClearDisabledActionMaps(typeof(NodeEditorController), new[] { typeof(CMInput.INodeEditorActions) });
+                CMInputCallbackInstaller.ClearDisabledActionMaps(typeof(NodeEditorController), actionMapsDisabled);
                 BeatmapActionContainer.RemoveAllActionsOfType<NodeEditorTextChangedAction>();
             }
             else
             {
                 closeButton.gameObject.SetActive(true);
-                CMInputCallbackInstaller.DisableActionMaps(actionMapsDisabled);
+                CMInputCallbackInstaller.DisableActionMaps(typeof(NodeEditorController), actionMapsDisabled);
             }
             StartCoroutine(UpdateGroup(!IsActive, transform as RectTransform));
         }

--- a/Assets/__Scripts/MapEditor/UI/PauseManager.cs
+++ b/Assets/__Scripts/MapEditor/UI/PauseManager.cs
@@ -15,7 +15,7 @@ public class PauseManager : MonoBehaviour, CMInput.IPauseMenuActions
     private PlatformDescriptor platform;
     [SerializeField] private AutoSaveController saveController;
 
-    private IEnumerable<Type> disabledActionMaps = typeof(CMInput).GetNestedTypes().Where(t => t.IsInterface && t != typeof(CMInput.IUtilsActions));
+    private IEnumerable<Type> disabledActionMaps = typeof(CMInput).GetNestedTypes().Where(t => t.IsInterface && t != typeof(CMInput.IUtilsActions) && t != typeof(CMInput.IPauseMenuActions));
 
     public static bool IsPaused;
 
@@ -40,7 +40,7 @@ public class PauseManager : MonoBehaviour, CMInput.IPauseMenuActions
         IsPaused = !IsPaused;
         if (IsPaused)
         {
-            CMInputCallbackInstaller.DisableActionMaps(disabledActionMaps);
+            CMInputCallbackInstaller.DisableActionMaps(typeof(PauseManager), disabledActionMaps);
             previousUIModeType = uiMode.selectedMode;
             uiMode.SetUIMode(UIModeType.NORMAL, false);
             foreach (LightsManager e in platform.gameObject.GetComponentsInChildren<LightsManager>())
@@ -48,7 +48,7 @@ public class PauseManager : MonoBehaviour, CMInput.IPauseMenuActions
         }
         else
         {
-            CMInputCallbackInstaller.ClearDisabledActionMaps(disabledActionMaps);
+            CMInputCallbackInstaller.ClearDisabledActionMaps(typeof(PauseManager), disabledActionMaps);
             uiMode.SetUIMode(previousUIModeType, false);
         }
         StartCoroutine(TransitionMenu());

--- a/Assets/__Scripts/UI/CM_DialogBox.cs
+++ b/Assets/__Scripts/UI/CM_DialogBox.cs
@@ -30,7 +30,7 @@ public class CM_DialogBox : MonoBehaviour
     {
         if (IsEnabled)
             throw new Exception("Dialog box is already enabled! Please wait until this Dialog Box has been disabled.");
-        CMInputCallbackInstaller.DisableActionMaps(disabledActionMaps);
+        CMInputCallbackInstaller.DisableActionMaps(typeof(CM_DialogBox), disabledActionMaps);
         UpdateGroup(true);
         CameraController.ClearCameraMovement();
 
@@ -90,7 +90,7 @@ public class CM_DialogBox : MonoBehaviour
 
     public void SendResult(int buttonID)
     {
-        CMInputCallbackInstaller.ClearDisabledActionMaps(disabledActionMaps);
+        CMInputCallbackInstaller.ClearDisabledActionMaps(typeof(CM_DialogBox), disabledActionMaps);
         UpdateGroup(false);
         resultAction?.Invoke(buttonID);
     }

--- a/Assets/__Scripts/UI/CM_DialogBox.cs
+++ b/Assets/__Scripts/UI/CM_DialogBox.cs
@@ -16,7 +16,7 @@ public class CM_DialogBox : MonoBehaviour
     private Action<int> resultAction;
 
 
-    private IEnumerable<Type> disabledActionMaps = typeof(CMInput).GetNestedTypes().Where(t => t.IsInterface && t != typeof(CMInput.IUtilsActions));
+    private IEnumerable<Type> disabledActionMaps = typeof(CMInput).GetNestedTypes().Where(t => t.IsInterface && t != typeof(CMInput.IUtilsActions) && t != typeof(CMInput.IMenusExtendedActions));
 
     private void Start()
     {

--- a/Assets/__Scripts/UI/CM_InputBox.cs
+++ b/Assets/__Scripts/UI/CM_InputBox.cs
@@ -14,7 +14,7 @@ public class CM_InputBox : MenuBase
     [SerializeField] private CanvasGroup group;
     private Action<string> resultAction;
 
-    private IEnumerable<Type> disabledActionMaps = typeof(CMInput).GetNestedTypes().Where(t => t.IsInterface && t != typeof(CMInput.IUtilsActions));
+    private IEnumerable<Type> disabledActionMaps = typeof(CMInput).GetNestedTypes().Where(t => t.IsInterface && t != typeof(CMInput.IUtilsActions) && t != typeof(CMInput.IMenusExtendedActions));
 
     public bool IsEnabled => group.alpha == 1;
 

--- a/Assets/__Scripts/UI/CM_InputBox.cs
+++ b/Assets/__Scripts/UI/CM_InputBox.cs
@@ -22,7 +22,7 @@ public class CM_InputBox : MenuBase
     {
         if (IsEnabled)
             throw new Exception("Input box is already enabled! Please wait until this Input Box has been disabled.");
-        CMInputCallbackInstaller.DisableActionMaps(disabledActionMaps);
+        CMInputCallbackInstaller.DisableActionMaps(typeof(CM_InputBox), disabledActionMaps);
         UpdateGroup(true);
         CameraController.ClearCameraMovement();
         UIMessage.text = message;
@@ -40,7 +40,7 @@ public class CM_InputBox : MenuBase
 
     public void SendResult(int buttonID)
     {
-        CMInputCallbackInstaller.ClearDisabledActionMaps(disabledActionMaps);
+        CMInputCallbackInstaller.ClearDisabledActionMaps(typeof(CM_InputBox), disabledActionMaps);
         UpdateGroup(false);
         string res = string.IsNullOrWhiteSpace(InputField.text) ? "" : InputField.text;
         resultAction?.Invoke(buttonID == 0 ? res : null);

--- a/Assets/__Scripts/UI/Contributors/ContributorListItem.cs
+++ b/Assets/__Scripts/UI/Contributors/ContributorListItem.cs
@@ -77,7 +77,7 @@ public class ContributorListItem : MonoBehaviour
         };
 
         string songDir = BeatSaberSongContainer.Instance.song.directory;
-        CMInputCallbackInstaller.DisableActionMaps(new[] { typeof(CMInput.IMenusExtendedActions) });
+        CMInputCallbackInstaller.DisableActionMaps(typeof(ContributorListItem), new[] { typeof(CMInput.IMenusExtendedActions) });
         var paths = StandaloneFileBrowser.OpenFilePanel("Open File", songDir, extensions, false);
         StartCoroutine(ClearDisabledActionMaps());
         if (paths.Length > 0)
@@ -118,7 +118,7 @@ public class ContributorListItem : MonoBehaviour
     private IEnumerator ClearDisabledActionMaps()
     {
         yield return new WaitForEndOfFrame();
-        CMInputCallbackInstaller.ClearDisabledActionMaps(new[] { typeof(CMInput.IMenusExtendedActions) });
+        CMInputCallbackInstaller.ClearDisabledActionMaps(typeof(ContributorListItem), new[] { typeof(CMInput.IMenusExtendedActions) });
     }
 
     private bool FileExistsAlready(string songDir, string fileName)

--- a/Assets/__Scripts/UI/InputBoxFileValidator.cs
+++ b/Assets/__Scripts/UI/InputBoxFileValidator.cs
@@ -72,7 +72,7 @@ public class InputBoxFileValidator : MonoBehaviour
         };
 
         string songDir = BeatSaberSongContainer.Instance.song.directory;
-        CMInputCallbackInstaller.DisableActionMaps(new[] { typeof(CMInput.IMenusExtendedActions) });
+        CMInputCallbackInstaller.DisableActionMaps(typeof(InputBoxFileValidator), new[] { typeof(CMInput.IMenusExtendedActions) });
         var paths = StandaloneFileBrowser.OpenFilePanel("Open File", songDir, exts, false);
         StartCoroutine(ClearDisabledActionMaps());
         if (paths.Length > 0)
@@ -115,7 +115,7 @@ public class InputBoxFileValidator : MonoBehaviour
     private IEnumerator ClearDisabledActionMaps()
     {
         yield return new WaitForEndOfFrame();
-        CMInputCallbackInstaller.ClearDisabledActionMaps(new[] { typeof(CMInput.IMenusExtendedActions) });
+        CMInputCallbackInstaller.ClearDisabledActionMaps(typeof(InputBoxFileValidator), new[] { typeof(CMInput.IMenusExtendedActions) });
     }
 
     private bool FileExistsAlready(string songDir, string fileName)

--- a/Assets/__Scripts/UI/Options/OptionsController.cs
+++ b/Assets/__Scripts/UI/Options/OptionsController.cs
@@ -25,7 +25,7 @@ public class OptionsController : MonoBehaviour
     {
         if (IsActive) return;
         SceneManager.LoadScene(4, LoadSceneMode.Additive);
-        CMInputCallbackInstaller.DisableActionMaps(typeof(CMInput).GetNestedTypes().Where(x => x.IsInterface));
+        CMInputCallbackInstaller.DisableActionMaps(typeof(OptionsController), typeof(CMInput).GetNestedTypes().Where(x => x.IsInterface));
         OptionsLoadedEvent?.Invoke();
         IsActive = true;
     }
@@ -43,7 +43,7 @@ public class OptionsController : MonoBehaviour
     private IEnumerator CloseOptions()
     {
         yield return StartCoroutine(Close(2, optionsCanvasGroup));
-        CMInputCallbackInstaller.ClearDisabledActionMaps(typeof(CMInput).GetNestedTypes().Where(x => x.IsInterface));
+        CMInputCallbackInstaller.ClearDisabledActionMaps(typeof(OptionsController), typeof(CMInput).GetNestedTypes().Where(x => x.IsInterface));
         IsActive = false;
         yield return SceneManager.UnloadSceneAsync(SceneManager.GetSceneByName("04_Options"));
     }


### PR DESCRIPTION
Sort the bookmarks array, fixes weird next/previous behaviour see https://discordapp.com/channels/702230714585710602/702232127755780197/779680425391292426

Harden up CMInputCallbackInstaller to stop rogue classes locking out the user, each type can only have a single block of an input type. Fixes editing colour selection as that called disable for each keystroke see https://discordapp.com/channels/702230714585710602/702232127755780197/779682737917001758

Re-enable escape and tab on CM_Inputbox and CM_Dialogbox

Fix random blocks changing direction as the dragged container is never cleared so when it gets reused somewhere it will get updated when you press directions as if you were still dragging see https://discordapp.com/channels/702230714585710602/702232127755780197/779738549251080203

Don't allow shift + click to select unloaded objects, especially if they're the queued object, we update the properties of this object a lot and it gets weird copy/pasting with it see https://discordapp.com/channels/702230714585710602/702232127755780197/779735929677414410
