### PR TITLE
Fix notes not deleting properly after being moved in time

### DIFF
--- a/Assets/__Scripts/Map/BeatmapObject.cs
+++ b/Assets/__Scripts/Map/BeatmapObject.cs
@@ -71,7 +71,7 @@ public abstract class BeatmapObject {
     /// <returns>Whether or not they are conflicting with each other.</returns>
     public virtual bool IsConflictingWith(BeatmapObject other, bool deletion = false)
     {
-        if (Mathf.Abs(_time - other._time) < NotesContainer.Epsilon)
+        if (Mathf.Abs(_time - other._time) < BeatmapObjectContainerCollection.Epsilon)
         {
             return IsConflictingWithObjectAtSameTime(other, deletion);
         }

--- a/Assets/__Scripts/Map/BeatmapObject.cs
+++ b/Assets/__Scripts/Map/BeatmapObject.cs
@@ -1,5 +1,6 @@
 ﻿using SimpleJSON;
 using System;
+using UnityEngine;
 
 public abstract class BeatmapObject {
 
@@ -70,7 +71,7 @@ public abstract class BeatmapObject {
     /// <returns>Whether or not they are conflicting with each other.</returns>
     public virtual bool IsConflictingWith(BeatmapObject other, bool deletion = false)
     {
-        if (_time == other._time)
+        if (Mathf.Abs(_time - other._time) < NotesContainer.Epsilon)
         {
             return IsConflictingWithObjectAtSameTime(other, deletion);
         }

--- a/Assets/__Scripts/Map/Notes/BeatmapNoteContainer.cs
+++ b/Assets/__Scripts/Map/Notes/BeatmapNoteContainer.cs
@@ -124,7 +124,7 @@ public class BeatmapNoteContainer : BeatmapObjectContainer {
     private bool CurrentState = false;
     public void CheckTranslucent()
     {
-        bool newState = transform.parent != null && (transform.localPosition.z + transform.parent.localPosition.z) <= NotesContainer.TranslucentCull;
+        bool newState = transform.parent != null && (transform.localPosition.z + transform.parent.localPosition.z) <= BeatmapObjectContainerCollection.TranslucentCull;
         if (newState != CurrentState) {
             noteRenderer.ForEach(it =>
             {

--- a/Assets/__Scripts/MapEditor/Grid/Collections/BeatmapObjectContainerCollection.cs
+++ b/Assets/__Scripts/MapEditor/Grid/Collections/BeatmapObjectContainerCollection.cs
@@ -7,6 +7,22 @@ public abstract class BeatmapObjectContainerCollection : MonoBehaviour
 {
     public static readonly int ChunkSize = 5;
 
+    public static float Epsilon = 0.001f;
+    public static float TranslucentCull = -0.001f;
+
+    private void Start()
+    {
+        UpdateEpsilon(Settings.Instance.TimeValueDecimalPrecision);
+        Settings.NotifyBySettingName("TimeValueDecimalPrecision", UpdateEpsilon);
+        Settings.NotifyBySettingName("EditorScale", UpdateEpsilon);
+    }
+
+    private void UpdateEpsilon(object precision)
+    {
+        Epsilon = 1 / Mathf.Pow(10, Settings.Instance.TimeValueDecimalPrecision);
+        TranslucentCull = -Settings.Instance.EditorScale * Epsilon;
+    }
+
     public static string TrackFilterID { get; private set; } = null;
 
     private static Dictionary<BeatmapObject.Type, BeatmapObjectContainerCollection> loadedCollections = new Dictionary<BeatmapObject.Type, BeatmapObjectContainerCollection>();

--- a/Assets/__Scripts/MapEditor/Grid/Collections/NotesContainer.cs
+++ b/Assets/__Scripts/MapEditor/Grid/Collections/NotesContainer.cs
@@ -11,7 +11,7 @@ public class NotesContainer : BeatmapObjectContainerCollection {
     [SerializeField] private TracksManager tracksManager;
 
     private HashSet<Material> allNoteRenderers = new HashSet<Material>();
-    private float epsilon = 0.001f;
+    public static float Epsilon = 0.001f;
     public static float TranslucentCull = -0.001f;
 
     private void Start()
@@ -23,8 +23,8 @@ public class NotesContainer : BeatmapObjectContainerCollection {
 
     private void UpdateEpsilon(object precision)
     {
-        epsilon = 1 / Mathf.Pow(10, (int)Settings.Instance.TimeValueDecimalPrecision);
-        TranslucentCull = -Settings.Instance.EditorScale * epsilon;
+        Epsilon = 1 / Mathf.Pow(10, Settings.Instance.TimeValueDecimalPrecision);
+        TranslucentCull = -Settings.Instance.EditorScale * Epsilon;
     }
 
     public static bool ShowArcVisualizer { get; private set; } = false;
@@ -150,7 +150,7 @@ public class NotesContainer : BeatmapObjectContainerCollection {
         objectsAtSameTime.Clear();
         foreach (var x in LoadedContainers)
         {
-            if (!(x.Key._time - epsilon <= obj._time && x.Key._time + epsilon >= obj._time &&
+            if (!(x.Key._time - Epsilon <= obj._time && x.Key._time + Epsilon >= obj._time &&
             (x.Key as BeatmapNote)._type == (obj as BeatmapNote)._type)) continue;
 
             objectsAtSameTime.Add(x.Value);

--- a/Assets/__Scripts/MapEditor/Grid/Collections/NotesContainer.cs
+++ b/Assets/__Scripts/MapEditor/Grid/Collections/NotesContainer.cs
@@ -11,21 +11,6 @@ public class NotesContainer : BeatmapObjectContainerCollection {
     [SerializeField] private TracksManager tracksManager;
 
     private HashSet<Material> allNoteRenderers = new HashSet<Material>();
-    public static float Epsilon = 0.001f;
-    public static float TranslucentCull = -0.001f;
-
-    private void Start()
-    {
-        UpdateEpsilon(Settings.Instance.TimeValueDecimalPrecision);
-        Settings.NotifyBySettingName("TimeValueDecimalPrecision", UpdateEpsilon);
-        Settings.NotifyBySettingName("EditorScale", UpdateEpsilon);
-    }
-
-    private void UpdateEpsilon(object precision)
-    {
-        Epsilon = 1 / Mathf.Pow(10, Settings.Instance.TimeValueDecimalPrecision);
-        TranslucentCull = -Settings.Instance.EditorScale * Epsilon;
-    }
 
     public static bool ShowArcVisualizer { get; private set; } = false;
 

--- a/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/PlacementController.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/PlacementController.cs
@@ -217,6 +217,12 @@ public abstract class PlacementController<BO, BOC, BOCC> : MonoBehaviour, CMInpu
         //First, find and delete anything that's overlapping our dragged object.
         var selected = SelectionController.IsObjectSelected(draggedObjectData);
 
+        // To delete properly we need to set the original time
+        float _time = draggedObjectData._time;
+        draggedObjectData._time = originalDraggedObjectData._time;
+        objectContainerCollection.DeleteObject(draggedObjectData, false, false);
+        draggedObjectData._time = _time;
+
         objectContainerCollection.SpawnObject(draggedObjectData, out List<BeatmapObject> conflicting, true, true);
         if (conflicting.Contains(draggedObjectData))
         {

--- a/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/PlacementController.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/PlacementController.cs
@@ -216,10 +216,10 @@ public abstract class PlacementController<BO, BOC, BOCC> : MonoBehaviour, CMInpu
         if (!(isDraggingObject || isDraggingObjectAtTime)) return;
         //First, find and delete anything that's overlapping our dragged object.
         var selected = SelectionController.IsObjectSelected(draggedObjectData);
-        objectContainerCollection.RemoveConflictingObjects(new[] { draggedObjectData }, out List<BeatmapObject> conflicting);
+
+        objectContainerCollection.SpawnObject(draggedObjectData, out List<BeatmapObject> conflicting, true, true);
         if (conflicting.Contains(draggedObjectData))
         {
-            objectContainerCollection.SpawnObject(draggedObjectData, false, true);
             conflicting.Remove(draggedObjectData);
 
             if (selected)

--- a/Assets/__Scripts/MapEditor/Mapping/Selection/SelectionController.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/Selection/SelectionController.cs
@@ -375,11 +375,15 @@ public class SelectionController : MonoBehaviour, CMInput.ISelectingActions, CMI
         List<BeatmapAction> allActions = new List<BeatmapAction>();
         foreach (BeatmapObject data in SelectedObjects)
         {
+            BeatmapObjectContainerCollection collection = BeatmapObjectContainerCollection.GetCollectionForType(data.beatmapType);
             BeatmapObject original = BeatmapObject.GenerateCopy(data);
+
+            collection.LoadedObjects.Remove(data);
             data._time += beats;
             if (snapObjects)
                 data._time = Mathf.Round(beats / (1f / atsc.gridMeasureSnapping)) * (1f / atsc.gridMeasureSnapping);
-            BeatmapObjectContainerCollection collection = BeatmapObjectContainerCollection.GetCollectionForType(data.beatmapType);
+            collection.LoadedObjects.Add(data);
+
             if (collection.LoadedContainers.TryGetValue(data, out BeatmapObjectContainer con))
             {
                 con.UpdateGridPosition();


### PR DESCRIPTION
So after hours of confusion and actually stepping through the source code for SortedSet<T> I learned that for delete to function as expected the items must still be sorted in the same way as when they were added to the set. This means any time we want to change the _time property of an object we need to re-add it to the set otherwise there's a chance when the tree is traversed later it won't work.

### Demo code:
https://ideone.com/wpLvu3

### How to reproduce in CM:
On a new map place a single block
Place a second block later in time
Drag or shift move the second block before the first in time
Delete the second block
Save and exit
Reload the map
Observe the second block has not been deleted

----

At the time time I realised that if you move a note to a precision where _time will have more decimal places than the current selected precision then the undo will fail as the _time will not match the rounded _time saved in the BeatmapAction.

To fix this we need to check within the current precision for deletes (this should still be 15x smaller than it's possible to place blocks together at 3dp, it will fall over at 1dp but come on)