### PR TITLE
Bugfixes

### DIFF
--- a/Assets/_Prefabs/MapEditor/Platforms/Crab Rave.prefab
+++ b/Assets/_Prefabs/MapEditor/Platforms/Crab Rave.prefab
@@ -127,6 +127,121 @@ PrefabInstance:
       propertyPath: ObstacleColor.b
       value: 0.08627451
       objectReference: {fileID: 0}
+    - target: {fileID: 7351533105162161635, guid: 812da6791f6f5bb41902ddf7118c338d,
+        type: 3}
+      propertyPath: defaultColors.RedNoteColor.r
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7351533105162161635, guid: 812da6791f6f5bb41902ddf7118c338d,
+        type: 3}
+      propertyPath: defaultColors.RedNoteColor.g
+      value: 0.71300006
+      objectReference: {fileID: 0}
+    - target: {fileID: 7351533105162161635, guid: 812da6791f6f5bb41902ddf7118c338d,
+        type: 3}
+      propertyPath: defaultColors.RedNoteColor.b
+      value: 0.07806564
+      objectReference: {fileID: 0}
+    - target: {fileID: 7351533105162161635, guid: 812da6791f6f5bb41902ddf7118c338d,
+        type: 3}
+      propertyPath: defaultColors.BlueNoteColor.r
+      value: 0.04805952
+      objectReference: {fileID: 0}
+    - target: {fileID: 7351533105162161635, guid: 812da6791f6f5bb41902ddf7118c338d,
+        type: 3}
+      propertyPath: defaultColors.BlueNoteColor.g
+      value: 0.5068096
+      objectReference: {fileID: 0}
+    - target: {fileID: 7351533105162161635, guid: 812da6791f6f5bb41902ddf7118c338d,
+        type: 3}
+      propertyPath: defaultColors.BlueNoteColor.b
+      value: 0.734
+      objectReference: {fileID: 0}
+    - target: {fileID: 7351533105162161635, guid: 812da6791f6f5bb41902ddf7118c338d,
+        type: 3}
+      propertyPath: defaultColors.RedColor.r
+      value: 0.13456802
+      objectReference: {fileID: 0}
+    - target: {fileID: 7351533105162161635, guid: 812da6791f6f5bb41902ddf7118c338d,
+        type: 3}
+      propertyPath: defaultColors.RedColor.g
+      value: 0.756
+      objectReference: {fileID: 0}
+    - target: {fileID: 7351533105162161635, guid: 812da6791f6f5bb41902ddf7118c338d,
+        type: 3}
+      propertyPath: defaultColors.RedColor.b
+      value: 0.15575325
+      objectReference: {fileID: 0}
+    - target: {fileID: 7351533105162161635, guid: 812da6791f6f5bb41902ddf7118c338d,
+        type: 3}
+      propertyPath: defaultColors.BlueColor.r
+      value: 0.05647058
+      objectReference: {fileID: 0}
+    - target: {fileID: 7351533105162161635, guid: 812da6791f6f5bb41902ddf7118c338d,
+        type: 3}
+      propertyPath: defaultColors.BlueColor.g
+      value: 0.6211764
+      objectReference: {fileID: 0}
+    - target: {fileID: 7351533105162161635, guid: 812da6791f6f5bb41902ddf7118c338d,
+        type: 3}
+      propertyPath: defaultColors.BlueColor.b
+      value: 0.9
+      objectReference: {fileID: 0}
+    - target: {fileID: 7351533105162161635, guid: 812da6791f6f5bb41902ddf7118c338d,
+        type: 3}
+      propertyPath: defaultColors.RedBoostColor.r
+      value: 0.13333334
+      objectReference: {fileID: 0}
+    - target: {fileID: 7351533105162161635, guid: 812da6791f6f5bb41902ddf7118c338d,
+        type: 3}
+      propertyPath: defaultColors.RedBoostColor.g
+      value: 0.7568628
+      objectReference: {fileID: 0}
+    - target: {fileID: 7351533105162161635, guid: 812da6791f6f5bb41902ddf7118c338d,
+        type: 3}
+      propertyPath: defaultColors.RedBoostColor.b
+      value: 0.15686275
+      objectReference: {fileID: 0}
+    - target: {fileID: 7351533105162161635, guid: 812da6791f6f5bb41902ddf7118c338d,
+        type: 3}
+      propertyPath: defaultColors.RedBoostColor.a
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7351533105162161635, guid: 812da6791f6f5bb41902ddf7118c338d,
+        type: 3}
+      propertyPath: defaultColors.BlueBoostColor.r
+      value: 0.05490196
+      objectReference: {fileID: 0}
+    - target: {fileID: 7351533105162161635, guid: 812da6791f6f5bb41902ddf7118c338d,
+        type: 3}
+      propertyPath: defaultColors.BlueBoostColor.g
+      value: 0.61960787
+      objectReference: {fileID: 0}
+    - target: {fileID: 7351533105162161635, guid: 812da6791f6f5bb41902ddf7118c338d,
+        type: 3}
+      propertyPath: defaultColors.BlueBoostColor.b
+      value: 0.90196085
+      objectReference: {fileID: 0}
+    - target: {fileID: 7351533105162161635, guid: 812da6791f6f5bb41902ddf7118c338d,
+        type: 3}
+      propertyPath: defaultColors.BlueBoostColor.a
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7351533105162161635, guid: 812da6791f6f5bb41902ddf7118c338d,
+        type: 3}
+      propertyPath: defaultColors.ObstacleColor.r
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7351533105162161635, guid: 812da6791f6f5bb41902ddf7118c338d,
+        type: 3}
+      propertyPath: defaultColors.ObstacleColor.g
+      value: 0.8117648
+      objectReference: {fileID: 0}
+    - target: {fileID: 7351533105162161635, guid: 812da6791f6f5bb41902ddf7118c338d,
+        type: 3}
+      propertyPath: defaultColors.ObstacleColor.b
+      value: 0.09019608
+      objectReference: {fileID: 0}
     - target: {fileID: 7351533105162161638, guid: 812da6791f6f5bb41902ddf7118c338d,
         type: 3}
       propertyPath: m_IsActive

