### PR TITLE
Split prop ids when running strobe gen

### DIFF
--- a/Assets/__Scripts/Map/BeatmapObject.cs
+++ b/Assets/__Scripts/Map/BeatmapObject.cs
@@ -1,6 +1,5 @@
 ﻿using SimpleJSON;
 using System;
-using System.Security.Cryptography.X509Certificates;
 
 public abstract class BeatmapObject {
 

--- a/Assets/__Scripts/Map/Events/BeatmapEventContainer.cs
+++ b/Assets/__Scripts/Map/Events/BeatmapEventContainer.cs
@@ -62,6 +62,11 @@ public class BeatmapEventContainer : BeatmapObjectContainer {
 
         if (position == null)
         {
+            transform.localPosition = new Vector3(
+                -0.5f,
+                0.5f,
+                eventData._time * EditorScaleController.EditorScale
+            );
             SafeSetActive(false);
         }
         else

--- a/Assets/__Scripts/Map/Events/MapEvent.cs
+++ b/Assets/__Scripts/Map/Events/MapEvent.cs
@@ -117,6 +117,8 @@ public class MapEvent : BeatmapObject {
     public bool IsUtilityEvent => IsRotationEvent || IsRingEvent || IsLaserSpeedEvent || _type == EVENT_TYPE_BOOST_LIGHTS;
     public bool IsLegacyChromaEvent => _value >= ColourManager.RGB_INT_OFFSET;
     public bool IsChromaEvent => (_customData?.HasKey("_color") ?? false);
+    public bool IsPropogationEvent => _customData?.HasKey("_propID") ?? false;
+    public int PropId => _customData["_propID"].AsInt;
 
     public override JSONNode ConvertToJSON() {
         JSONNode node = new JSONObject();
@@ -142,11 +144,11 @@ public class MapEvent : BeatmapObject {
     {
         if (other is MapEvent @event)
         {
-            if ((_customData?.HasKey("_propID") ?? false) && (@event._customData?.HasKey("_propID") ?? false))
+            if (IsPropogationEvent && @event.IsPropogationEvent)
             {
-                return _type == @event._type && _customData["_propID"].AsInt == @event._customData["_propID"].AsInt;
+                return _type == @event._type && PropId == @event.PropId;
             }
-            else if ((_customData?.HasKey("_propID") ?? false) || (@event._customData?.HasKey("_propID") ?? false))
+            else if (IsPropogationEvent || @event.IsPropogationEvent)
             {
                 // One has ring prop and the other doesn't; they do not conflict
                 return false;

--- a/Assets/__Scripts/MapEditor/Grid/Collections/EventsContainer.cs
+++ b/Assets/__Scripts/MapEditor/Grid/Collections/EventsContainer.cs
@@ -1,10 +1,8 @@
-﻿using System;
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.InputSystem;
-using UnityEngine.Rendering;
 
 public class EventsContainer : BeatmapObjectContainerCollection, CMInput.IEventGridActions
 {

--- a/Assets/__Scripts/MapEditor/Mapping/Strobe Generator/Passes/StrobeChromaPass.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/Strobe Generator/Passes/StrobeChromaPass.cs
@@ -12,7 +12,7 @@ public class StrobeChromaPass : StrobeGeneratorPass
 
     public override bool IsEventValidForPass(MapEvent @event) => @event.IsChromaEvent;
 
-    public override IEnumerable<MapEvent> StrobePassForLane(IEnumerable<MapEvent> original, int type)
+    public override IEnumerable<MapEvent> StrobePassForLane(IEnumerable<MapEvent> original, int type, int? propID)
     {
         List<MapEvent> generatedObjects = new List<MapEvent>();
 

--- a/Assets/__Scripts/MapEditor/Mapping/Strobe Generator/Passes/StrobeLaserSpeedInterpolationPass.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/Strobe Generator/Passes/StrobeLaserSpeedInterpolationPass.cs
@@ -54,7 +54,7 @@ public class StrobeLaserSpeedInterpolationPass : StrobeGeneratorPass
 
     public override bool IsEventValidForPass(MapEvent @event) => @event.IsLaserSpeedEvent;
 
-    public override IEnumerable<MapEvent> StrobePassForLane(IEnumerable<MapEvent> original, int type)
+    public override IEnumerable<MapEvent> StrobePassForLane(IEnumerable<MapEvent> original, int type, int? propID)
     {
         List<MapEvent> generatedObjects = new List<MapEvent>();
 

--- a/Assets/__Scripts/MapEditor/Mapping/Strobe Generator/Passes/StrobeLightingPass.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/Strobe Generator/Passes/StrobeLightingPass.cs
@@ -23,26 +23,7 @@ public class StrobeLightingPass : StrobeGeneratorPass
 
     public override bool IsEventValidForPass(MapEvent @event) => !@event.IsUtilityEvent && !@event.IsLegacyChromaEvent;
 
-    public override IEnumerable<MapEvent> StrobePassForLane(IEnumerable<MapEvent> original, int type)
-    {
-        List<MapEvent> generated = new List<MapEvent>();
-
-        var noProp = original.Where(x => !x.IsPropogationEvent);
-        if (noProp.Any())
-        {
-            generated.AddRange(StrobePassForPropID(noProp, type, null));
-        }
-
-        var prop = original.Where(x => x.IsPropogationEvent);
-        if (prop.Any())
-        {
-            generated.AddRange(StrobePassForPropID(prop, type, prop.First().PropId));
-        }
-
-        return generated;
-    }
-
-    private IEnumerable<MapEvent> StrobePassForPropID(IEnumerable<MapEvent> original, int type, int? propID)
+    public override IEnumerable<MapEvent> StrobePassForLane(IEnumerable<MapEvent> original, int type, int? propID)
     {
         List<MapEvent> generatedObjects = new List<MapEvent>();
 

--- a/Assets/__Scripts/MapEditor/Mapping/Strobe Generator/Passes/StrobeLightingPass.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/Strobe Generator/Passes/StrobeLightingPass.cs
@@ -27,13 +27,16 @@ public class StrobeLightingPass : StrobeGeneratorPass
     {
         List<MapEvent> generated = new List<MapEvent>();
 
-        generated.AddRange(StrobePassForPropID(original.Where(x => x._customData == null || !x._customData.HasKey("_propID")), type, null));
-
-        foreach (var grouping in original.Where(x => x._customData != null && x._customData.HasKey("_propID"))
-            .GroupBy(x => x._customData["_propID"].AsInt))
+        var noProp = original.Where(x => !x.IsPropogationEvent);
+        if (noProp.Any())
         {
-            int propID = grouping.Key;
-            generated.AddRange(StrobePassForPropID(grouping, type, propID));
+            generated.AddRange(StrobePassForPropID(noProp, type, null));
+        }
+
+        var prop = original.Where(x => x.IsPropogationEvent);
+        if (prop.Any())
+        {
+            generated.AddRange(StrobePassForPropID(prop, type, prop.First().PropId));
         }
 
         return generated;

--- a/Assets/__Scripts/MapEditor/Mapping/Strobe Generator/Passes/StrobeStepGradientPass.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/Strobe Generator/Passes/StrobeStepGradientPass.cs
@@ -22,18 +22,16 @@ public class StrobeStepGradientPass : StrobeGeneratorPass
     {
         List<MapEvent> generated = new List<MapEvent>();
 
-        var noProp = original.Where(x => x._customData == null || !x._customData.HasKey("_propID"));
+        var noProp = original.Where(x => !x.IsPropogationEvent);
 
         if (noProp.Any())
         {
             generated.AddRange(StrobePassForPropID(noProp, type));
         }
 
-        foreach (var grouping in original.Where(x => x._customData != null && x._customData.HasKey("_propID"))
-            .GroupBy(x => x._customData["_propID"].AsInt))
-        {
-            int propID = grouping.Key;
-            generated.AddRange(StrobePassForPropID(grouping, type, propID));
+        var prop = original.Where(x => x.IsPropogationEvent);
+        if (prop.Any()) {
+            generated.AddRange(StrobePassForPropID(prop, type, prop.First().PropId));
         }
 
         return generated;

--- a/Assets/__Scripts/MapEditor/Mapping/Strobe Generator/Passes/StrobeStepGradientPass.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/Strobe Generator/Passes/StrobeStepGradientPass.cs
@@ -18,26 +18,7 @@ public class StrobeStepGradientPass : StrobeGeneratorPass
 
     public override bool IsEventValidForPass(MapEvent @event) => !@event.IsUtilityEvent;
 
-    public override IEnumerable<MapEvent> StrobePassForLane(IEnumerable<MapEvent> original, int type)
-    {
-        List<MapEvent> generated = new List<MapEvent>();
-
-        var noProp = original.Where(x => !x.IsPropogationEvent);
-
-        if (noProp.Any())
-        {
-            generated.AddRange(StrobePassForPropID(noProp, type));
-        }
-
-        var prop = original.Where(x => x.IsPropogationEvent);
-        if (prop.Any()) {
-            generated.AddRange(StrobePassForPropID(prop, type, prop.First().PropId));
-        }
-
-        return generated;
-    }
-
-    public IEnumerable<MapEvent> StrobePassForPropID(IEnumerable<MapEvent> original, int type, int? propID = null)
+    public override IEnumerable<MapEvent> StrobePassForLane(IEnumerable<MapEvent> original, int type, int? propID = null)
     {
         List<MapEvent> generatedObjects = new List<MapEvent>();
 

--- a/Assets/__Scripts/MapEditor/Mapping/Strobe Generator/StrobeGenerator.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/Strobe Generator/StrobeGenerator.cs
@@ -25,9 +25,10 @@ public class StrobeGenerator : MonoBehaviour {
         foreach (var group in groupings)
         {
             int type = group.Key;
-            var propGroups = group.GroupBy(y => y.IsPropogationEvent ? y.PropId : -1);
+            var propGroups = group.GroupBy(y => y.IsPropogationEvent ? (int?) y.PropId : null);
 
             foreach (var propGroup in propGroups) {
+                int? prop = propGroup.Key;
                 if (propGroup.Count() >= 2)
                 {
                     IEnumerable<MapEvent> ordered = propGroup.OrderByDescending(x => x._time);
@@ -46,7 +47,7 @@ public class StrobeGenerator : MonoBehaviour {
                         IEnumerable<MapEvent> validEvents = containersBetween.Where(x => pass.IsEventValidForPass(x));
                         if (validEvents.Count() >= 2)
                         {
-                            List<MapEvent> strobePassGenerated = pass.StrobePassForLane(validEvents.OrderBy(x => x._time), start._type).ToList();
+                            List<MapEvent> strobePassGenerated = pass.StrobePassForLane(validEvents.OrderBy(x => x._time), type, prop).ToList();
                             // REVIEW: Perhaps implement a "smart merge" to conflicting events, rather than outright removing those from previous passes
                             // Now, what would a "smart merge" entail? I have no clue.
                             generatedObjects.RemoveAll(x => strobePassGenerated.Any(y => y.IsConflictingWith(x)));

--- a/Assets/__Scripts/MapEditor/Mapping/Strobe Generator/StrobeGenerator.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/Strobe Generator/StrobeGenerator.cs
@@ -25,28 +25,33 @@ public class StrobeGenerator : MonoBehaviour {
         foreach (var group in groupings)
         {
             int type = group.Key;
-            if (group.Count() >= 2)
-            {
-                IEnumerable<MapEvent> ordered = group.OrderByDescending(x => x._time);
-                MapEvent end = ordered.First();
-                MapEvent start = ordered.Last();
+            var propGroups = group.GroupBy(y => y.IsPropogationEvent ? y.PropId : -1);
 
-                IEnumerable<MapEvent> containersBetween = eventsContainer.UnsortedObjects.Where(x =>
-                (x as MapEvent)._type == type && //Grab all events between start and end point.
-                x._time >= start._time && x._time <= end._time
-                ).Cast<MapEvent>();
-                oldEvents.AddRange(containersBetween);
-
-                foreach (StrobeGeneratorPass pass in passes)
+            foreach (var propGroup in propGroups) {
+                if (propGroup.Count() >= 2)
                 {
-                    IEnumerable<MapEvent> validEvents = containersBetween.Where(x => pass.IsEventValidForPass(x));
-                    if (validEvents.Count() >= 2)
+                    IEnumerable<MapEvent> ordered = propGroup.OrderByDescending(x => x._time);
+                    MapEvent end = ordered.First();
+                    MapEvent start = ordered.Last();
+
+                    IEnumerable<MapEvent> containersBetween = eventsContainer.UnsortedObjects.Cast<MapEvent>().Where(x =>
+                       x._type == start._type && //Grab all events between start and end point.
+                       x._time >= start._time && x._time <= end._time &&
+                       start.IsPropogationEvent == x.IsPropogationEvent && start.PropId == x.PropId
+                    );
+                    oldEvents.AddRange(containersBetween);
+
+                    foreach (StrobeGeneratorPass pass in passes)
                     {
-                        List<MapEvent> strobePassGenerated = pass.StrobePassForLane(validEvents.OrderBy(x => x._time), type).ToList();
-                        // REVIEW: Perhaps implement a "smart merge" to conflicting events, rather than outright removing those from previous passes
-                        // Now, what would a "smart merge" entail? I have no clue.
-                        generatedObjects.RemoveAll(x => strobePassGenerated.Any(y => y.IsConflictingWith(x)));
-                        generatedObjects.AddRange(strobePassGenerated);
+                        IEnumerable<MapEvent> validEvents = containersBetween.Where(x => pass.IsEventValidForPass(x));
+                        if (validEvents.Count() >= 2)
+                        {
+                            List<MapEvent> strobePassGenerated = pass.StrobePassForLane(validEvents.OrderBy(x => x._time), start._type).ToList();
+                            // REVIEW: Perhaps implement a "smart merge" to conflicting events, rather than outright removing those from previous passes
+                            // Now, what would a "smart merge" entail? I have no clue.
+                            generatedObjects.RemoveAll(x => strobePassGenerated.Any(y => y.IsConflictingWith(x)));
+                            generatedObjects.AddRange(strobePassGenerated);
+                        }
                     }
                 }
             }

--- a/Assets/__Scripts/MapEditor/Mapping/Strobe Generator/StrobeGeneratorPass.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/Strobe Generator/StrobeGeneratorPass.cs
@@ -21,5 +21,5 @@ public abstract class StrobeGeneratorPass
     /// </summary>
     /// <param name="original">The list of all valid events for this pass.</param>
     /// <returns>A new list of objects that will be created.</returns>
-    public abstract IEnumerable<MapEvent> StrobePassForLane(IEnumerable<MapEvent> original, int type);
+    public abstract IEnumerable<MapEvent> StrobePassForLane(IEnumerable<MapEvent> original, int type, int? propID);
 }


### PR DESCRIPTION
Moved prop id splitting up to the main function as otherwise we delete all other prop notes nearby

Also fixes prop notes not being visible if spawned while propagation editing is enabled but not their event type