### PR TITLE
Light id changes / fixes

### DIFF
--- a/Assets/_Prefabs/MapEditor/Platforms/KDA.prefab
+++ b/Assets/_Prefabs/MapEditor/Platforms/KDA.prefab
@@ -99,6 +99,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &13815772407672375
 GameObject:
   m_ObjectHideFlags: 0
@@ -343,6 +344,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &254824196850933271
 GameObject:
   m_ObjectHideFlags: 0
@@ -650,6 +652,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &760597903517839888
 GameObject:
   m_ObjectHideFlags: 0
@@ -749,6 +752,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &908066069482740103
 GameObject:
   m_ObjectHideFlags: 0
@@ -927,6 +931,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &1107564559657842125
 GameObject:
   m_ObjectHideFlags: 0
@@ -1135,6 +1140,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &1232110310220603176
 GameObject:
   m_ObjectHideFlags: 0
@@ -1755,6 +1761,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &2076211754928481829
 GameObject:
   m_ObjectHideFlags: 0
@@ -1885,6 +1892,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &2095007007908745405
 GameObject:
   m_ObjectHideFlags: 0
@@ -2303,6 +2311,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &2803975274851132607
 GameObject:
   m_ObjectHideFlags: 0
@@ -2536,6 +2545,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &3145325757835232756
 GameObject:
   m_ObjectHideFlags: 0
@@ -2635,6 +2645,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &3349435801491561759
 GameObject:
   m_ObjectHideFlags: 0
@@ -2734,6 +2745,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &3459555731494397772
 GameObject:
   m_ObjectHideFlags: 0
@@ -3078,6 +3090,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: -100
 --- !u!1 &3730129544149060668
 GameObject:
   m_ObjectHideFlags: 0
@@ -3343,6 +3356,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &4042404644260783440
 GameObject:
   m_ObjectHideFlags: 0
@@ -3442,6 +3456,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &4061206134861046906
 GameObject:
   m_ObjectHideFlags: 0
@@ -3541,6 +3556,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &4180084392161678958
 GameObject:
   m_ObjectHideFlags: 0
@@ -3813,6 +3829,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: -100
 --- !u!1 &4362687963356594788
 GameObject:
   m_ObjectHideFlags: 0
@@ -4042,6 +4059,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &4518043958057388686
 GameObject:
   m_ObjectHideFlags: 0
@@ -4156,6 +4174,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: -100
 --- !u!1 &4798922767217584700
 GameObject:
   m_ObjectHideFlags: 0
@@ -4392,6 +4411,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &5067107877328175190
 GameObject:
   m_ObjectHideFlags: 0
@@ -4522,6 +4542,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &5173239875999120038
 GameObject:
   m_ObjectHideFlags: 0
@@ -4782,6 +4803,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &5544828730213102349
 GameObject:
   m_ObjectHideFlags: 0
@@ -4960,6 +4982,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &5666389974330141274
 GameObject:
   m_ObjectHideFlags: 0
@@ -5092,6 +5115,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &5838464521857199805
 GameObject:
   m_ObjectHideFlags: 0
@@ -5222,6 +5246,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &6319468886780944063
 GameObject:
   m_ObjectHideFlags: 0
@@ -5382,6 +5407,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &6622272525267384230
 GameObject:
   m_ObjectHideFlags: 0
@@ -5946,6 +5972,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536064
 GameObject:
   m_ObjectHideFlags: 0
@@ -5997,6 +6024,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536069
 GameObject:
   m_ObjectHideFlags: 0
@@ -6048,6 +6076,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536072
 GameObject:
   m_ObjectHideFlags: 0
@@ -6099,6 +6128,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536074
 GameObject:
   m_ObjectHideFlags: 0
@@ -6229,6 +6259,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536077
 GameObject:
   m_ObjectHideFlags: 0
@@ -6280,6 +6311,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536079
 GameObject:
   m_ObjectHideFlags: 0
@@ -6331,6 +6363,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536080
 GameObject:
   m_ObjectHideFlags: 0
@@ -6382,6 +6415,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536083
 GameObject:
   m_ObjectHideFlags: 0
@@ -6433,6 +6467,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536085
 GameObject:
   m_ObjectHideFlags: 0
@@ -6879,6 +6914,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536093
 GameObject:
   m_ObjectHideFlags: 0
@@ -6930,6 +6966,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536094
 GameObject:
   m_ObjectHideFlags: 0
@@ -6981,6 +7018,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536100
 GameObject:
   m_ObjectHideFlags: 0
@@ -7032,6 +7070,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536101
 GameObject:
   m_ObjectHideFlags: 0
@@ -7083,6 +7122,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536102
 GameObject:
   m_ObjectHideFlags: 0
@@ -7134,6 +7174,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536103
 GameObject:
   m_ObjectHideFlags: 0
@@ -7501,6 +7542,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536115
 GameObject:
   m_ObjectHideFlags: 0
@@ -7552,6 +7594,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536116
 GameObject:
   m_ObjectHideFlags: 0