--- a/Assets/_Prefabs/MapEditor/Platforms/Monstercat.prefab
+++ b/Assets/_Prefabs/MapEditor/Platforms/Monstercat.prefab
@@ -99,6 +99,57 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+--- !u!1 &1063356554349949085
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8376547354407572871}
+  - component: {fileID: 599520936443548402}
+  m_Layer: 0
+  m_Name: ZOffset
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8376547354407572871
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1063356554349949085}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 9}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 7351533105162161495}
+  m_Father: {fileID: 8512819717719568252}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &599520936443548402
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1063356554349949085}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a8bbd4261539e9e44803b613e65c101f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  LightMaterial: {fileID: 0}
+  OverrideLightGroup: 0
+  OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
+  currentAlpha: 0
+  multiplyAlpha: 1
 --- !u!1 &1950044953334517209
 GameObject:
   m_ObjectHideFlags: 0
@@ -3441,7 +3492,6 @@ GameObject:
   - component: {fileID: 7351533105162161495}
   - component: {fileID: 7351533105162161200}
   - component: {fileID: 7351533105162161232}
-  - component: {fileID: 7351533105162161548}
   m_Layer: 0
   m_Name: BoxLight
   m_TagString: 
@@ -3457,11 +3507,11 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7351533105162161547}
   m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -2.25, y: -0.000030517578, z: 258.60004}
-  m_LocalScale: {x: 0.02, y: 250.00012, z: 0.020000007}
+  m_LocalPosition: {x: -2.25, y: -0.000030517578, z: 249.60004}
+  m_LocalScale: {x: 0.02, y: 250.00012, z: 0.020000005}
   m_Children: []
-  m_Father: {fileID: 8512819717719568252}
-  m_RootOrder: 8
+  m_Father: {fileID: 8376547354407572871}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!23 &7351533105162161200
 MeshRenderer:
@@ -3510,25 +3560,6 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7351533105162161547}
   m_Mesh: {fileID: 4300000, guid: e8f0e23cb3d14a178d6807f1b86111cb, type: 2}
---- !u!114 &7351533105162161548
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7351533105162161547}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a8bbd4261539e9e44803b613e65c101f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  LightMaterial: {fileID: 0}
-  OverrideLightGroup: 0
-  OverrideLightGroupID: 0
-  UseInvertedPlatformColors: 0
-  CanBeTurnedOff: 1
-  currentAlpha: 0
-  multiplyAlpha: 1
 --- !u!1 &7351533105162161549
 GameObject:
   m_ObjectHideFlags: 0
@@ -3655,7 +3686,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7351533105162161554}
   m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: 4, y: -0.04, z: 9}
