### PR TITLE
Strobe gen go brrrr

### DIFF
--- a/Assets/__Scripts/Map/BeatmapObject.cs
+++ b/Assets/__Scripts/Map/BeatmapObject.cs
@@ -52,8 +52,20 @@ public abstract class BeatmapObject {
     public static T GenerateCopy<T>(T originalData) where T : BeatmapObject
     {
         if (originalData is null) throw new ArgumentException("originalData is null.");
-        T objectData = Activator.CreateInstance(originalData.GetType(), new object[] { originalData.ConvertToJSON() }) as T;
-        if (originalData._customData != null) objectData._customData = originalData._customData.Clone();
+        T objectData;
+        switch (originalData)
+        {
+            case MapEvent evt:
+                objectData = new MapEvent(evt._time, evt._type, evt._value, originalData._customData?.Clone()) as T;
+                break;
+            case BeatmapNote note:
+                objectData = new BeatmapNote(note._time, note._lineIndex, note._lineLayer, note._type, note._cutDirection, originalData._customData?.Clone()) as T;
+                break;
+            default:
+                objectData = Activator.CreateInstance(originalData.GetType(), new object[] { originalData.ConvertToJSON() }) as T;
+                if (originalData._customData != null) objectData._customData = originalData._customData.Clone();
+                break;
+        }
         return objectData;
     }
 

--- a/Assets/__Scripts/Map/Events/MapEvent.cs
+++ b/Assets/__Scripts/Map/Events/MapEvent.cs
@@ -63,10 +63,16 @@ public class MapEvent : BeatmapObject {
         }
     }
 
-    public MapEvent(float time, int type, int value) {
+    public MapEvent(float time, int type, int value, JSONNode customData = null) {
         _time = time;
         _type = type;
         _value = value;
+        _customData = customData;
+
+        if (_customData != null && _customData.HasKey("_lightGradient"))
+        {
+            _lightGradient = new ChromaGradient(_customData["_lightGradient"]);
+        }
     }
 
     public int? GetRotationDegreeFromValue()

--- a/Assets/__Scripts/MapEditor/Mapping/Strobe Generator/StrobeGenerator.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/Strobe Generator/StrobeGenerator.cs
@@ -35,9 +35,8 @@ public class StrobeGenerator : MonoBehaviour {
                     MapEvent end = ordered.First();
                     MapEvent start = ordered.Last();
 
-                    IEnumerable<MapEvent> containersBetween = eventsContainer.UnsortedObjects.Cast<MapEvent>().Where(x =>
+                    IEnumerable<MapEvent> containersBetween = eventsContainer.LoadedObjects.GetViewBetween(start, end).Cast<MapEvent>().Where(x =>
                        x._type == start._type && //Grab all events between start and end point.
-                       x._time >= start._time && x._time <= end._time &&
                        start.IsPropogationEvent == x.IsPropogationEvent && (!start.IsPropogationEvent || start.PropId == x.PropId)
                     );
                     oldEvents.AddRange(containersBetween);


### PR DESCRIPTION
Couple of performance optimisations for copying events and notes as they are most common to spam

Big boost in strobe gen on high event count maps by using the sorted set to exclude objects before and after the selected region.