### PR TITLE
Bug fix

### DIFF
--- a/Assets/HSVPicker/UI/HexColorField.cs
+++ b/Assets/HSVPicker/UI/HexColorField.cs
@@ -1,9 +1,10 @@
 ﻿using System.Linq;
 using UnityEngine;
+using UnityEngine.EventSystems;
 using UnityEngine.UI;
 
 [RequireComponent(typeof(InputField))]
-public class HexColorField : MonoBehaviour
+public class HexColorField : MonoBehaviour, ISelectHandler, IDeselectHandler
 {
     public ColorPicker hsvpicker;
 
@@ -16,22 +17,24 @@ public class HexColorField : MonoBehaviour
         hexInputField = GetComponent<InputField>();
 
         // Add listeners to keep text (and color) up to date
-        hexInputField.onValueChanged.AddListener(TextValueChanged);
         hexInputField.onEndEdit.AddListener(UpdateColor);
         hsvpicker.onValueChanged.AddListener(UpdateHex);
     }
 
     private void OnDestroy()
     {
-        hexInputField.onValueChanged.RemoveListener(TextValueChanged);
         hexInputField.onEndEdit.RemoveListener(UpdateColor);
         hsvpicker.onValueChanged.RemoveListener(UpdateHex);
     }
 
-    private void TextValueChanged(string arg0)
+    public void OnSelect(BaseEventData eventData)
     {
-        if (!hexInputField.isFocused) return;
         CMInputCallbackInstaller.DisableActionMaps(typeof(HexColorField), typeof(CMInput).GetNestedTypes().Where(x => x.IsInterface));
+    }
+
+    public void OnDeselect(BaseEventData eventData)
+    {
+        CMInputCallbackInstaller.ClearDisabledActionMaps(typeof(HexColorField), typeof(CMInput).GetNestedTypes().Where(x => x.IsInterface));
     }
 
     private void UpdateHex(Color newColor)
@@ -41,7 +44,6 @@ public class HexColorField : MonoBehaviour
 
     private void UpdateColor(string newHex)
     {
-        CMInputCallbackInstaller.ClearDisabledActionMaps(typeof(HexColorField), typeof(CMInput).GetNestedTypes().Where(x => x.IsInterface));
         Color color;
         if (!newHex.StartsWith("#"))
             newHex = "#"+newHex;

--- a/Assets/HSVPicker/UI/TextMeshPro/ColorTMPField.cs
+++ b/Assets/HSVPicker/UI/TextMeshPro/ColorTMPField.cs
@@ -1,16 +1,13 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using UnityEngine;
-using UnityEngine.UI;
 using TMPro;
+using UnityEngine.EventSystems;
+using System.Linq;
 
 namespace Assets.HSVPicker.UI.TextMeshPro
 {
     [RequireComponent(typeof(TMP_InputField))]
-    public class ColorTMPField : MonoBehaviour
+    public class ColorTMPField : MonoBehaviour, ISelectHandler, IDeselectHandler
     {
         [SerializeField] private ColorPicker picker;
         [SerializeField] private ColorValues type;
@@ -96,6 +93,16 @@ namespace Assets.HSVPicker.UI.TextMeshPro
 
                 picker.AssignColor(type, v);
             }
+        }
+
+        public void OnSelect(BaseEventData eventData)
+        {
+            CMInputCallbackInstaller.DisableActionMaps(typeof(ColorTMPField), typeof(CMInput).GetNestedTypes().Where(x => x.IsInterface));
+        }
+
+        public void OnDeselect(BaseEventData eventData)
+        {
+            CMInputCallbackInstaller.ClearDisabledActionMaps(typeof(ColorTMPField), typeof(CMInput).GetNestedTypes().Where(x => x.IsInterface));
         }
     }
 }

--- a/Assets/__Scenes/03_Mapper.unity
+++ b/Assets/__Scenes/03_Mapper.unity
@@ -1648,6 +1648,7 @@ MonoBehaviour:
   tracksManager: {fileID: 25550679}
   eventPlacement: {fileID: 1277691436}
   labels: {fileID: 322207091}
+  boxSelectionPlacementController: {fileID: 1524038341}
   EventTypeToPropagate: 1
   EventTypePropagationSize: 0
   AllRotationEvents: []