+  m_LocalPosition: {x: 4, y: -0.04, z: 100}
   m_LocalScale: {x: 0.02, y: 250.00012, z: 0.020000007}
   m_Children: []
   m_Father: {fileID: 8512819717719568252}
@@ -4410,7 +4441,6 @@ GameObject:
   - component: {fileID: 7351533105162161523}
   - component: {fileID: 7351533105162161349}
   - component: {fileID: 7351533105162161253}
-  - component: {fileID: 7351533105162161594}
   m_Layer: 0
   m_Name: BoxLight
   m_TagString: 
@@ -4426,11 +4456,11 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7351533105162161575}
   m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: 2.25, y: -0.000030517578, z: 258.60004}
-  m_LocalScale: {x: 0.02, y: 250.00012, z: 0.020000007}
+  m_LocalPosition: {x: 2.25, y: -0.000030517578, z: 249.60004}
+  m_LocalScale: {x: 0.02, y: 250.00012, z: 0.020000005}
   m_Children: []
-  m_Father: {fileID: 8512819717719568252}
-  m_RootOrder: 10
+  m_Father: {fileID: 4747270216935041092}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!23 &7351533105162161349
 MeshRenderer:
@@ -4479,25 +4509,6 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7351533105162161575}
   m_Mesh: {fileID: 4300000, guid: e8f0e23cb3d14a178d6807f1b86111cb, type: 2}
---- !u!114 &7351533105162161594
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7351533105162161575}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a8bbd4261539e9e44803b613e65c101f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  LightMaterial: {fileID: 0}
-  OverrideLightGroup: 0
-  OverrideLightGroupID: 0
-  UseInvertedPlatformColors: 0
-  CanBeTurnedOff: 1
-  currentAlpha: 0
-  multiplyAlpha: 1
 --- !u!1 &7351533105162161581
 GameObject:
   m_ObjectHideFlags: 0
@@ -4525,11 +4536,11 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7351533105162161581}
   m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -4, y: 0, z: 9}
+  m_LocalPosition: {x: -4, y: 0, z: 100}
   m_LocalScale: {x: 0.02, y: 250.00012, z: 0.020000007}
   m_Children: []
   m_Father: {fileID: 8512819717719568252}
-  m_RootOrder: 9
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!23 &7351533105162161353
 MeshRenderer:
@@ -6988,6 +6999,57 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+--- !u!1 &8348115093478747336
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4747270216935041092}
+  - component: {fileID: 5686155932574391370}
+  m_Layer: 0
+  m_Name: ZOffset (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4747270216935041092
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8348115093478747336}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 9}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 7351533105162161523}
+  m_Father: {fileID: 8512819717719568252}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &5686155932574391370
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8348115093478747336}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a8bbd4261539e9e44803b613e65c101f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  LightMaterial: {fileID: 0}
+  OverrideLightGroup: 0
+  OverrideLightGroupID: 0
+  UseInvertedPlatformColors: 0
+  CanBeTurnedOff: 1
+  currentAlpha: 0
+  multiplyAlpha: 1
 --- !u!1 &8512819717394002138
 GameObject:
   m_ObjectHideFlags: 0
@@ -7178,9 +7240,9 @@ Transform:
   - {fileID: 7351533105162161291}
   - {fileID: 7351533105162161290}
   - {fileID: 7351533105162161395}
-  - {fileID: 7351533105162161495}
+  - {fileID: 8376547354407572871}
+  - {fileID: 4747270216935041092}
   - {fileID: 7351533105162161529}
-  - {fileID: 7351533105162161523}
   - {fileID: 7351533105162161502}
   - {fileID: 7351533105162161508}
   - {fileID: 7351533105162161324}

--- a/Assets/_Prefabs/MapEditor/Platforms/Monstercat.prefab
+++ b/Assets/_Prefabs/MapEditor/Platforms/Monstercat.prefab
@@ -1463,6 +1463,7 @@ MonoBehaviour:
   LightsGroupedByZ: []
   RotatingLights: []
   GroupingMultiplier: 1
+  GroupingOffset: 0.001
 --- !u!1 &6609029981511743619
 GameObject:
   m_ObjectHideFlags: 0
@@ -7114,7 +7115,7 @@ MonoBehaviour:
   ringCount: 32
   prefab: {fileID: 8512819718878058976}
   moveFirstRing: 0
-  minPositionStep: 1
+  minPositionStep: 4
   maxPositionStep: 4
   moveSpeed: 1
   rotationStep: 5