@@ -7603,6 +7646,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536117
 GameObject:
   m_ObjectHideFlags: 0
@@ -7654,6 +7698,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536121
 GameObject:
   m_ObjectHideFlags: 0
@@ -7863,6 +7908,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536125
 GameObject:
   m_ObjectHideFlags: 0
@@ -7914,6 +7960,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536126
 GameObject:
   m_ObjectHideFlags: 0
@@ -8202,6 +8249,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536137
 GameObject:
   m_ObjectHideFlags: 0
@@ -8253,6 +8301,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536143
 GameObject:
   m_ObjectHideFlags: 0
@@ -8304,6 +8353,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536145
 GameObject:
   m_ObjectHideFlags: 0
@@ -8355,6 +8405,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536147
 GameObject:
   m_ObjectHideFlags: 0
@@ -8406,6 +8457,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536148
 GameObject:
   m_ObjectHideFlags: 0
@@ -8536,6 +8588,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536153
 GameObject:
   m_ObjectHideFlags: 0
@@ -8587,6 +8640,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536155
 GameObject:
   m_ObjectHideFlags: 0
@@ -8875,6 +8929,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536162
 GameObject:
   m_ObjectHideFlags: 0
@@ -9005,6 +9060,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536164
 GameObject:
   m_ObjectHideFlags: 0
@@ -9214,6 +9270,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536168
 GameObject:
   m_ObjectHideFlags: 0
@@ -9265,6 +9322,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536170
 GameObject:
   m_ObjectHideFlags: 0
@@ -9316,6 +9374,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536171
 GameObject:
   m_ObjectHideFlags: 0
@@ -9446,6 +9505,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536179
 GameObject:
   m_ObjectHideFlags: 0
@@ -9655,6 +9715,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536183
 GameObject:
   m_ObjectHideFlags: 0
@@ -9706,6 +9767,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536186
 GameObject:
   m_ObjectHideFlags: 0
@@ -9836,6 +9898,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536191
 GameObject:
   m_ObjectHideFlags: 0
@@ -9887,6 +9950,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536206
 GameObject:
   m_ObjectHideFlags: 0
@@ -9938,6 +10002,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536207
 GameObject:
   m_ObjectHideFlags: 0
@@ -9989,6 +10054,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536208
 GameObject:
   m_ObjectHideFlags: 0
@@ -10040,6 +10106,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536210
 GameObject:
   m_ObjectHideFlags: 0
@@ -10091,6 +10158,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536213
 GameObject:
   m_ObjectHideFlags: 0
@@ -10142,6 +10210,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536214
 GameObject:
   m_ObjectHideFlags: 0
@@ -10430,6 +10499,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536223
 GameObject:
   m_ObjectHideFlags: 0
@@ -10560,6 +10630,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536226
 GameObject:
   m_ObjectHideFlags: 0
@@ -10611,6 +10682,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536227
 GameObject:
   m_ObjectHideFlags: 0
@@ -10741,6 +10813,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536232
 GameObject:
   m_ObjectHideFlags: 0
@@ -10792,6 +10865,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536233
 GameObject:
   m_ObjectHideFlags: 0
@@ -10922,6 +10996,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536239
 GameObject:
   m_ObjectHideFlags: 0
@@ -11052,6 +11127,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536242
 GameObject:
   m_ObjectHideFlags: 0
@@ -11340,6 +11416,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536246
 GameObject:
   m_ObjectHideFlags: 0
@@ -11549,6 +11626,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536252
 GameObject:
   m_ObjectHideFlags: 0
@@ -11837,6 +11915,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536265
 GameObject:
   m_ObjectHideFlags: 0
@@ -12152,6 +12231,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536274
 GameObject:
   m_ObjectHideFlags: 0
@@ -12519,6 +12599,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536284
 GameObject:
   m_ObjectHideFlags: 0
@@ -12570,6 +12651,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536285
 GameObject:
   m_ObjectHideFlags: 0
@@ -12621,6 +12703,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536286
 GameObject:
   m_ObjectHideFlags: 0
@@ -12672,6 +12755,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536287
 GameObject:
   m_ObjectHideFlags: 0
@@ -12723,6 +12807,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536288
 GameObject:
   m_ObjectHideFlags: 0
@@ -12853,6 +12938,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536293
 GameObject:
   m_ObjectHideFlags: 0
@@ -13141,6 +13227,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536300
 GameObject:
   m_ObjectHideFlags: 0
@@ -13271,6 +13358,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536302
 GameObject:
   m_ObjectHideFlags: 0
@@ -13638,6 +13726,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536310
 GameObject:
   m_ObjectHideFlags: 0
@@ -13689,6 +13778,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536313
 GameObject:
   m_ObjectHideFlags: 0
@@ -13898,6 +13988,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536451
 GameObject:
   m_ObjectHideFlags: 0
@@ -13949,6 +14040,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536457
 GameObject:
   m_ObjectHideFlags: 0