@@ -3202,7 +3203,7 @@ MonoBehaviour:
   picker: {fileID: 1225848101}
   dropdown: {fileID: 81479822}
   eventsContainer: {fileID: 25550674}
-  toggle: {fileID: 1427203218}
+  toggle: {fileID: 157530501}
 --- !u!1 &81669278
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/__Scripts/MapEditor/Grid/Collections/EventsContainer.cs
+++ b/Assets/__Scripts/MapEditor/Grid/Collections/EventsContainer.cs
@@ -12,6 +12,7 @@ public class EventsContainer : BeatmapObjectContainerCollection, CMInput.IEventG
     [SerializeField] private TracksManager tracksManager;
     [SerializeField] private EventPlacement eventPlacement;
     [SerializeField] private CreateEventTypeLabels labels;
+    [SerializeField] private BoxSelectionPlacementController boxSelectionPlacementController;
 
     internal PlatformDescriptor platformDescriptor;
 
@@ -30,6 +31,7 @@ public class EventsContainer : BeatmapObjectContainerCollection, CMInput.IEventG
         set
         {
             propagationEditing = value;
+            boxSelectionPlacementController.CancelPlacement();
             int propagationLength = platformDescriptor.LightingManagers[EventTypeToPropagate]?.LightsGroupedByZ?.Length ?? 0;
             labels.UpdateLabels(value, EventTypeToPropagate, value ? propagationLength + 1 : 16);
             eventPlacement.SetGridSize(value ? propagationLength + 1 : SpecialEventTypeCount + platformDescriptor.LightingManagers.Count(s => s != null));

--- a/Assets/__Scripts/MapEditor/Grid/PauseToggleLights.cs
+++ b/Assets/__Scripts/MapEditor/Grid/PauseToggleLights.cs
@@ -9,6 +9,8 @@ public class PauseToggleLights : MonoBehaviour
     [SerializeField] private AudioTimeSyncController atsc;
     [SerializeField] private EventsContainer events;
 
+    private MapEvent defaultBoostEvent = new MapEvent(0, 5, 0);
+
     private HashSet<int> eventTypesHash = new HashSet<int>();
     private List<MapEvent> lastEvents = new List<MapEvent>();
     private List<MapEvent> lastChromaEvents = new List<MapEvent>();
@@ -47,6 +49,10 @@ public class PauseToggleLights : MonoBehaviour
             if (eventTypesHash.Contains(MapEvent.EVENT_TYPE_BOOST_LIGHTS))
             {
                 descriptor.EventPassed(false, 0, lastEvents.First(x => x._type == MapEvent.EVENT_TYPE_BOOST_LIGHTS));
+            }
+            else
+            {
+                descriptor.EventPassed(false, 0, defaultBoostEvent);
             }
             MapEvent blankEvent = new MapEvent(0, 0, 0);
             for (int i = 0; i < 16; i++)

--- a/Assets/__Scripts/MapEditor/UI/Chroma/ColourHistory.cs
+++ b/Assets/__Scripts/MapEditor/UI/Chroma/ColourHistory.cs
@@ -14,7 +14,12 @@ public class ColourHistory : MonoBehaviour {
     {
         JSONObject obj = new JSONObject();
         JSONArray colors = new JSONArray();
-        foreach (Color color in ColorPresetManager.Get().Colors) colors.Add(ColourManager.ColourToInt(color));
+        foreach (Color color in ColorPresetManager.Get().Colors)
+        {
+            var node = new JSONObject();
+            node.WriteColor(color, true);
+            colors.Add(node);
+        }
         obj.Add("colors", colors);
         using (StreamWriter writer = new StreamWriter(Application.persistentDataPath + "/ChromaColors.json", false))
             writer.Write(obj.ToString());
@@ -36,7 +41,10 @@ public class ColourHistory : MonoBehaviour {
             {
                 JSONNode mainNode = JSON.Parse(reader.ReadToEnd());
                 foreach (JSONNode n in mainNode["colors"].AsArray)
-                    presetList.Colors.Add(ColourManager.ColourFromInt(n.AsInt));
+                {
+                    Color color = n.IsObject ? n.ReadColor(Color.black) : ColourManager.ColourFromInt(n.AsInt);
+                    presetList.Colors.Add(color);
+                }
             }
             Debug.Log($"Loaded {presetList.Colors.Count} colors!");
             ColorPresetManager.Presets.Add("default", presetList);

--- a/Assets/__Scripts/MapEditor/UI/Chroma/ColourPicker.cs
+++ b/Assets/__Scripts/MapEditor/UI/Chroma/ColourPicker.cs
@@ -1,6 +1,4 @@
 ﻿using UnityEngine.UI;
-using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
 
 public class ColourPicker : MonoBehaviour
@@ -13,8 +11,8 @@ public class ColourPicker : MonoBehaviour
     // Start is called before the first frame update
     private void Start()
     {
-        toggle.isOn = Settings.Instance.PickColorFromChromaEvents;
         SelectionController.ObjectWasSelectedEvent += SelectedObject;
+        toggle.isOn = Settings.Instance.PickColorFromChromaEvents;
     }
 
     private void OnDestroy()

--- a/Assets/__Scripts/MapEditor/UI/Strobe Generator/StrobeGeneratorControllerUI.cs
+++ b/Assets/__Scripts/MapEditor/UI/Strobe Generator/StrobeGeneratorControllerUI.cs
@@ -20,6 +20,13 @@ public class StrobeGeneratorControllerUI : MonoBehaviour, CMInput.IStrobeGenerat
 
     public void GenerateStrobeWithUISettings()
     {
+        if (!SelectionController.HasSelectedObjects())
+        {
+            PersistentUI.Instance.ShowDialogBox("Mapper", "gradient.error",
+                null, PersistentUI.DialogBoxPresetType.Ok);
+            return;
+        }
+
         List<StrobeGeneratorPass> passes = new List<StrobeGeneratorPass>();
 
         foreach (StrobeGeneratorPassUIController activePass in allPassUIControllers.Where(x => x.WillGenerate))

--- a/Assets/__Scripts/MapEditor/UI/Strobe Generator/StrobeGeneratorUIDropdown.cs
+++ b/Assets/__Scripts/MapEditor/UI/Strobe Generator/StrobeGeneratorUIDropdown.cs
@@ -9,11 +9,6 @@ public class StrobeGeneratorUIDropdown : MonoBehaviour
 
     public void ToggleDropdown(bool visible)
     {
-        if (visible && !SelectionController.HasSelectedObjects())
-        {
-            PersistentUI.Instance.ShowDialogBox("Mapper", "gradient.error",
-                null, PersistentUI.DialogBoxPresetType.Ok);
-        }
         StartCoroutine(UpdateGroup(visible, strobeGenUIRect));
     }
 

--- a/Assets/__Scripts/Platforms/PlatformDescriptor.cs
+++ b/Assets/__Scripts/Platforms/PlatformDescriptor.cs
@@ -257,7 +257,7 @@ public class PlatformDescriptor : MonoBehaviour {
         }
         
         //Check to see if we're soloing any particular event
-        if (SoloAnEventType && e._type != SoloEventType) mainColor = invertedColor = Color.black;
+        if (SoloAnEventType && e._type != SoloEventType) mainColor = invertedColor = Color.black.WithAlpha(0);
 
         IEnumerable<LightingEvent> allLights = group.ControllingLights;
         if (e._customData?.HasKey("_propID") ?? false && Settings.Instance.EmulateChromaAdvanced)


### PR DESCRIPTION
Fix keybinds activating when typing in colour menu
See https://discordapp.com/channels/702230714585710602/702232127755780197/780822223694200873

Move gradient error to after the user clicks generate
See https://discordapp.com/channels/702230714585710602/702232105769500694/781159943772438550

Fix colour picker display being incorrect on start
See https://discordapp.com/channels/702230714585710602/702232127755780197/781186608581312552

Cancel box select when changing prop views
See https://discordapp.com/channels/702230714585710602/702232127755780197/781167446518267924

Fix event soloing and boost colours before first boost
See https://discordapp.com/channels/702230714585710602/702232127755780197/780885796328570940

Store colour presets as json objects (ala Chroma 2.0) instead of ints
See https://discordapp.com/channels/702230714585710602/702232127755780197/781166409009856544