@@ -7204,6 +7205,7 @@ MonoBehaviour:
   LightsGroupedByZ: []
   RotatingLights: []
   GroupingMultiplier: 1
+  GroupingOffset: 0.001
 --- !u!1 &8512819718369206043
 GameObject:
   m_ObjectHideFlags: 0
@@ -7260,6 +7262,7 @@ MonoBehaviour:
   LightsGroupedByZ: []
   RotatingLights: []
   GroupingMultiplier: 1
+  GroupingOffset: 0.001
 --- !u!1 &8512819718662657262
 GameObject:
   m_ObjectHideFlags: 0
@@ -7317,6 +7320,7 @@ MonoBehaviour:
   LightsGroupedByZ: []
   RotatingLights: []
   GroupingMultiplier: 1
+  GroupingOffset: 0.001
 --- !u!1 &8512819718859163276
 GameObject:
   m_ObjectHideFlags: 0
@@ -7371,6 +7375,7 @@ MonoBehaviour:
   LightsGroupedByZ: []
   RotatingLights: []
   GroupingMultiplier: 1
+  GroupingOffset: 0.001
 --- !u!1 &8512819718878058978
 GameObject:
   m_ObjectHideFlags: 0
@@ -7469,6 +7474,7 @@ MonoBehaviour:
   LightsGroupedByZ: []
   RotatingLights: []
   GroupingMultiplier: 1
+  GroupingOffset: 0.001
 --- !u!1 &8566686002961940649
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/_Prefabs/MapEditor/Platforms/Monstercat.prefab
+++ b/Assets/_Prefabs/MapEditor/Platforms/Monstercat.prefab
@@ -5292,13 +5292,13 @@ MonoBehaviour:
     BlueNoteColor: {r: 0, g: 0.3701827, b: 0.7352942, a: 1}
     ObstacleColor: {r: 0.7352942, g: 0, b: 0, a: 1}
   defaultColors:
-    RedColor: {r: 1, g: 0, b: 0, a: 1}
-    BlueColor: {r: 0, g: 0.282353, b: 1, a: 1}
+    RedColor: {r: 0.78431374, g: 0.07843138, b: 0.07843138, a: 1}
+    BlueColor: {r: 0.1882353, g: 0.59607846, b: 1, a: 1}
     RedBoostColor: {r: 0, g: 0, b: 0, a: 0}
     BlueBoostColor: {r: 0, g: 0, b: 0, a: 0}
-    RedNoteColor: {r: 0.7352942, g: 0, b: 0, a: 1}
-    BlueNoteColor: {r: 0, g: 0.3701827, b: 0.7352942, a: 1}
-    ObstacleColor: {r: 0.7352942, g: 0, b: 0, a: 1}
+    RedNoteColor: {r: 0.78431374, g: 0.07843138, b: 0.07843138, a: 1}
+    BlueNoteColor: {r: 0, g: 0.4627451, b: 0.8235294, a: 1}
+    ObstacleColor: {r: 1, g: 0.18823531, b: 0.18823531, a: 1}
   SortMode: 0
   DisablableObjects:
   - {fileID: 7351533105162161417}

--- a/Assets/__Scenes/999_PrefabBuilding.unity
+++ b/Assets/__Scenes/999_PrefabBuilding.unity
@@ -365,7 +365,7 @@ PrefabInstance:
     - target: {fileID: 6242133936360174716, guid: 76b9890868824df4b9fc89f35f915306,
         type: 3}
       propertyPath: m_IsActive
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6988419381684225647, guid: 76b9890868824df4b9fc89f35f915306,
         type: 3}
@@ -2573,7 +2573,7 @@ PrefabInstance:
     - target: {fileID: 7351533105162161641, guid: 812da6791f6f5bb41902ddf7118c338d,
         type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 812da6791f6f5bb41902ddf7118c338d, type: 3}

--- a/Assets/__Scripts/Input/ChroMapper/CMInputCallbackInstaller.cs
+++ b/Assets/__Scripts/Input/ChroMapper/CMInputCallbackInstaller.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using JetBrains.Annotations;
 using UnityEngine;
 using UnityEngine.InputSystem;
 using UnityEngine.SceneManagement;
@@ -291,6 +292,8 @@ public class CMInputCallbackInstaller : MonoBehaviour
             EventObject = eventObject;
             Handler = handler;
             InterfaceType = interfaceType;
+            
+            EventInfo.AddEventHandler(EventObject, (Action<InputAction.CallbackContext>) ReleaseListenerFunc);
         }
 
         public void EnableEventHandler()
