### PR TITLE
Fix selection in 360

### DIFF
--- a/Assets/__Scripts/Extensions/TransformExtensions.cs
+++ b/Assets/__Scripts/Extensions/TransformExtensions.cs
@@ -1,0 +1,40 @@
+﻿using UnityEngine;
+
+static class TransformExtensions
+{
+    public static Bounds TransformBounds( this Transform _transform, Bounds _localBounds )
+    {
+        var center = _transform.TransformPoint(_localBounds.center);
+ 
+        // transform the local extents' axes
+        var extents = _localBounds.extents;
+        var axisX = _transform.TransformVector(extents.x, 0, 0);
+        var axisY = _transform.TransformVector(0, extents.y, 0);
+        var axisZ = _transform.TransformVector(0, 0, extents.z);
+ 
+        // sum their absolute value to get the world extents
+        extents.x = Mathf.Abs(axisX.x) + Mathf.Abs(axisY.x) + Mathf.Abs(axisZ.x);
+        extents.y = Mathf.Abs(axisX.y) + Mathf.Abs(axisY.y) + Mathf.Abs(axisZ.y);
+        extents.z = Mathf.Abs(axisX.z) + Mathf.Abs(axisY.z) + Mathf.Abs(axisZ.z);
+ 
+        return new Bounds { center = center, extents = extents };
+    }
+    
+    public static Bounds InverseTransformBounds( this Transform _transform, Bounds _localBounds )
+    {
+        var center = _transform.InverseTransformPoint(_localBounds.center);
+ 
+        // transform the local extents' axes
+        var extents = _localBounds.extents;
+        var axisX = _transform.InverseTransformVector(extents.x, 0, 0);
+        var axisY = _transform.InverseTransformVector(0, extents.y, 0);
+        var axisZ = _transform.InverseTransformVector(0, 0, extents.z);
+ 
+        // sum their absolute value to get the world extents
+        extents.x = Mathf.Abs(axisX.x) + Mathf.Abs(axisY.x) + Mathf.Abs(axisZ.x);
+        extents.y = Mathf.Abs(axisX.y) + Mathf.Abs(axisY.y) + Mathf.Abs(axisZ.y);
+        extents.z = Mathf.Abs(axisX.z) + Mathf.Abs(axisY.z) + Mathf.Abs(axisZ.z);
+ 
+        return new Bounds { center = center, extents = extents };
+    }
+}

--- a/Assets/__Scripts/Extensions/TransformExtensions.cs.meta
+++ b/Assets/__Scripts/Extensions/TransformExtensions.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 83604b5a2cb3400bbb0d9030761c1512
+timeCreated: 1610541462

--- a/Assets/__Scripts/MapEditor/Mapping/Selection/BoxSelectionPlacementController.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/Selection/BoxSelectionPlacementController.cs
@@ -46,14 +46,20 @@ public class BoxSelectionPlacementController : PlacementController<MapEvent, Bea
             SelectedTypes.Add(type);
 
             var boundLocal = placementObj.GetComponentsInChildren<Renderer>().FirstOrDefault(it => it.name == "Grid X").bounds;
+
+            // Transform the bounds into the pseudo-world space we use for selection
+            var localTransform = placementObj.transform;
+            var boundsNew = localTransform.InverseTransformBounds(boundLocal);
+            boundsNew.center = boundsNew.center + localTransform.localPosition;
+
             if (bounds == default)
             {
-                bounds = boundLocal;
+                bounds = boundsNew;
             }
             else
             {
                 // Probably a bad idea but why not drag between lanes
-                bounds.Encapsulate(boundLocal);
+                bounds.Encapsulate(boundsNew);
             }
         }
     }


### PR DESCRIPTION
Transform bounds correctly when rotated into the co-ordinate space we use for selection, this was preventing (or sometimes allowing) the selection box getting to objects in the map