@@ -14000,6 +14092,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536458
 GameObject:
   m_ObjectHideFlags: 0
@@ -14051,6 +14144,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536459
 GameObject:
   m_ObjectHideFlags: 0
@@ -14418,6 +14512,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536474
 GameObject:
   m_ObjectHideFlags: 0
@@ -14469,6 +14564,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536476
 GameObject:
   m_ObjectHideFlags: 0
@@ -14757,6 +14853,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536482
 GameObject:
   m_ObjectHideFlags: 0
@@ -14966,6 +15063,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536488
 GameObject:
   m_ObjectHideFlags: 0
@@ -15017,6 +15115,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536491
 GameObject:
   m_ObjectHideFlags: 0
@@ -15384,6 +15483,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536498
 GameObject:
   m_ObjectHideFlags: 0
@@ -15514,6 +15614,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536500
 GameObject:
   m_ObjectHideFlags: 0
@@ -15644,6 +15745,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536504
 GameObject:
   m_ObjectHideFlags: 0
@@ -15853,6 +15955,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &7933757585112536510
 GameObject:
   m_ObjectHideFlags: 0
@@ -16107,6 +16210,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: -100
 --- !u!1 &8436084715461386452
 GameObject:
   m_ObjectHideFlags: 0
@@ -16299,6 +16403,7 @@ MonoBehaviour:
   CanBeTurnedOff: 1
   currentAlpha: 0
   multiplyAlpha: 1
+  lightIdOffset: 0
 --- !u!1 &8844315766948792079
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/__Scripts/MapEditor/Mapping/Strobe Generator/StrobeGenerator.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/Strobe Generator/StrobeGenerator.cs
@@ -53,7 +53,8 @@ public class StrobeGenerator : MonoBehaviour {
 
                         IEnumerable<MapEvent> containersBetween = eventsContainer.LoadedObjects.GetViewBetween(start, end).Cast<MapEvent>().Where(x =>
                             x._type == start._type && //Grab all events between start and end point.
-                            start.IsPropogationEvent == x.IsPropogationEvent && (!start.IsPropogationEvent || start.PropId == x.PropId)
+                            (propMode != EventsContainer.PropMode.Prop || start.IsPropogationEvent == x.IsPropogationEvent && (!start.IsPropogationEvent || start.PropId == x.PropId)) &&
+                            (propMode != EventsContainer.PropMode.Light || start.IsLightIdEvent == x.IsLightIdEvent && (!start.IsLightIdEvent || start.LightId == x.LightId))
                         );
                         oldEvents.AddRange(containersBetween);
 

--- a/Assets/__Scripts/Platforms/LightingEvent.cs
+++ b/Assets/__Scripts/Platforms/LightingEvent.cs
@@ -22,6 +22,7 @@ public class LightingEvent : MonoBehaviour {
     private float colorTime = 0;
     private float timeToTransitionColor = 0;
     private float timeToTransitionAlpha = 0;
+    public int lightIdOffset = 0;
 
     // Use this for initialization
     void Start ()

--- a/Assets/__Scripts/Platforms/LightsManager.cs
+++ b/Assets/__Scripts/Platforms/LightsManager.cs
@@ -41,7 +41,7 @@ public class LightsManager : MonoBehaviour
                     ControllingLights.Add(e);
                 }
             }
-            ControllingLights = ControllingLights.OrderBy(x => x.transform.position.z).ToList();
+            ControllingLights = ControllingLights.OrderBy(x => x.transform.position.z + x.lightIdOffset).ToList();
             foreach (RotatingLightsBase e in GetComponentsInChildren<RotatingLightsBase>())
             {
                 if (!e.IsOverrideLightGroup())
@@ -61,7 +61,8 @@ public class LightsManager : MonoBehaviour
         foreach(LightingEvent light in ControllingLights)
         {
             if (!light.gameObject.activeInHierarchy) continue;
-            int z = Mathf.RoundToInt((light.transform.position.z * GroupingMultiplier) + GroupingOffset);
+            float tz = (light.transform.position.z * GroupingMultiplier) + GroupingOffset;
+            int z = Mathf.RoundToInt(tz);
             if (pregrouped.TryGetValue(z, out List<LightingEvent> list))
             {
                 list.Add(light);
@@ -184,9 +185,9 @@ public class LightsManager : MonoBehaviour
     {
         Gizmos.color = Color.red;
         if (GroupingMultiplier <= 0.1f) return;
-        for (var i = 0; i < 150; i++)
+        for (var i = -5; i < 150; i++)
         {
-            var z = Mathf.RoundToInt(i * GroupingMultiplier);
+            var z = ((i - GroupingOffset) / GroupingMultiplier) + 0.5f;
             Gizmos.DrawLine(new Vector3(-50, 0, z), new Vector3(50, 0, z));
         }
     }


### PR DESCRIPTION
I missed a spot in gradient gen
Add light id offset because KDA sticks can't be re-ordered sensibly in prop id mode due to groupings between the chevron / lane lights and random sticks. But we can adjust the light id order.