### PR TITLE
Schedule hit sounds instead of playing during frames

### DIFF
--- a/Assets/__Scenes/03_Mapper.unity
+++ b/Assets/__Scenes/03_Mapper.unity
@@ -32022,8 +32022,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 13585791}
   m_HandleRect: {fileID: 13585789}
   m_Direction: 2
-  m_Value: 0.50000006
-  m_Size: 0.54347825
+  m_Value: 0.5
+  m_Size: 0.5434783
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -38079,12 +38079,6 @@ MonoBehaviour:
   - {fileID: 6481668442401791511, guid: 52c75513c5e86f14fa72fc9c355e24ad, type: 3}
   DirectionalPlatformPrefabs:
   - {fileID: 749128188192919665, guid: 558261e2e6dd38a46af6768faf558ab7, type: 3}
-  CustomPlatformPrefabs:
-  - {fileID: 4745573179871663215, guid: b12ffe571f21cfa47887cd15eeafbe67, type: 3}
-  - {fileID: 6303346498651901762, guid: 2d25e2feef444584d8b24c04cff95003, type: 3}
-  - {fileID: 6256441204431556818, guid: 8eb202530df0d7444b55bdcb9865546d, type: 3}
-  - {fileID: 7701948425691940433, guid: 69808f53bcaba924286bec5007ca428a, type: 3}
-  - {fileID: 6191877054514693231, guid: b9bcb27b163d5b141a5997330a267912, type: 3}
 --- !u!114 &1117169519
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/__Scripts/MapEditor/Detection/BeatmapObjectCallbackController.cs
+++ b/Assets/__Scripts/MapEditor/Detection/BeatmapObjectCallbackController.cs
@@ -75,7 +75,6 @@ public class BeatmapObjectCallbackController : MonoBehaviour {
         }
         nextNoteIndex = notesContainer.LoadedObjects.Count - allNotes.Count;
         RecursiveNoteCheckFinished?.Invoke(natural, nextNoteIndex - 1);
-        allNotes.OrderBy(x => x._time);
         nextNotes.Clear();
         for (int i = 0; i < notesToLookAhead; i++)
             if (allNotes.Any()) nextNotes.Add(allNotes.Dequeue());
@@ -91,7 +90,6 @@ public class BeatmapObjectCallbackController : MonoBehaviour {
         }
         nextEventIndex = eventsContainer.LoadedObjects.Count - allEvents.Count;
         RecursiveEventCheckFinished?.Invoke(natural, nextEventIndex - 1);
-        allEvents.OrderBy(x => x._time);
         nextEvents.Clear();
         for (int i = 0; i < eventsToLookAhead; i++)
             if (allEvents.Any()) nextEvents.Add(allEvents.Dequeue());

--- a/Assets/__Scripts/MapEditor/Grid/Collections/BeatmapObjectContainerCollection.cs
+++ b/Assets/__Scripts/MapEditor/Grid/Collections/BeatmapObjectContainerCollection.cs
@@ -128,6 +128,13 @@ public abstract class BeatmapObjectContainerCollection : MonoBehaviour
         }
     }
 
+    public SortedSet<BeatmapObject> GetBetween(float time, float time2) {
+        // Events etc. can still have a sort order between notes
+        var now = new BeatmapNote(time - 0.0000001f, 0, 0, 0, 0);
+        var window = new BeatmapNote(time2 + 0.0000001f, 0, 0, 0, 0);
+        return LoadedObjects.GetViewBetween(now, window);
+    }
+
     /// <summary>
     /// Refreshes the pool with a defined lower and upper bound.
     /// </summary>

--- a/Assets/__Scripts/MapEditor/Hit Sounds/AudioUtil.cs
+++ b/Assets/__Scripts/MapEditor/Hit Sounds/AudioUtil.cs
@@ -50,11 +50,12 @@ public class AudioUtil : MonoBehaviour
     /// <param name="filenameWithExtension">The file name with extension, found in the Audio folder</param>
     /// <param name="volume">Optional volume multiplier</param>
     /// <param name="pitch">Optional pitch multiplier</param>
+    /// <param name="delay">Optional time before sound is played</param>
     /// <returns>The Unity AudioSource used to play the sound</returns>
-    public AudioSource PlayOneShotSound(AudioClip clip, float volume = 1f, float pitch = 1f)
+    public AudioSource PlayOneShotSound(AudioClip clip, float volume = 1f, float pitch = 1f, float delay = 0f)
     {
         AudioSource oneShotSource = AvailableOneShot;
-        PlayOneShotSound(clip, oneShotSource, volume, pitch);
+        PlayOneShotSound(clip, oneShotSource, volume, pitch, delay);
         return oneShotSource;
     }
 
@@ -65,12 +66,21 @@ public class AudioUtil : MonoBehaviour
     /// <param name="oneShotSource">The AudioSource to play the file through</param>
     /// <param name="volume">Optional volume multiplier</param>
     /// <param name="pitch">Optional pitch multiplier</param>
-    public void PlayOneShotSound(AudioClip clip, AudioSource oneShotSource, float volume = 1f, float pitch = 1f)
+    /// <param name="delay">Optional time before sound is played</param>
+    public void PlayOneShotSound(AudioClip clip, AudioSource oneShotSource, float volume = 1f, float pitch = 1f, float delay = 0f)
     {
         oneShotSource.volume = volume;
         oneShotSource.pitch = pitch;
         oneShotSource.clip = clip;
-        oneShotSource.PlayScheduled(AudioSettings.dspTime);
+        oneShotSource.PlayScheduled(AudioSettings.dspTime + delay);
+    }
+
+    public void StopOneShot()
+    {
+        foreach (var source in oneShotPool)
+        {
+            source.Stop();
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Basically moves the point at which are processed 0.5 seconds before they hit the play head and then adds a delay before they are played in the call to unity's audio system

Plus some handling for the notes between now and 0.5s time when pressing play and making sure things don't play after you stop