@@ -303,6 +306,14 @@ public class CMInputCallbackInstaller : MonoBehaviour
         {
             EventInfo.RemoveEventHandler(EventObject, Handler);
             IsDisabled = true;
+        }
+
+        private void ReleaseListenerFunc(InputAction.CallbackContext context)
+        {
+            if (IsDisabled && context.canceled)
+            {
+                Handler.DynamicInvoke(context);
+            }
         }
 
         public override int GetHashCode()

--- a/Assets/__Scripts/Map/Notes/BeatmapNote.cs
+++ b/Assets/__Scripts/Map/Notes/BeatmapNote.cs
@@ -96,7 +96,7 @@ public class BeatmapNote : BeatmapObject, IBeatmapObjectBounds
 
     public Vector2 GetCenter()
     {
-        return GetPosition() + new Vector2(0.5f, 0.5f);
+        return GetPosition() + new Vector2(0f, 0.5f);
     }
 
     protected override bool IsConflictingWithObjectAtSameTime(BeatmapObject other, bool deletion)

--- a/Assets/__Scripts/MapEditor/Detection/DingOnNotePassingGrid.cs
+++ b/Assets/__Scripts/MapEditor/Detection/DingOnNotePassingGrid.cs
@@ -128,6 +128,12 @@ public class DingOnNotePassingGrid : MonoBehaviour {
         // (Commonly occurs when Unity freezes for some unrelated fucking reason)
         if (objectData._time - container.AudioTimeSyncController.CurrentBeat <= -0.5f) return;
 
+        var soundListId = Settings.Instance.NoteHitSound;
+        if (soundListId == (int)HitSounds.DISCORD)
+        {
+            Instantiate(discordPingPrefab, gameObject.transform, true);
+        }
+
         // bongo cat
         bongocat.triggerArm(objectData as BeatmapNote, container);
     }
@@ -144,15 +150,10 @@ public class DingOnNotePassingGrid : MonoBehaviour {
          * the same time that are supposed to ding from triggering the sound effects.
          */
         lastCheckedTime = objectData._time;
-        int soundListId = Settings.Instance.NoteHitSound;
-        SoundList list = soundLists[soundListId];
-        
-        if (soundListId == (int)HitSounds.DISCORD)
-        {
-            Instantiate(discordPingPrefab, gameObject.transform, true);
-        }
-        
-        bool shortCut = false;
+        var soundListId = Settings.Instance.NoteHitSound;
+        var list = soundLists[soundListId];
+
+        var shortCut = false;
         if (index - DensityCheckOffset > 0 && index + DensityCheckOffset < container.LoadedObjects.Count)
         {
             BeatmapObject first = container.LoadedObjects.ElementAt(index + DensityCheckOffset);

--- a/Assets/__Scripts/MapEditor/UI/Bookmarks/BookmarkContainer.cs
+++ b/Assets/__Scripts/MapEditor/UI/Bookmarks/BookmarkContainer.cs
@@ -48,7 +48,7 @@ public class BookmarkContainer : MonoBehaviour, IPointerClickHandler
     {
         if (res == 0)
         {
-            manager.bookmarkContainers.Remove(this);
+            manager.DeleteBookmark(this);
             Destroy(gameObject);
         }
     }

--- a/Assets/__Scripts/MapEditor/UI/CurrentSectionDisplay.cs
+++ b/Assets/__Scripts/MapEditor/UI/CurrentSectionDisplay.cs
@@ -22,12 +22,14 @@ public class CurrentSectionDisplay : MonoBehaviour
     {
         atsc.OnTimeChanged += OnTimeChanged;
         atsc.OnPlayToggle += OnPlayToggle;
+        bookmarkManger.OnBookmarksUpdated += OnTimeChanged;
     }
 
     void OnDisable()
     {
         atsc.OnTimeChanged -= OnTimeChanged;
         atsc.OnPlayToggle -= OnPlayToggle;
+        bookmarkManger.OnBookmarksUpdated -= OnTimeChanged;
     }
 
     private void OnTimeChanged()


### PR DESCRIPTION
- Break zoom on monstercat as it doesn't work in game
- Update current bookmark display when adding or removing bookmarks
- Fix selection box getting notes to the left
- Fix monstercat prop ordering
- Fix crab rave and monstercat colours
- Spawn discord hit objects at correct time
- Allow keys to be released even when input map is disabled. Fixes issues where modifier keys get stuck after certain actions.