### PR TITLE
Only use _preciseSpeed when necessary

### DIFF
--- a/Assets/__Scripts/MapEditor/Mapping/Strobe Generator/Passes/StrobeLaserSpeedInterpolationPass.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/Strobe Generator/Passes/StrobeLaserSpeedInterpolationPass.cs
@@ -86,7 +86,8 @@ public class StrobeLaserSpeedInterpolationPass : StrobeGeneratorPass
             var decimalPreciseSpeed = Math.Round(Mathf.Lerp(lastSpeed, nextSpeed, easingFunc(progress)), decimalPrecision);
             MapEvent data = new MapEvent(newTime, type, 1);
             data._customData = new JSONObject();
-            data._customData["_preciseSpeed"] = decimalPreciseSpeed;
+            data._value = (int)(Math.Round(decimalPreciseSpeed, MidpointRounding.AwayFromZero) == 0 && decimalPreciseSpeed != 0 ? 1 : Math.Round(decimalPreciseSpeed, MidpointRounding.AwayFromZero));
+            if (decimalPreciseSpeed % 1 != 0) data._customData["_preciseSpeed"] = decimalPreciseSpeed;
             if (overrideDirection)
             {
                 switch (type)


### PR DESCRIPTION
Will not use _preciseSpeed if decimalPreciseSpeed is a whole number. Will also change _value to the whole number closest to decimalPreciseSpeed (unless that number is 0, in which case 1 will get used).

I changed one line and added another, probably badly, you're welcome.