### PR TITLE
Objects actions refactor

### DIFF
--- a/Assets/Plugins/SimpleJSONUnity.cs
+++ b/Assets/Plugins/SimpleJSONUnity.cs
@@ -98,7 +98,7 @@ namespace SimpleJSON
         public static implicit operator JSONNode(Color aColor)
         {
             JSONNode n = GetContainer(ColorContainerType);
-            n.WriteColor(aColor, aColor.a != 1);
+            n.WriteColor(aColor);
             return n;
         }
 

--- a/Assets/Tests/BPMTest.cs
+++ b/Assets/Tests/BPMTest.cs
@@ -1,0 +1,65 @@
+﻿using NUnit.Framework;
+using System.Collections;
+using System.Linq;
+using Tests.Util;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Tests
+{
+    public class BPMTest
+    {
+        [UnityOneTimeSetUp]
+        public IEnumerator LoadMap() => TestUtils.LoadMapper();
+
+        [TearDown]
+        public void ContainerCleanup()
+        {
+            BeatmapActionContainer.RemoveAllActionsOfType<BeatmapAction>();
+            TestUtils.CleanupBPMChanges();
+        }
+
+        private static void CheckBPM(BeatmapObjectContainerCollection container, int idx, int time, int bpm)
+        {
+            var newObjA = container.LoadedObjects.Skip(idx).First();
+            Assert.IsInstanceOf<BeatmapBPMChange>(newObjA);
+            if (newObjA is BeatmapBPMChange newNoteA)
+            {
+                Assert.AreEqual(time, newNoteA._time);
+                Assert.AreEqual(bpm, newNoteA._BPM);
+            }
+        }
+        
+        [Test]
+        public void ModifyEvent()
+        {
+            var actionContainer = Object.FindObjectOfType<BeatmapActionContainer>();
+            var collection = BeatmapObjectContainerCollection.GetCollectionForType(BeatmapObject.Type.BPM_CHANGE);
+            if (collection is BPMChangesContainer bpmCollection)
+            {
+                var root = bpmCollection.transform.root;
+
+                var bpmChange = new BeatmapBPMChange(50, 10);
+                bpmCollection.SpawnObject(bpmChange);
+
+                if (bpmCollection.LoadedContainers[bpmChange] is BeatmapBPMChangeContainer container)
+                {
+                    BeatmapBPMChangeInputController.ChangeBPM(container, "60");
+                }
+
+                Assert.AreEqual(1, bpmCollection.LoadedObjects.Count);
+                CheckBPM(bpmCollection, 0, 10, 60);
+
+                actionContainer.Undo();
+
+                Assert.AreEqual(1, bpmCollection.LoadedObjects.Count);
+                CheckBPM(bpmCollection, 0, 10, 50);
+
+                actionContainer.Redo();
+
+                Assert.AreEqual(1, bpmCollection.LoadedObjects.Count);
+                CheckBPM(bpmCollection, 0, 10, 60);
+            }
+        }
+    }
+}

--- a/Assets/Tests/BPMTest.cs
+++ b/Assets/Tests/BPMTest.cs
@@ -37,8 +37,6 @@ namespace Tests
             var collection = BeatmapObjectContainerCollection.GetCollectionForType(BeatmapObject.Type.BPM_CHANGE);
             if (collection is BPMChangesContainer bpmCollection)
             {
-                var root = bpmCollection.transform.root;
-
                 var bpmChange = new BeatmapBPMChange(50, 10);
                 bpmCollection.SpawnObject(bpmChange);
 

--- a/Assets/Tests/BPMTest.cs.meta
+++ b/Assets/Tests/BPMTest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 32e5cb59e55f414cbe8dc499cd84ba9b
+timeCreated: 1612641463

--- a/Assets/Tests/BeatmapActionTest.cs
+++ b/Assets/Tests/BeatmapActionTest.cs
@@ -14,6 +14,7 @@ namespace Tests
         [TearDown]
         public void ContainerCleanup()
         {
+            BeatmapActionContainer.RemoveAllActionsOfType<BeatmapAction>();
             TestUtils.CleanupNotes();
         }
 
@@ -46,6 +47,164 @@ namespace Tests
 
             Assert.AreEqual(1, notesContainer.LoadedObjects.Count);
             Assert.AreEqual(1.9999999f, notesContainer.UnsortedObjects[0]._time);
+        }
+
+        [Test]
+        public void CompositeTest()
+        {
+            var actionContainer = Object.FindObjectOfType<BeatmapActionContainer>();
+            var notesContainer = BeatmapObjectContainerCollection.GetCollectionForType(BeatmapObject.Type.NOTE);
+            var root = notesContainer.transform.root;
+            var selectionController = root.GetComponentInChildren<SelectionController>();
+            var notePlacement = root.GetComponentInChildren<NotePlacement>();
+
+            var noteA = new BeatmapNote
+            {
+                _time = 2,
+                _type = BeatmapNote.NOTE_TYPE_A
+            };
+            var noteB = new BeatmapNote
+            {
+                _time = 2,
+                _type = BeatmapNote.NOTE_TYPE_B,
+                _lineIndex = 1,
+                _lineLayer = 1
+            };
+
+            notePlacement.queuedData = noteA;
+            notePlacement.RoundedTime = notePlacement.queuedData._time;
+            notePlacement.ApplyToMap();
+            
+            SelectionController.Select(noteA);
+            
+            selectionController.ShiftSelection(1, 1);
+
+            // Should conflict with existing note and delete it
+            notePlacement.queuedData = noteB;
+            notePlacement.RoundedTime = notePlacement.queuedData._time;
+            notePlacement.ApplyToMap();
+            
+            SelectionController.Select(noteB);
+            selectionController.ShiftSelection(1, 1);
+            selectionController.Copy(true);
+            
+            selectionController.Paste();
+            selectionController.Delete();
+            
+            void CheckState(int loadedObjects, int selectedObjects, int time, int type, int index, int layer)
+            {
+                Assert.AreEqual(loadedObjects, notesContainer.LoadedObjects.Count);
+                Assert.AreEqual(selectedObjects, SelectionController.SelectedObjects.Count);
+                Assert.AreEqual(time, notesContainer.UnsortedObjects[0]._time);
+                Assert.AreEqual(type, ((BeatmapNote) notesContainer.UnsortedObjects[0])._type);
+                Assert.AreEqual(index, ((BeatmapNote) notesContainer.UnsortedObjects[0])._lineIndex);
+                Assert.AreEqual(layer, ((BeatmapNote) notesContainer.UnsortedObjects[0])._lineLayer);
+            }
+
+            // No notes loaded
+            Assert.AreEqual(0, notesContainer.LoadedObjects.Count);
+            Assert.AreEqual(0, notesContainer.UnsortedObjects.Count);
+            
+            // Undo delete action
+            actionContainer.Undo();
+            CheckState(1, 1, 0, BeatmapNote.NOTE_TYPE_B, 2, 2);
+            
+            // Undo paste action
+            actionContainer.Undo();
+            Assert.AreEqual(0, notesContainer.LoadedObjects.Count);
+            Assert.AreEqual(0, notesContainer.UnsortedObjects.Count);
+            
+            // Undo cut action
+            actionContainer.Undo();
+            CheckState(1, 1, 2, BeatmapNote.NOTE_TYPE_B, 2, 2);
+
+            // Undo movement
+            actionContainer.Undo();
+            CheckState(1, 1, 2, BeatmapNote.NOTE_TYPE_B, 1, 1);
+
+            // Undo overwrite
+            actionContainer.Undo();
+            CheckState(1, 0, 2, BeatmapNote.NOTE_TYPE_A, 1, 1);
+
+            // Undo movement
+            actionContainer.Undo();
+            CheckState(1, 1, 2, BeatmapNote.NOTE_TYPE_A, 0, 0);
+
+            // Undo placement
+            actionContainer.Undo();
+
+            Assert.AreEqual(0, notesContainer.LoadedObjects.Count);
+            Assert.AreEqual(0, SelectionController.SelectedObjects.Count);
+            
+            // Redo it all! - Selection is lost :(
+            actionContainer.Redo();
+            CheckState(1, 0, 2, BeatmapNote.NOTE_TYPE_A, 0, 0);
+            
+            // Moving it selects it
+            actionContainer.Redo();
+            CheckState(1, 1, 2, BeatmapNote.NOTE_TYPE_A, 1, 1);
+            
+            // Everything is backwards
+            actionContainer.Redo();
+            CheckState(1, 0, 2, BeatmapNote.NOTE_TYPE_B, 1, 1);
+
+            actionContainer.Redo();
+            CheckState(1, 1, 2, BeatmapNote.NOTE_TYPE_B, 2, 2);
+
+            actionContainer.Redo();
+            Assert.AreEqual(0, notesContainer.LoadedObjects.Count);
+            Assert.AreEqual(0, notesContainer.UnsortedObjects.Count);
+            
+            // Redo paste
+            actionContainer.Redo();
+            CheckState(1, 1, 0, BeatmapNote.NOTE_TYPE_B, 2, 2);
+
+            // Delete redo should still work even if our object isn't selected
+            SelectionController.DeselectAll();
+            
+            // Redo delete
+            actionContainer.Redo();
+            Assert.AreEqual(0, notesContainer.LoadedObjects.Count);
+            Assert.AreEqual(0, notesContainer.UnsortedObjects.Count);
+        }
+        
+        [Test]
+        public void ModifiedWithConflictingAction()
+        {
+            var actionContainer = Object.FindObjectOfType<BeatmapActionContainer>();
+
+            var notesContainer = BeatmapObjectContainerCollection.GetCollectionForType(BeatmapObject.Type.NOTE);
+            var root = notesContainer.transform.root;
+            var notePlacement = root.GetComponentInChildren<NotePlacement>();
+
+            notePlacement.queuedData = new BeatmapNote
+            {
+                _time = 2,
+                _type = BeatmapNote.NOTE_TYPE_A
+            };
+            notePlacement.RoundedTime = notePlacement.queuedData._time;
+            notePlacement.ApplyToMap();
+
+            notePlacement.queuedData = new BeatmapNote
+            {
+                _time = 2,
+                _type = BeatmapNote.NOTE_TYPE_B
+            };
+            notePlacement.RoundedTime = notePlacement.queuedData._time;
+            notePlacement.ApplyToMap();
+
+            Assert.AreEqual(1, notesContainer.LoadedObjects.Count);
+            Assert.AreEqual(2, notesContainer.UnsortedObjects[0]._time);
+
+            actionContainer.Undo();
+
+            Assert.AreEqual(1, notesContainer.LoadedObjects.Count);
+            Assert.AreEqual(2, notesContainer.UnsortedObjects[0]._time);
+
+            actionContainer.Redo();
+
+            Assert.AreEqual(1, notesContainer.LoadedObjects.Count);
+            Assert.AreEqual(2, notesContainer.UnsortedObjects[0]._time);
         }
     }
 }

--- a/Assets/Tests/EventTest.cs
+++ b/Assets/Tests/EventTest.cs
@@ -1,0 +1,121 @@
+﻿using NUnit.Framework;
+using System.Collections;
+using System.Linq;
+using SimpleJSON;
+using Tests.Util;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Tests
+{
+    public class EventTest
+    {
+        [UnityOneTimeSetUp]
+        public IEnumerator LoadMap() => TestUtils.LoadMapper();
+
+        [TearDown]
+        public void ContainerCleanup()
+        {
+            BeatmapActionContainer.RemoveAllActionsOfType<BeatmapAction>();
+            TestUtils.CleanupEvents();
+        }
+
+        public static void CheckEvent(BeatmapObjectContainerCollection container, int idx, int time, int type, int value, JSONNode customData = null)
+        {
+            var newObjA = container.LoadedObjects.Skip(idx).First();
+            Assert.IsInstanceOf<MapEvent>(newObjA);
+            if (newObjA is MapEvent newNoteA)
+            {
+                Assert.AreEqual(time, newNoteA._time);
+                Assert.AreEqual(type, newNoteA._type);
+                Assert.AreEqual(value, newNoteA._value);
+
+                // ConvertToJSON causes gradient to get updated
+                if (customData != null) Assert.AreEqual(customData.ToString(), newNoteA.ConvertToJSON()["_customData"].ToString());
+            }
+        }
+        
+        [Test]
+        public void Invert()
+        {
+            var actionContainer = Object.FindObjectOfType<BeatmapActionContainer>();
+            var containerCollection = BeatmapObjectContainerCollection.GetCollectionForType(BeatmapObject.Type.EVENT);
+            if (containerCollection is EventsContainer eventsContainer)
+            {
+                var root = eventsContainer.transform.root;
+                var eventPlacement = root.GetComponentInChildren<EventPlacement>();
+                var inputController = root.GetComponentInChildren<BeatmapEventInputController>();
+
+                var eventA = new MapEvent(2, MapEvent.EVENT_TYPE_LATE_ROTATION, MapEvent.LIGHT_VALUE_TO_ROTATION_DEGREES.ToList().IndexOf(45));
+                var eventB = new MapEvent(3, MapEvent.EVENT_TYPE_BACK_LASERS, MapEvent.LIGHT_VALUE_RED_FADE);
+
+                eventPlacement.queuedData = eventA;
+                eventPlacement.queuedValue = eventPlacement.queuedData._value;
+                eventPlacement.RoundedTime = eventPlacement.queuedData._time;
+                eventPlacement.ApplyToMap();
+                
+                eventPlacement.queuedData = eventB;
+                eventPlacement.queuedValue = eventPlacement.queuedData._value;
+                eventPlacement.RoundedTime = eventPlacement.queuedData._time;
+                eventPlacement.ApplyToMap();
+
+                if (eventsContainer.LoadedContainers[eventA] is BeatmapEventContainer containerA)
+                {
+                    inputController.InvertEvent(containerA);
+                }
+                if (eventsContainer.LoadedContainers[eventB] is BeatmapEventContainer containerB)
+                {
+                    inputController.InvertEvent(containerB);
+                }
+
+                CheckEvent(eventsContainer, 0, 2, MapEvent.EVENT_TYPE_LATE_ROTATION, MapEvent.LIGHT_VALUE_TO_ROTATION_DEGREES.ToList().IndexOf(-45));
+                CheckEvent(eventsContainer, 1, 3, MapEvent.EVENT_TYPE_BACK_LASERS, MapEvent.LIGHT_VALUE_BLUE_FADE);
+
+                // Undo invert
+                actionContainer.Undo();
+                
+                CheckEvent(eventsContainer, 0, 2, MapEvent.EVENT_TYPE_LATE_ROTATION, MapEvent.LIGHT_VALUE_TO_ROTATION_DEGREES.ToList().IndexOf(-45));
+                CheckEvent(eventsContainer, 1, 3, MapEvent.EVENT_TYPE_BACK_LASERS, MapEvent.LIGHT_VALUE_RED_FADE);
+                
+                actionContainer.Undo();
+                
+                CheckEvent(eventsContainer, 0, 2, MapEvent.EVENT_TYPE_LATE_ROTATION, MapEvent.LIGHT_VALUE_TO_ROTATION_DEGREES.ToList().IndexOf(45));
+                CheckEvent(eventsContainer, 1, 3, MapEvent.EVENT_TYPE_BACK_LASERS, MapEvent.LIGHT_VALUE_RED_FADE);
+            }
+        }
+        
+        [Test]
+        public void TweakValue()
+        {
+            var actionContainer = Object.FindObjectOfType<BeatmapActionContainer>();
+            var containerCollection = BeatmapObjectContainerCollection.GetCollectionForType(BeatmapObject.Type.EVENT);
+            if (containerCollection is EventsContainer eventsContainer)
+            {
+                var root = eventsContainer.transform.root;
+                var eventPlacement = root.GetComponentInChildren<EventPlacement>();
+                var inputController = root.GetComponentInChildren<BeatmapEventInputController>();
+
+                var eventA = new MapEvent(2, MapEvent.EVENT_TYPE_LEFT_LASERS_SPEED, 2);
+
+                eventPlacement.queuedData = eventA;
+                eventPlacement.queuedValue = eventPlacement.queuedData._value;
+                eventPlacement.RoundedTime = eventPlacement.queuedData._time;
+                eventPlacement.PlacePrecisionRotation = true;
+                eventPlacement.ApplyToMap();
+                eventPlacement.PlacePrecisionRotation = false;
+
+                if (eventsContainer.LoadedContainers[eventA] is BeatmapEventContainer containerA)
+                {
+                    inputController.TweakValue(containerA, 1);
+                }
+
+                CheckEvent(eventsContainer, 0, 2, MapEvent.EVENT_TYPE_LEFT_LASERS_SPEED, 3);
+
+                // Undo invert
+                actionContainer.Undo();
+                
+                CheckEvent(eventsContainer, 0, 2, MapEvent.EVENT_TYPE_LEFT_LASERS_SPEED, 2);
+            }
+        }
+    }
+}

--- a/Assets/Tests/EventTest.cs.meta
+++ b/Assets/Tests/EventTest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1622978b810b4de699bc8798f55d9440
+timeCreated: 1612644658

--- a/Assets/Tests/MirrorTest.cs
+++ b/Assets/Tests/MirrorTest.cs
@@ -1,0 +1,142 @@
+﻿using NUnit.Framework;
+using System.Collections;
+using System.Linq;
+using Tests.Util;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Tests
+{
+    public class MirrorTest
+    {
+        private BeatmapActionContainer _actionContainer;
+        private MirrorSelection _mirror;
+        private BeatmapObjectContainerCollection _notesContainer;
+        private Transform _root;
+        private NotePlacement _notePlacement;
+        
+        [UnityOneTimeSetUp]
+        public IEnumerator LoadMap()
+        {
+            yield return TestUtils.LoadMapper();
+
+            _actionContainer = Object.FindObjectOfType<BeatmapActionContainer>();
+            _mirror = Object.FindObjectOfType<MirrorSelection>();
+            _notesContainer = BeatmapObjectContainerCollection.GetCollectionForType(BeatmapObject.Type.NOTE);
+            _root = _notesContainer.transform.root;
+            _notePlacement = _root.GetComponentInChildren<NotePlacement>();
+        }
+
+        [SetUp]
+        public void SpawnNotes()
+        {
+            var noteA = new BeatmapNote
+            {
+                _time = 2,
+                _type = BeatmapNote.NOTE_TYPE_A,
+                _lineIndex = BeatmapNote.LINE_INDEX_FAR_LEFT,
+                _lineLayer = BeatmapNote.LINE_LAYER_BOTTOM,
+                _cutDirection = BeatmapNote.NOTE_CUT_DIRECTION_LEFT
+            };
+            var noteB = new BeatmapNote
+            {
+                _time = 3,
+                _type = BeatmapNote.NOTE_TYPE_B,
+                _lineIndex = BeatmapNote.LINE_INDEX_FAR_RIGHT,
+                _lineLayer = BeatmapNote.LINE_LAYER_TOP,
+                _cutDirection = BeatmapNote.NOTE_CUT_DIRECTION_UP_RIGHT
+            };
+
+            _notePlacement.queuedData = noteA;
+            _notePlacement.RoundedTime = _notePlacement.queuedData._time;
+            _notePlacement.ApplyToMap();
+
+            // Should conflict with existing note and delete it
+            _notePlacement.queuedData = noteB;
+            _notePlacement.RoundedTime = _notePlacement.queuedData._time;
+            _notePlacement.ApplyToMap();
+            
+            SelectionController.Select(noteA);
+            SelectionController.Select(noteB, true);
+        }
+        
+        [TearDown]
+        public void ContainerCleanup()
+        {
+            BeatmapActionContainer.RemoveAllActionsOfType<BeatmapAction>();
+            TestUtils.CleanupNotes();
+        }
+
+        [Test]
+        public void MirrorInTime()
+        {
+            _mirror.MirrorTime();
+            
+            // Check we can still delete our objects
+            var toDelete = _notesContainer.UnsortedObjects.FirstOrDefault();
+            _notesContainer.DeleteObject(toDelete);
+            Assert.AreEqual(1, _notesContainer.LoadedObjects.Count);
+            
+            _actionContainer.Undo();
+            
+            Assert.AreEqual(2, _notesContainer.LoadedObjects.Count);
+
+            NoteTest.CheckNote(_notesContainer, 0, 2, BeatmapNote.NOTE_TYPE_B, BeatmapNote.LINE_INDEX_FAR_RIGHT, BeatmapNote.LINE_LAYER_TOP, BeatmapNote.NOTE_CUT_DIRECTION_UP_RIGHT);
+            NoteTest.CheckNote(_notesContainer, 1, 3, BeatmapNote.NOTE_TYPE_A, BeatmapNote.LINE_INDEX_FAR_LEFT, BeatmapNote.LINE_LAYER_BOTTOM, BeatmapNote.NOTE_CUT_DIRECTION_LEFT);
+
+            // Undo mirror
+            _actionContainer.Undo();
+
+            NoteTest.CheckNote(_notesContainer, 0, 2, BeatmapNote.NOTE_TYPE_A, BeatmapNote.LINE_INDEX_FAR_LEFT, BeatmapNote.LINE_LAYER_BOTTOM, BeatmapNote.NOTE_CUT_DIRECTION_LEFT);
+            NoteTest.CheckNote(_notesContainer, 1, 3, BeatmapNote.NOTE_TYPE_B, BeatmapNote.LINE_INDEX_FAR_RIGHT, BeatmapNote.LINE_LAYER_TOP, BeatmapNote.NOTE_CUT_DIRECTION_UP_RIGHT);
+        }
+        
+        [Test]
+        public void Mirror()
+        {
+            _mirror.Mirror();
+            
+            // Check we can still delete our objects
+            var toDelete = _notesContainer.UnsortedObjects.FirstOrDefault();
+            _notesContainer.DeleteObject(toDelete);
+            Assert.AreEqual(1, _notesContainer.LoadedObjects.Count);
+            
+            _actionContainer.Undo();
+            
+            Assert.AreEqual(2, _notesContainer.LoadedObjects.Count);
+            
+            NoteTest.CheckNote(_notesContainer, 0, 2, BeatmapNote.NOTE_TYPE_B, BeatmapNote.LINE_INDEX_FAR_RIGHT, BeatmapNote.LINE_LAYER_BOTTOM, BeatmapNote.NOTE_CUT_DIRECTION_RIGHT);
+            NoteTest.CheckNote(_notesContainer, 1, 3, BeatmapNote.NOTE_TYPE_A, BeatmapNote.LINE_INDEX_FAR_LEFT, BeatmapNote.LINE_LAYER_TOP, BeatmapNote.NOTE_CUT_DIRECTION_UP_LEFT);
+
+            // Undo mirror
+            _actionContainer.Undo();
+
+            NoteTest.CheckNote(_notesContainer, 0, 2, BeatmapNote.NOTE_TYPE_A, BeatmapNote.LINE_INDEX_FAR_LEFT, BeatmapNote.LINE_LAYER_BOTTOM, BeatmapNote.NOTE_CUT_DIRECTION_LEFT);
+            NoteTest.CheckNote(_notesContainer, 1, 3, BeatmapNote.NOTE_TYPE_B, BeatmapNote.LINE_INDEX_FAR_RIGHT, BeatmapNote.LINE_LAYER_TOP, BeatmapNote.NOTE_CUT_DIRECTION_UP_RIGHT);
+        }
+        
+        [Test]
+        public void SwapColors()
+        {
+            _mirror.Mirror(false);
+            
+            // Check we can still delete our objects
+            var toDelete = _notesContainer.UnsortedObjects.FirstOrDefault();
+            _notesContainer.DeleteObject(toDelete);
+            Assert.AreEqual(1, _notesContainer.LoadedObjects.Count);
+            
+            _actionContainer.Undo();
+            
+            Assert.AreEqual(2, _notesContainer.LoadedObjects.Count);
+            
+            NoteTest.CheckNote(_notesContainer, 0, 2, BeatmapNote.NOTE_TYPE_B, BeatmapNote.LINE_INDEX_FAR_LEFT, BeatmapNote.LINE_LAYER_BOTTOM, BeatmapNote.NOTE_CUT_DIRECTION_LEFT);
+            NoteTest.CheckNote(_notesContainer, 1, 3, BeatmapNote.NOTE_TYPE_A, BeatmapNote.LINE_INDEX_FAR_RIGHT, BeatmapNote.LINE_LAYER_TOP, BeatmapNote.NOTE_CUT_DIRECTION_UP_RIGHT);
+
+            // Undo mirror
+            _actionContainer.Undo();
+
+            NoteTest.CheckNote(_notesContainer, 0, 2, BeatmapNote.NOTE_TYPE_A, BeatmapNote.LINE_INDEX_FAR_LEFT, BeatmapNote.LINE_LAYER_BOTTOM, BeatmapNote.NOTE_CUT_DIRECTION_LEFT);
+            NoteTest.CheckNote(_notesContainer, 1, 3, BeatmapNote.NOTE_TYPE_B, BeatmapNote.LINE_INDEX_FAR_RIGHT, BeatmapNote.LINE_LAYER_TOP, BeatmapNote.NOTE_CUT_DIRECTION_UP_RIGHT);
+        }
+    }
+}

--- a/Assets/Tests/MirrorTest.cs.meta
+++ b/Assets/Tests/MirrorTest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e749330ef8534b6a8975f2219bbd720b
+timeCreated: 1612567467

--- a/Assets/Tests/NoteTest.cs
+++ b/Assets/Tests/NoteTest.cs
@@ -1,0 +1,101 @@
+﻿using NUnit.Framework;
+using System.Collections;
+using System.Linq;
+using SimpleJSON;
+using Tests.Util;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Tests
+{
+    public class NoteTest
+    {
+        [UnityOneTimeSetUp]
+        public IEnumerator LoadMap() => TestUtils.LoadMapper();
+
+        [TearDown]
+        public void ContainerCleanup()
+        {
+            BeatmapActionContainer.RemoveAllActionsOfType<BeatmapAction>();
+            TestUtils.CleanupNotes();
+        }
+
+        public static void CheckNote(BeatmapObjectContainerCollection container, int idx, int time, int type, int index, int layer, int cutDirection, JSONNode customData = null)
+        {
+            var newObjA = container.LoadedObjects.Skip(idx).First();
+            Assert.IsInstanceOf<BeatmapNote>(newObjA);
+            if (newObjA is BeatmapNote newNoteA)
+            {
+                Assert.AreEqual(time, newNoteA._time);
+                Assert.AreEqual(type, newNoteA._type);
+                Assert.AreEqual(index, newNoteA._lineIndex);
+                Assert.AreEqual(layer, newNoteA._lineLayer);
+                Assert.AreEqual(cutDirection, newNoteA._cutDirection);
+                
+                if (customData != null) Assert.AreEqual(customData.ToString(), newNoteA._customData.ToString());
+            }
+        }
+        
+        [Test]
+        public void InvertNote()
+        {
+            var actionContainer = Object.FindObjectOfType<BeatmapActionContainer>();
+            var containerCollection = BeatmapObjectContainerCollection.GetCollectionForType(BeatmapObject.Type.NOTE);
+            if (containerCollection is NotesContainer notesContainer)
+            {
+                var root = notesContainer.transform.root;
+                var notePlacement = root.GetComponentInChildren<NotePlacement>();
+                var inputController = root.GetComponentInChildren<BeatmapNoteInputController>();
+
+                var noteA = new BeatmapNote(2, BeatmapNote.NOTE_TYPE_A, BeatmapNote.LINE_INDEX_FAR_LEFT, BeatmapNote.LINE_LAYER_BOTTOM, BeatmapNote.NOTE_CUT_DIRECTION_LEFT);
+            
+                notePlacement.queuedData = noteA;
+                notePlacement.RoundedTime = notePlacement.queuedData._time;
+                notePlacement.ApplyToMap();
+
+                if (notesContainer.LoadedContainers[noteA] is BeatmapNoteContainer containerA)
+                {
+                    inputController.InvertNote(containerA);
+                }
+
+                CheckNote(notesContainer, 0, 2, BeatmapNote.NOTE_TYPE_B, BeatmapNote.LINE_INDEX_FAR_LEFT, BeatmapNote.LINE_LAYER_BOTTOM, BeatmapNote.NOTE_CUT_DIRECTION_LEFT);
+
+                // Undo invert
+                actionContainer.Undo();
+                
+                CheckNote(notesContainer, 0, 2, BeatmapNote.NOTE_TYPE_A, BeatmapNote.LINE_INDEX_FAR_LEFT, BeatmapNote.LINE_LAYER_BOTTOM, BeatmapNote.NOTE_CUT_DIRECTION_LEFT);
+            }
+        }
+        
+        [Test]
+        public void UpdateNoteDirection()
+        {
+            var actionContainer = Object.FindObjectOfType<BeatmapActionContainer>();
+            var containerCollection = BeatmapObjectContainerCollection.GetCollectionForType(BeatmapObject.Type.NOTE);
+            if (containerCollection is NotesContainer notesContainer)
+            {
+                var root = notesContainer.transform.root;
+                var notePlacement = root.GetComponentInChildren<NotePlacement>();
+                var inputController = root.GetComponentInChildren<BeatmapNoteInputController>();
+
+                var noteA = new BeatmapNote(2, BeatmapNote.NOTE_TYPE_A, BeatmapNote.LINE_INDEX_FAR_LEFT, BeatmapNote.LINE_LAYER_BOTTOM, BeatmapNote.NOTE_CUT_DIRECTION_LEFT);
+            
+                notePlacement.queuedData = noteA;
+                notePlacement.RoundedTime = notePlacement.queuedData._time;
+                notePlacement.ApplyToMap();
+
+                if (notesContainer.LoadedContainers[noteA] is BeatmapNoteContainer containerA)
+                {
+                    inputController.UpdateNoteDirection(containerA, true);
+                }
+
+                CheckNote(notesContainer, 0, 2, BeatmapNote.NOTE_TYPE_A, BeatmapNote.LINE_INDEX_FAR_LEFT, BeatmapNote.LINE_LAYER_BOTTOM, BeatmapNote.NOTE_CUT_DIRECTION_UP_LEFT);
+
+                // Undo direction
+                actionContainer.Undo();
+                
+                CheckNote(notesContainer, 0, 2, BeatmapNote.NOTE_TYPE_A, BeatmapNote.LINE_INDEX_FAR_LEFT, BeatmapNote.LINE_LAYER_BOTTOM, BeatmapNote.NOTE_CUT_DIRECTION_LEFT);
+            }
+        }
+    }
+}

--- a/Assets/Tests/NoteTest.cs.meta
+++ b/Assets/Tests/NoteTest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e2c415f7244b48c8a2c434876995c0e9
+timeCreated: 1612646683

--- a/Assets/Tests/PaintTest.cs
+++ b/Assets/Tests/PaintTest.cs
@@ -1,0 +1,148 @@
+﻿using NUnit.Framework;
+using System.Collections;
+using System.Reflection;
+using SimpleJSON;
+using Tests.Util;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Tests
+{
+    public class PaintTest
+    {
+        [UnityOneTimeSetUp]
+        public IEnumerator LoadMap() => TestUtils.LoadMapper();
+
+        [TearDown]
+        public void ContainerCleanup()
+        {
+            BeatmapActionContainer.RemoveAllActionsOfType<BeatmapAction>();
+            TestUtils.CleanupEvents();
+        }
+        
+        [Test]
+        public void PaintGradientUndo()
+        {
+            var actionContainer = Object.FindObjectOfType<BeatmapActionContainer>();
+            var colorPicker = Object.FindObjectOfType<ColorPicker>();
+            var painter = Object.FindObjectOfType<PaintSelectedObjects>();
+            
+            var eventsContainer = BeatmapObjectContainerCollection.GetCollectionForType(BeatmapObject.Type.EVENT);
+            var root = eventsContainer.transform.root;
+            
+            var selectionController = root.GetComponentInChildren<SelectionController>();
+            var eventPlacement = root.GetComponentInChildren<EventPlacement>();
+
+            var customData = new JSONObject();
+            customData["_lightGradient"] = new MapEvent.ChromaGradient(Color.blue, Color.cyan, 1, "easeLinear").ToJSONNode();
+            var noteA = new MapEvent(2, 1, 1, customData);
+            eventPlacement.queuedData = noteA;
+            eventPlacement.queuedValue = eventPlacement.queuedData._value;
+            eventPlacement.RoundedTime = eventPlacement.queuedData._time;
+            eventPlacement.ApplyToMap();
+            
+            SelectionController.Select(noteA);
+            
+            colorPicker.CurrentColor = Color.red;
+            painter.Paint();
+            
+            selectionController.ShiftSelection(1, 0);
+
+            Assert.AreEqual(1, eventsContainer.LoadedObjects.Count);
+            Assert.AreEqual(2, eventsContainer.UnsortedObjects[0]._time);
+            Assert.AreEqual(2, ((MapEvent) eventsContainer.UnsortedObjects[0])._type);
+            Assert.AreEqual(Color.red, ((MapEvent) eventsContainer.UnsortedObjects[0])._lightGradient.StartColor);
+
+            // Undo move
+            actionContainer.Undo();
+
+            Assert.AreEqual(1, eventsContainer.LoadedObjects.Count);
+            Assert.AreEqual(2, eventsContainer.UnsortedObjects[0]._time);
+            Assert.AreEqual(1, ((MapEvent) eventsContainer.UnsortedObjects[0])._type);
+            Assert.AreEqual(Color.red, ((MapEvent) eventsContainer.UnsortedObjects[0])._lightGradient.StartColor);
+
+            // Undo paint
+            actionContainer.Undo();
+
+            Assert.AreEqual(1, eventsContainer.LoadedObjects.Count);
+            Assert.AreEqual(2, eventsContainer.UnsortedObjects[0]._time);
+            Assert.AreEqual(1, ((MapEvent) eventsContainer.UnsortedObjects[0])._type);
+            Assert.AreEqual(Color.blue, ((MapEvent) eventsContainer.UnsortedObjects[0])._lightGradient.StartColor);
+        }
+
+        [Test]
+        public void PaintUndo()
+        {
+            var actionContainer = Object.FindObjectOfType<BeatmapActionContainer>();
+            var colorPicker = Object.FindObjectOfType<ColorPicker>();
+            var painter = Object.FindObjectOfType<PaintSelectedObjects>();
+            
+            var eventsContainer = BeatmapObjectContainerCollection.GetCollectionForType(BeatmapObject.Type.EVENT);
+            var root = eventsContainer.transform.root;
+            
+            var selectionController = root.GetComponentInChildren<SelectionController>();
+            var eventPlacement = root.GetComponentInChildren<EventPlacement>();
+
+            var noteA = new MapEvent(2, 1, 1);
+            eventPlacement.queuedData = noteA;
+            eventPlacement.queuedValue = eventPlacement.queuedData._value;
+            eventPlacement.RoundedTime = eventPlacement.queuedData._time;
+            eventPlacement.ApplyToMap();
+            
+            SelectionController.Select(noteA);
+            
+            colorPicker.CurrentColor = Color.red;
+            painter.Paint();
+            
+            selectionController.ShiftSelection(1, 0);
+
+            Assert.AreEqual(1, eventsContainer.LoadedObjects.Count);
+            Assert.AreEqual(2, eventsContainer.UnsortedObjects[0]._time);
+            Assert.AreEqual(2, ((MapEvent) eventsContainer.UnsortedObjects[0])._type);
+            Assert.AreEqual(Color.red, eventsContainer.UnsortedObjects[0]._customData["_color"].ReadColor());
+
+            // Undo move
+            actionContainer.Undo();
+
+            Assert.AreEqual(1, eventsContainer.LoadedObjects.Count);
+            Assert.AreEqual(2, eventsContainer.UnsortedObjects[0]._time);
+            Assert.AreEqual(1, ((MapEvent) eventsContainer.UnsortedObjects[0])._type);
+            Assert.AreEqual(Color.red, eventsContainer.UnsortedObjects[0]._customData["_color"].ReadColor());
+
+            // Undo paint
+            actionContainer.Undo();
+
+            Assert.AreEqual(1, eventsContainer.LoadedObjects.Count);
+            Assert.AreEqual(2, eventsContainer.UnsortedObjects[0]._time);
+            Assert.AreEqual(1, ((MapEvent) eventsContainer.UnsortedObjects[0])._type);
+            Assert.AreEqual(true, eventsContainer.UnsortedObjects[0]._customData == null || !eventsContainer.UnsortedObjects[0]._customData.HasKey("_color"));
+        }
+        
+        [Test]
+        public void IgnoresOff()
+        {
+            var colorPicker = Object.FindObjectOfType<ColorPicker>();
+            var painter = Object.FindObjectOfType<PaintSelectedObjects>();
+            
+            var eventsContainer = BeatmapObjectContainerCollection.GetCollectionForType(BeatmapObject.Type.EVENT);
+            var root = eventsContainer.transform.root;
+            var eventPlacement = root.GetComponentInChildren<EventPlacement>();
+
+            var noteA = new MapEvent(2, 1, 0);
+            eventPlacement.queuedData = noteA;
+            eventPlacement.queuedValue = eventPlacement.queuedData._value;
+            eventPlacement.RoundedTime = eventPlacement.queuedData._time;
+            eventPlacement.ApplyToMap();
+            
+            SelectionController.Select(noteA);
+            
+            colorPicker.CurrentColor = Color.red;
+            painter.Paint();
+
+            Assert.AreEqual(1, eventsContainer.LoadedObjects.Count);
+            Assert.AreEqual(2, eventsContainer.UnsortedObjects[0]._time);
+            Assert.AreEqual(1, ((MapEvent) eventsContainer.UnsortedObjects[0])._type);
+            Assert.AreEqual(true, eventsContainer.UnsortedObjects[0]._customData == null || !eventsContainer.UnsortedObjects[0]._customData.HasKey("_color"));
+        }
+    }
+}

--- a/Assets/Tests/PaintTest.cs.meta
+++ b/Assets/Tests/PaintTest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: cbf81f1ea5b94fee91bfc7962ce2a84a
+timeCreated: 1612048947

--- a/Assets/Tests/SimpleMirrorTest.cs
+++ b/Assets/Tests/SimpleMirrorTest.cs
@@ -1,0 +1,239 @@
+﻿using NUnit.Framework;
+using System.Collections;
+using System.Linq;
+using SimpleJSON;
+using Tests.Util;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Tests
+{
+    public class SimpleMirrorTest
+    {
+        private BeatmapActionContainer _actionContainer;
+        private MirrorSelection _mirror;
+        
+        [UnityOneTimeSetUp]
+        public IEnumerator LoadMap()
+        {
+            yield return TestUtils.LoadMapper();
+
+            _actionContainer = Object.FindObjectOfType<BeatmapActionContainer>();
+            _mirror = Object.FindObjectOfType<MirrorSelection>();
+        }
+
+        [TearDown]
+        public void ContainerCleanup()
+        {
+            BeatmapActionContainer.RemoveAllActionsOfType<BeatmapAction>();
+            TestUtils.CleanupNotes();
+            TestUtils.CleanupEvents();
+            TestUtils.CleanupObstacles();
+        }
+
+        [Test]
+        public void MirrorME()
+        {
+            var notesContainer = BeatmapObjectContainerCollection.GetCollectionForType(BeatmapObject.Type.NOTE);
+            var root = notesContainer.transform.root;
+            var notePlacement = root.GetComponentInChildren<NotePlacement>();
+
+            var noteA = new BeatmapNote(2, -2345, BeatmapNote.LINE_LAYER_BOTTOM, BeatmapNote.NOTE_TYPE_A, BeatmapNote.NOTE_CUT_DIRECTION_LEFT);
+            
+            notePlacement.queuedData = noteA;
+            notePlacement.RoundedTime = notePlacement.queuedData._time;
+            notePlacement.ApplyToMap();
+
+            SelectionController.Select(noteA);
+
+            _mirror.Mirror();
+            NoteTest.CheckNote(notesContainer, 0, 2, BeatmapNote.NOTE_TYPE_B, 5345, BeatmapNote.LINE_LAYER_BOTTOM, BeatmapNote.NOTE_CUT_DIRECTION_RIGHT);
+
+            // Undo mirror
+            _actionContainer.Undo();
+            NoteTest.CheckNote(notesContainer, 0, 2, BeatmapNote.NOTE_TYPE_A, -2345, BeatmapNote.LINE_LAYER_BOTTOM, BeatmapNote.NOTE_CUT_DIRECTION_LEFT);
+        }
+        
+        [Test]
+        public void MirrorNoteNE()
+        {
+            var notesContainer = BeatmapObjectContainerCollection.GetCollectionForType(BeatmapObject.Type.NOTE);
+            var root = notesContainer.transform.root;
+            var notePlacement = root.GetComponentInChildren<NotePlacement>();
+            
+            var noteA = new BeatmapNote
+            {
+                _time = 2,
+                _type = BeatmapNote.NOTE_TYPE_A,
+                _lineIndex = BeatmapNote.LINE_INDEX_FAR_LEFT,
+                _lineLayer = BeatmapNote.LINE_LAYER_BOTTOM,
+                _customData = JSON.Parse("{\"_position\": [-1, 0]}"),
+                _cutDirection = BeatmapNote.NOTE_CUT_DIRECTION_LEFT
+            };
+            
+            notePlacement.queuedData = noteA;
+            notePlacement.RoundedTime = notePlacement.queuedData._time;
+            notePlacement.ApplyToMap();
+
+            SelectionController.Select(noteA);
+
+            _mirror.Mirror();
+            NoteTest.CheckNote(notesContainer, 0, 2, BeatmapNote.NOTE_TYPE_B, BeatmapNote.LINE_INDEX_FAR_LEFT, BeatmapNote.LINE_LAYER_BOTTOM, BeatmapNote.NOTE_CUT_DIRECTION_RIGHT, JSON.Parse("{\"_position\": [1, 0]}"));
+
+            // Undo mirror
+            _actionContainer.Undo();
+            NoteTest.CheckNote(notesContainer, 0, 2, BeatmapNote.NOTE_TYPE_A, BeatmapNote.LINE_INDEX_FAR_LEFT, BeatmapNote.LINE_LAYER_BOTTOM, BeatmapNote.NOTE_CUT_DIRECTION_LEFT, JSON.Parse("{\"_position\": [-1, 0]}"));
+        }
+
+        [Test]
+        public void MirrorProp()
+        {
+            var container = BeatmapObjectContainerCollection.GetCollectionForType(BeatmapObject.Type.EVENT);
+            if (container is EventsContainer eventsContainer)
+            {
+                var root = eventsContainer.transform.root;
+                var eventPlacement = root.GetComponentInChildren<EventPlacement>();
+
+                var eventA = new MapEvent(2, MapEvent.EVENT_TYPE_BACK_LASERS, MapEvent.LIGHT_VALUE_RED_FADE, JSON.Parse("{\"_propID\": 4}"));
+
+                eventPlacement.queuedData = eventA;
+                eventPlacement.queuedValue = eventPlacement.queuedData._value;
+                eventPlacement.RoundedTime = eventPlacement.queuedData._time;
+                eventPlacement.ApplyToMap();
+
+                SelectionController.Select(eventA);
+
+                eventsContainer.EventTypeToPropagate = eventA._type;
+                eventsContainer.PropagationEditing = EventsContainer.PropMode.Prop;
+
+                _mirror.Mirror();
+                // I'm sorry if you're here after changing the prop mapping for default env
+                EventTest.CheckEvent(eventsContainer, 0, 2, MapEvent.EVENT_TYPE_BACK_LASERS, MapEvent.LIGHT_VALUE_BLUE_FADE, JSON.Parse("{\"_propID\": 0}"));
+
+                // Undo mirror
+                _actionContainer.Undo();
+                EventTest.CheckEvent(eventsContainer, 0, 2, MapEvent.EVENT_TYPE_BACK_LASERS, MapEvent.LIGHT_VALUE_RED_FADE, JSON.Parse("{\"_propID\": 4}"));
+                
+                eventsContainer.PropagationEditing = EventsContainer.PropMode.Off;
+            }
+        }
+        
+        [Test]
+        public void MirrorGradient()
+        {
+            var container = BeatmapObjectContainerCollection.GetCollectionForType(BeatmapObject.Type.EVENT);
+            if (container is EventsContainer eventsContainer)
+            {
+                var root = eventsContainer.transform.root;
+                var eventPlacement = root.GetComponentInChildren<EventPlacement>();
+
+                var eventA = new MapEvent(2, MapEvent.EVENT_TYPE_BACK_LASERS, MapEvent.LIGHT_VALUE_RED_FADE, JSON.Parse("{\"_lightGradient\": {\"_duration\": 1, \"_startColor\": [1, 0, 0, 1], \"_endColor\": [0, 1, 0, 1], \"_easing\": \"easeLinear\"}}"));
+
+                eventPlacement.queuedData = eventA;
+                eventPlacement.queuedValue = eventPlacement.queuedData._value;
+                eventPlacement.RoundedTime = eventPlacement.queuedData._time;
+                eventPlacement.ApplyToMap();
+
+                SelectionController.Select(eventA);
+
+                _mirror.Mirror();
+                EventTest.CheckEvent(eventsContainer, 0, 2, MapEvent.EVENT_TYPE_BACK_LASERS, MapEvent.LIGHT_VALUE_BLUE_FADE, JSON.Parse("{\"_lightGradient\": {\"_duration\": 1, \"_startColor\": [0, 1, 0, 1], \"_endColor\": [1, 0, 0, 1], \"_easing\": \"easeLinear\"}}"));
+
+                // Undo mirror
+                _actionContainer.Undo();
+                EventTest.CheckEvent(eventsContainer, 0, 2, MapEvent.EVENT_TYPE_BACK_LASERS, MapEvent.LIGHT_VALUE_RED_FADE, JSON.Parse("{\"_lightGradient\": {\"_duration\": 1, \"_startColor\": [1, 0, 0, 1], \"_endColor\": [0, 1, 0, 1], \"_easing\": \"easeLinear\"}}"));
+            }
+        }
+
+        [Test]
+        public void MirrorWallME()
+        {
+            var container = BeatmapObjectContainerCollection.GetCollectionForType(BeatmapObject.Type.OBSTACLE);
+            if (container is ObstaclesContainer wallsContainer)
+            {
+                var root = wallsContainer.transform.root;
+                var wallPlacement = root.GetComponentInChildren<ObstaclePlacement>();
+                wallPlacement.RefreshVisuals();
+
+                // What the actual fuck - example from mirroring in MMA2
+                //{"_time":1.5,"_lineIndex":1446,"_type":595141,"_duration":0.051851850003004074,"_width":2596}
+                //{"_time":1.5,"_lineIndex":2958,"_type":595141,"_duration":0.051851850003004074,"_width":2596}
+                var wallA = new BeatmapObstacle(2, 1446, 595141, 1, 2596);
+
+                wallPlacement.queuedData = wallA;
+                wallPlacement.RoundedTime = wallPlacement.queuedData._time;
+                wallPlacement.instantiatedContainer.transform.localScale = new Vector3(0, 0, wallPlacement.queuedData._duration * EditorScaleController.EditorScale);
+                wallPlacement.ApplyToMap(); // Starts placement
+                wallPlacement.ApplyToMap(); // Completes placement
+
+                SelectionController.Select(wallA);
+
+                _mirror.Mirror();
+                WallTest.CheckWall(wallsContainer, 0, 2, 2958, 595141, 1, 2596);
+
+                // Undo mirror
+                _actionContainer.Undo();
+                WallTest.CheckWall(wallsContainer, 0, 2, 1446, 595141, 1, 2596);
+            }
+        }
+        
+        [Test]
+        public void MirrorWallNE()
+        {
+            var container = BeatmapObjectContainerCollection.GetCollectionForType(BeatmapObject.Type.OBSTACLE);
+            if (container is ObstaclesContainer wallsContainer)
+            {
+                var root = wallsContainer.transform.root;
+                var wallPlacement = root.GetComponentInChildren<ObstaclePlacement>();
+                wallPlacement.RefreshVisuals();
+
+                var wallA = new BeatmapObstacle(2, BeatmapNote.LINE_INDEX_FAR_LEFT, BeatmapObstacle.VALUE_FULL_BARRIER, 1, 2, JSON.Parse("{\"_position\": [-1.5, 0]}"));
+
+                wallPlacement.queuedData = wallA;
+                wallPlacement.RoundedTime = wallPlacement.queuedData._time;
+                wallPlacement.instantiatedContainer.transform.localScale = new Vector3(0, 0, wallPlacement.queuedData._duration * EditorScaleController.EditorScale);
+                wallPlacement.ApplyToMap(); // Starts placement
+                wallPlacement.ApplyToMap(); // Completes placement
+
+                SelectionController.Select(wallA);
+
+                _mirror.Mirror();
+                WallTest.CheckWall(wallsContainer, 0, 2, BeatmapNote.LINE_INDEX_MID_RIGHT, BeatmapObstacle.VALUE_FULL_BARRIER, 1, 2, JSON.Parse("{\"_position\": [-0.5, 0]}"));
+
+                // Undo mirror
+                _actionContainer.Undo();
+                WallTest.CheckWall(wallsContainer, 0, 2, BeatmapNote.LINE_INDEX_FAR_LEFT, BeatmapObstacle.VALUE_FULL_BARRIER, 1, 2, JSON.Parse("{\"_position\": [-1.5, 0]}"));
+            }
+        }
+        
+        [Test]
+        public void MirrorRotation()
+        {
+            var rotationCb = Object.FindObjectOfType<RotationCallbackController>();
+            rotationCb.Start();
+            
+            var container = BeatmapObjectContainerCollection.GetCollectionForType(BeatmapObject.Type.EVENT);
+            if (container is EventsContainer eventsContainer)
+            {
+                var root = eventsContainer.transform.root;
+                var eventPlacement = root.GetComponentInChildren<EventPlacement>();
+
+                var eventA = new MapEvent(2, MapEvent.EVENT_TYPE_LATE_ROTATION, MapEvent.LIGHT_VALUE_TO_ROTATION_DEGREES.ToList().IndexOf(45), JSON.Parse("{\"_rotation\": 33}"));
+
+                eventPlacement.queuedData = eventA;
+                eventPlacement.queuedValue = eventPlacement.queuedData._value;
+                eventPlacement.RoundedTime = eventPlacement.queuedData._time;
+                eventPlacement.ApplyToMap();
+
+                SelectionController.Select(eventA);
+
+                _mirror.Mirror();
+                EventTest.CheckEvent(eventsContainer, 0, 2, MapEvent.EVENT_TYPE_LATE_ROTATION, MapEvent.LIGHT_VALUE_TO_ROTATION_DEGREES.ToList().IndexOf(-45), JSON.Parse("{\"_rotation\": -33}"));
+
+                // Undo mirror
+                _actionContainer.Undo();
+                EventTest.CheckEvent(eventsContainer, 0, 2, MapEvent.EVENT_TYPE_LATE_ROTATION, MapEvent.LIGHT_VALUE_TO_ROTATION_DEGREES.ToList().IndexOf(45), JSON.Parse("{\"_rotation\": 33}"));
+            }
+        }
+    }
+}

--- a/Assets/Tests/SimpleMirrorTest.cs.meta
+++ b/Assets/Tests/SimpleMirrorTest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 8578fe2cdbd849ee821170e02a5f7f61
+timeCreated: 1612570744

--- a/Assets/Tests/Util/TestUtils.cs
+++ b/Assets/Tests/Util/TestUtils.cs
@@ -28,7 +28,7 @@ namespace Tests.Util
 
             yield return new WaitUntil(() => SceneManager.GetActiveScene().name.StartsWith("01") && !SceneTransitionManager.IsLoading);
             BeatSaberSongContainer.Instance.song = new BeatSaberSong("testmap", new JSONObject());
-            var parentSet = new BeatSaberSong.DifficultyBeatmapSet();
+            var parentSet = new BeatSaberSong.DifficultyBeatmapSet("Lawless");
             var diff = new BeatSaberSong.DifficultyBeatmap(parentSet);
             diff.customData = new JSONObject();
             BeatSaberSongContainer.Instance.difficultyData = diff;
@@ -36,18 +36,15 @@ namespace Tests.Util
             SceneTransitionManager.Instance.LoadScene("03_Mapper");
             yield return new WaitUntil(() => !SceneTransitionManager.IsLoading);
         }
+        
+        public static void CleanupNotes() => CleanupType(BeatmapObject.Type.NOTE);
+        public static void CleanupEvents() => CleanupType(BeatmapObject.Type.EVENT);
+        public static void CleanupObstacles() => CleanupType(BeatmapObject.Type.OBSTACLE);
+        public static void CleanupBPMChanges() => CleanupType(BeatmapObject.Type.BPM_CHANGE);
 
-        public static void CleanupNotes()
+        private static void CleanupType(BeatmapObject.Type type)
         {
-            var notesContainer = BeatmapObjectContainerCollection.GetCollectionForType(BeatmapObject.Type.NOTE);
-
-            foreach (var note in notesContainer.LoadedObjects.ToArray())
-                notesContainer.DeleteObject(note);
-        }
-
-        public static void CleanupEvents()
-        {
-            var eventsContainer = BeatmapObjectContainerCollection.GetCollectionForType(BeatmapObject.Type.EVENT);
+            var eventsContainer = BeatmapObjectContainerCollection.GetCollectionForType(type);
 
             foreach (var evt in eventsContainer.LoadedObjects.ToArray())
                 eventsContainer.DeleteObject(evt);

--- a/Assets/Tests/WallTest.cs
+++ b/Assets/Tests/WallTest.cs
@@ -1,0 +1,78 @@
+﻿using NUnit.Framework;
+using System.Collections;
+using System.Linq;
+using SimpleJSON;
+using Tests.Util;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Tests
+{
+    public class WallTest
+    {
+        [UnityOneTimeSetUp]
+        public IEnumerator LoadMap() => TestUtils.LoadMapper();
+
+        [TearDown]
+        public void ContainerCleanup()
+        {
+            BeatmapActionContainer.RemoveAllActionsOfType<BeatmapAction>();
+            TestUtils.CleanupObstacles();
+        }
+
+        public static void CheckWall(BeatmapObjectContainerCollection container, int idx, int time, int lineIndex, int type, int duration, int width, JSONNode customData = null)
+        {
+            var newObjA = container.LoadedObjects.Skip(idx).First();
+            Assert.IsInstanceOf<BeatmapObstacle>(newObjA);
+            if (newObjA is BeatmapObstacle newNoteA)
+            {
+                Assert.AreEqual(time, newNoteA._time);
+                Assert.AreEqual(type, newNoteA._type);
+                Assert.AreEqual(lineIndex, newNoteA._lineIndex);
+                Assert.AreEqual(duration, newNoteA._duration);
+                Assert.AreEqual(width, newNoteA._width);
+                
+                if (customData != null) Assert.AreEqual(customData.ToString(), newNoteA._customData.ToString());
+            }
+        }
+        
+        [Test]
+        public void HyperWall()
+        {
+            var actionContainer = Object.FindObjectOfType<BeatmapActionContainer>();
+            var collection = BeatmapObjectContainerCollection.GetCollectionForType(BeatmapObject.Type.OBSTACLE);
+            if (collection is ObstaclesContainer obstaclesCollection)
+            {
+                var root = obstaclesCollection.transform.root;
+                var wallPlacement = root.GetComponentInChildren<ObstaclePlacement>();
+                var inputController = root.GetComponentInChildren<BeatmapObstacleInputController>();
+                wallPlacement.RefreshVisuals();
+                
+                var wallA = new BeatmapObstacle(2, BeatmapNote.LINE_INDEX_FAR_LEFT, BeatmapObstacle.VALUE_FULL_BARRIER, 2, 1);
+                wallPlacement.queuedData = wallA;
+                wallPlacement.RoundedTime = wallPlacement.queuedData._time;
+                wallPlacement.instantiatedContainer.transform.localScale = new Vector3(0, 0, wallPlacement.queuedData._duration * EditorScaleController.EditorScale);
+                wallPlacement.ApplyToMap(); // Starts placement
+                wallPlacement.ApplyToMap(); // Completes placement
+
+                if (obstaclesCollection.LoadedContainers[wallA] is BeatmapObstacleContainer container)
+                {
+                    inputController.ToggleHyperWall(container);
+                }
+
+                var toDelete = obstaclesCollection.LoadedObjects.First();
+                obstaclesCollection.DeleteObject(toDelete);
+
+                Assert.AreEqual(0, obstaclesCollection.LoadedObjects.Count);
+                
+                actionContainer.Undo();
+                
+                Assert.AreEqual(1, obstaclesCollection.LoadedObjects.Count);
+                CheckWall(obstaclesCollection, 0, 4, BeatmapNote.LINE_INDEX_FAR_LEFT, BeatmapObstacle.VALUE_FULL_BARRIER, -2, 1);
+
+                actionContainer.Undo();
+                CheckWall(obstaclesCollection, 0, 2, BeatmapNote.LINE_INDEX_FAR_LEFT, BeatmapObstacle.VALUE_FULL_BARRIER, 2, 1);
+            }
+        }
+    }
+}

--- a/Assets/Tests/WallTest.cs.meta
+++ b/Assets/Tests/WallTest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9ec84988232348899df23a4a6bd04013
+timeCreated: 1612642804

--- a/Assets/__Scenes/03_Mapper.unity
+++ b/Assets/__Scenes/03_Mapper.unity
@@ -2073,83 +2073,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 55926401}
   m_CullTransparentMesh: 0
---- !u!21 &59336814
-Material:
-  serializedVersion: 6
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: Inherited From Round Corners
-  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
-  m_ShaderKeywords: 
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _BumpMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _EmissionMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _MetallicGlossMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _OcclusionMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _SpecGlossMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Floats:
-    - _AlphaClip: 0
-    - _Blend: 0
-    - _BumpScale: 1
-    - _ColorMask: 15
-    - _Cull: 2
-    - _Cutoff: 0.5
-    - _DstBlend: 0
-    - _GlossMapScale: 1
-    - _Glossiness: 0.5
-    - _GlossyReflections: 1
-    - _Metallic: 0
-    - _OcclusionStrength: 1
-    - _ReceiveShadows: 1
-    - _SmoothnessTextureChannel: 0
-    - _SpecularHighlights: 1
-    - _SrcBlend: 1
-    - _Stencil: 0
-    - _StencilComp: 8
-    - _StencilOp: 0
-    - _StencilReadMask: 255
-    - _StencilWriteMask: 255
-    - _Surface: 0
-    - _UseUIAlphaClip: 0
-    - _WorkflowMode: 1
-    - _ZWrite: 1
-    m_Colors:
-    - _Color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
-    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
-    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
-    - _WidthHeightRadius: {r: 43, g: 13.514961, b: 2, a: 0}
-    - _halfSize: {r: 29, g: 10, b: 0, a: 0}
-    - _r: {r: 3, g: 3, b: 3, a: 3}
-    - _rect2props: {r: 0.0000019073486, g: -0.0000038146973, b: 25.455845, a: 25.455845}
 --- !u!1 &63770831
 GameObject:
   m_ObjectHideFlags: 0
@@ -11317,6 +11240,83 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 335519737}
   m_CullTransparentMesh: 0
+--- !u!21 &341177478
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Inherited From Round Corners
+  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _AlphaClip: 0
+    - _Blend: 0
+    - _BumpScale: 1
+    - _ColorMask: 15
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _ReceiveShadows: 1
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _Surface: 0
+    - _UseUIAlphaClip: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+    - _WidthHeightRadius: {r: 43, g: 13.514961, b: 2, a: 0}
+    - _halfSize: {r: 29, g: 10, b: 0, a: 0}
+    - _r: {r: 3, g: 3, b: 3, a: 3}
+    - _rect2props: {r: 0.0000019073486, g: -0.0000038146973, b: 25.455845, a: 25.455845}
 --- !u!1 &351122359
 GameObject:
   m_ObjectHideFlags: 0
@@ -22349,18 +22349,7 @@ MonoBehaviour:
       m_Calls: []
   m_OnValueChanged:
     m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 504054569}
-        m_MethodName: NodeEditor_StartEdit
-        m_Mode: 0
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
+      m_Calls: []
   m_OnTouchScreenKeyboardStatusChanged:
     m_PersistentCalls:
       m_Calls: []
@@ -29325,7 +29314,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 13585789}
   m_Direction: 2
   m_Value: 0
-  m_Size: 0.99999964
+  m_Size: 0.9999999
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -52717,6 +52706,83 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1464760657}
   m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!21 &1468775321
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Inherited From Round Corners
+  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _AlphaClip: 0
+    - _Blend: 0
+    - _BumpScale: 1
+    - _ColorMask: 15
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _ReceiveShadows: 1
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _Surface: 0
+    - _UseUIAlphaClip: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+    - _WidthHeightRadius: {r: 46.281853, g: 16.4, b: 4, a: 0}
+    - _halfSize: {r: 29, g: 10, b: 0, a: 0}
+    - _r: {r: 3, g: 3, b: 3, a: 3}
+    - _rect2props: {r: 0.0000019073486, g: -0.0000038146973, b: 25.455845, a: 25.455845}
 --- !u!1 &1473160692
 GameObject:
   m_ObjectHideFlags: 0
@@ -69463,83 +69529,6 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
---- !u!21 &1993565349
-Material:
-  serializedVersion: 6
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: Inherited From Round Corners
-  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
-  m_ShaderKeywords: 
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _BumpMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _EmissionMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _MetallicGlossMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _OcclusionMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _SpecGlossMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Floats:
-    - _AlphaClip: 0
-    - _Blend: 0
-    - _BumpScale: 1
-    - _ColorMask: 15
-    - _Cull: 2
-    - _Cutoff: 0.5
-    - _DstBlend: 0
-    - _GlossMapScale: 1
-    - _Glossiness: 0.5
-    - _GlossyReflections: 1
-    - _Metallic: 0
-    - _OcclusionStrength: 1
-    - _ReceiveShadows: 1
-    - _SmoothnessTextureChannel: 0
-    - _SpecularHighlights: 1
-    - _SrcBlend: 1
-    - _Stencil: 0
-    - _StencilComp: 8
-    - _StencilOp: 0
-    - _StencilReadMask: 255
-    - _StencilWriteMask: 255
-    - _Surface: 0
-    - _UseUIAlphaClip: 0
-    - _WorkflowMode: 1
-    - _ZWrite: 1
-    m_Colors:
-    - _Color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
-    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
-    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
-    - _WidthHeightRadius: {r: 46.281853, g: 16.4, b: 4, a: 0}
-    - _halfSize: {r: 29, g: 10, b: 0, a: 0}
-    - _r: {r: 3, g: 3, b: 3, a: 3}
-    - _rect2props: {r: 0.0000019073486, g: -0.0000038146973, b: 25.455845, a: 25.455845}
 --- !u!1 &1996577491
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/__Scripts/BeatmapActions/Beatmap Action Containers/BeatmapActionContainer.cs
+++ b/Assets/__Scripts/BeatmapActions/Beatmap Action Containers/BeatmapActionContainer.cs
@@ -22,10 +22,12 @@ public class BeatmapActionContainer : MonoBehaviour, CMInput.IActionsActions
     /// Adds a BeatmapAction to the stack.
     /// </summary>
     /// <param name="action">BeatmapAction to add.</param>
-    public static void AddAction(BeatmapAction action)
+    /// <param name="perform">If true Redo will be triggered immediately. This means you don't need separate logic to perform the action the first time.</param>
+    public static void AddAction(BeatmapAction action, bool perform = false)
     {
         instance.beatmapActions.RemoveAll(x => !x.Active);
         instance.beatmapActions.Add(action);
+        if (perform) instance.DoRedo(action);
         Debug.Log($"Action of type {action.GetType().Name} added. ({action.Comment})");
     }
 
@@ -46,6 +48,7 @@ public class BeatmapActionContainer : MonoBehaviour, CMInput.IActionsActions
         BeatmapActionParams param = new BeatmapActionParams(this);
         lastActive.Undo(param);
         lastActive.Active = false;
+        nodeEditor.ObjectWasSelected();
     }
 
     public void Redo()
@@ -54,9 +57,15 @@ public class BeatmapActionContainer : MonoBehaviour, CMInput.IActionsActions
         BeatmapAction firstNotActive = beatmapActions.Find(x => !x.Active);
         if (firstNotActive == null) return;
         Debug.Log($"Redid a {firstNotActive?.GetType()?.Name ?? "UNKNOWN"}. ({firstNotActive?.Comment ?? "Unknown comment."})");
+        DoRedo(firstNotActive);
+    }
+
+    private void DoRedo(BeatmapAction action)
+    {
         BeatmapActionParams param = new BeatmapActionParams(this);
-        firstNotActive.Redo(param);
-        firstNotActive.Active = true;
+        action.Redo(param);
+        action.Active = true;
+        nodeEditor.ObjectWasSelected();
     }
 
     public void OnUndo(InputAction.CallbackContext context)

--- a/Assets/__Scripts/BeatmapActions/Beatmap Actions/ActionCollectionAction.cs
+++ b/Assets/__Scripts/BeatmapActions/Beatmap Actions/ActionCollectionAction.cs
@@ -16,6 +16,12 @@ public class ActionCollectionAction : BeatmapAction
     public ActionCollectionAction(IEnumerable<BeatmapAction> beatmapActions, bool forceRefreshPool = false, bool clearsSelection = true, string comment = "No comment.")
         : base(beatmapActions.SelectMany(x => x.Data), comment)
     {
+        foreach (var beatmapAction in beatmapActions)
+        {
+            // Stops the actions wastefully refreshing the object pool
+            beatmapAction.InCollection = true;
+        }
+
         actions = beatmapActions;
         clearSelection = clearsSelection;
         forceRefreshesPool = forceRefreshPool;
@@ -33,13 +39,7 @@ public class ActionCollectionAction : BeatmapAction
             action.Redo(param);
         }
 
-        if (forceRefreshesPool)
-        {
-            foreach (BeatmapObject unique in Data.DistinctBy(x => x.beatmapType))
-            {
-                BeatmapObjectContainerCollection.GetCollectionForType(unique.beatmapType).RefreshPool(true);
-            }
-        }
+        if (forceRefreshesPool) RefreshPools(Data);
     }
 
     public override void Undo(BeatmapActionContainer.BeatmapActionParams param)
@@ -54,12 +54,6 @@ public class ActionCollectionAction : BeatmapAction
             action.Undo(param);
         }
 
-        if (forceRefreshesPool)
-        {
-            foreach (BeatmapObject unique in Data.DistinctBy(x => x.beatmapType))
-            {
-                BeatmapObjectContainerCollection.GetCollectionForType(unique.beatmapType).RefreshPool(true);
-            }
-        }
+        if (forceRefreshesPool) RefreshPools(Data);
     }
 }

--- a/Assets/__Scripts/BeatmapActions/Beatmap Actions/BeatmapObjectDeletionAction.cs
+++ b/Assets/__Scripts/BeatmapActions/Beatmap Actions/BeatmapObjectDeletionAction.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 
 public class BeatmapObjectDeletionAction : BeatmapAction
 {
@@ -11,7 +10,7 @@ public class BeatmapObjectDeletionAction : BeatmapAction
     {
         foreach(BeatmapObject obj in Data)
         {
-            BeatmapObjectContainerCollection.GetCollectionForType(obj.beatmapType)?.SpawnObject(obj);
+            BeatmapObjectContainerCollection.GetCollectionForType(obj.beatmapType)?.SpawnObject(obj, refreshesPool: false);
         }
         RefreshPools(Data);
     }
@@ -20,7 +19,7 @@ public class BeatmapObjectDeletionAction : BeatmapAction
     {
         foreach (BeatmapObject obj in Data)
         {
-            BeatmapObjectContainerCollection.GetCollectionForType(obj.beatmapType).DeleteObject(obj, false);
+            BeatmapObjectContainerCollection.GetCollectionForType(obj.beatmapType).DeleteObject(obj, false, false);
         }
         RefreshPools(Data);
     }

--- a/Assets/__Scripts/BeatmapActions/Beatmap Actions/BeatmapObjectModifiedAction.cs
+++ b/Assets/__Scripts/BeatmapActions/Beatmap Actions/BeatmapObjectModifiedAction.cs
@@ -1,36 +1,63 @@
 ﻿public class BeatmapObjectModifiedAction : BeatmapAction
 {
-    private BeatmapObject originalData;
-    private BeatmapObject editedData;
-    private BeatmapObjectContainerCollection collection;
-    private bool addToSelection = false;
+    private readonly BeatmapObject _originalObject;
+    private readonly BeatmapObject _originalData;
 
-    public BeatmapObjectModifiedAction(BeatmapObject edited, BeatmapObject original, string comment = "No comment.", bool rewrapOriginal = true, bool keepSelection = false) : base(null, comment)
+    private readonly BeatmapObject _editedObject;
+    private readonly BeatmapObject _editedData;
+    private readonly BeatmapObjectContainerCollection _collection;
+    private readonly bool _addToSelection;
+
+    public BeatmapObjectModifiedAction(BeatmapObject edited, BeatmapObject originalObject, BeatmapObject originalData, string comment = "No comment.", bool keepSelection = false) : base(new[] { edited }, comment)
     {
-        collection = BeatmapObjectContainerCollection.GetCollectionForType(original.beatmapType);
-        editedData = BeatmapObject.GenerateCopy(edited);
+        _collection = BeatmapObjectContainerCollection.GetCollectionForType(originalObject.beatmapType);
+        _editedObject = edited;
+        _editedData = BeatmapObject.GenerateCopy(edited);
 
-        originalData = rewrapOriginal ? BeatmapObject.GenerateCopy(original) : original;
-        addToSelection = keepSelection;
+        _originalData = originalData;
+        _originalObject = originalObject;
+        _addToSelection = keepSelection;
     }
 
     public override void Undo(BeatmapActionContainer.BeatmapActionParams param)
     {
-        collection.DeleteObject(editedData, false);
-        SelectionController.Deselect(editedData);
+        if (_originalObject != _editedObject || _editedData._time.CompareTo(_originalData._time) != 0)
+        {
+            _collection.DeleteObject(_editedObject, false, false);
+            SelectionController.Deselect(_editedObject, false);
 
-        collection.SpawnObject(originalData, false);
-        SelectionController.Select(originalData, addToSelection, true, false);
+            _originalObject.Apply(_originalData);
+            _collection.SpawnObject(_originalObject, false, !InCollection);
+        }
+        else
+        {
+            // This is an optimisation only possible if the object has not changed position in the SortedSet
+            _originalObject.Apply(_originalData);
+            if (!InCollection) RefreshPools(Data);
+        }
+
+        SelectionController.Select(_originalObject, _addToSelection, true, !InCollection);
     }
 
     public override void Redo(BeatmapActionContainer.BeatmapActionParams param)
     {
-        collection.DeleteObject(originalData, false);
-        SelectionController.Deselect(originalData);
+        if (_originalObject != _editedObject || _editedData._time.CompareTo(_originalData._time) != 0)
+        {
+            _collection.DeleteObject(_originalObject, false, false);
+            SelectionController.Deselect(_originalObject, false);
 
-        collection.SpawnObject(editedData, false);
-        SelectionController.Select(editedData, addToSelection, true, false);
+            _editedObject.Apply(_editedData);
+            _collection.SpawnObject(_editedObject, false, !InCollection);
+        }
+        else
+        {
+            // This is an optimisation only possible if the object has not changed position in the SortedSet 
+            _editedObject.Apply(_editedData);
+            if (!InCollection) RefreshPools(Data);
+        }
+
+        SelectionController.Select(_editedObject, _addToSelection, true, !InCollection);
     }
 
-    public BeatmapObject GetEdited() => editedData;
+    public BeatmapObject GetEdited() => _editedObject;
 }

--- a/Assets/__Scripts/BeatmapActions/Beatmap Actions/BeatmapObjectModifiedWithConflictingAction.cs
+++ b/Assets/__Scripts/BeatmapActions/Beatmap Actions/BeatmapObjectModifiedWithConflictingAction.cs
@@ -2,9 +2,9 @@
 {
     private BeatmapObject conflictingObject = null;
 
-    public BeatmapObjectModifiedWithConflictingAction(BeatmapObject edited, BeatmapObject original, BeatmapObject conflicting, string comment = "No comment.") : base(edited, original, comment)
+    public BeatmapObjectModifiedWithConflictingAction(BeatmapObject edited, BeatmapObject originalObject, BeatmapObject originalData, BeatmapObject conflicting, string comment = "No comment.") : base(edited, originalObject, originalData, comment)
     {
-        conflictingObject = BeatmapObject.GenerateCopy(conflicting);
+        conflictingObject = conflicting;
     }
 
     public override void Undo(BeatmapActionContainer.BeatmapActionParams param)
@@ -13,7 +13,6 @@
         if (conflictingObject != null)
         {
             BeatmapObjectContainerCollection.GetCollectionForType(conflictingObject.beatmapType).SpawnObject(conflictingObject, false, true);
-            conflictingObject = BeatmapObject.GenerateCopy(conflictingObject);
         }
     }
 

--- a/Assets/__Scripts/BeatmapActions/Beatmap Actions/BeatmapObjectPlacementAction.cs
+++ b/Assets/__Scripts/BeatmapActions/Beatmap Actions/BeatmapObjectPlacementAction.cs
@@ -19,11 +19,12 @@ public class BeatmapObjectPlacementAction : BeatmapAction
     {
         foreach (BeatmapObject obj in Data)
         {
-            BeatmapObjectContainerCollection.GetCollectionForType(obj.beatmapType).DeleteObject(obj, false);
+            BeatmapObjectContainerCollection.GetCollectionForType(obj.beatmapType).DeleteObject(obj, false, false);
         }
+        RefreshPools(Data);
         foreach (BeatmapObject data in removedConflictObjects)
         {
-            BeatmapObjectContainerCollection.GetCollectionForType(data.beatmapType).SpawnObject(data);
+            BeatmapObjectContainerCollection.GetCollectionForType(data.beatmapType).SpawnObject(data, refreshesPool: false);
         }
         RefreshPools(removedConflictObjects);
     }
@@ -32,11 +33,12 @@ public class BeatmapObjectPlacementAction : BeatmapAction
     {
         foreach (BeatmapObject obj in removedConflictObjects)
         {
-            BeatmapObjectContainerCollection.GetCollectionForType(obj.beatmapType).DeleteObject(obj, false);
+            BeatmapObjectContainerCollection.GetCollectionForType(obj.beatmapType).DeleteObject(obj, false, false);
         }
+        RefreshPools(Data);
         foreach (BeatmapObject con in Data)
         {
-            BeatmapObjectContainerCollection.GetCollectionForType(con.beatmapType)?.SpawnObject(con);
+            BeatmapObjectContainerCollection.GetCollectionForType(con.beatmapType)?.SpawnObject(con, refreshesPool: false);
         }
         RefreshPools(Data);
     }

--- a/Assets/__Scripts/BeatmapActions/Beatmap Actions/NodeEditorTextChangedAction.cs
+++ b/Assets/__Scripts/BeatmapActions/Beatmap Actions/NodeEditorTextChangedAction.cs
@@ -1,5 +1,7 @@
-﻿using TMPro;
+﻿using System;
+using TMPro;
 
+[Obsolete("Undo/Redo is disabled when node editor is open anyway")]
 public class NodeEditorTextChangedAction : BeatmapAction
 {
     private TMP_InputField inputField;

--- a/Assets/__Scripts/BeatmapActions/Beatmap Actions/SelectionChangedAction.cs
+++ b/Assets/__Scripts/BeatmapActions/Beatmap Actions/SelectionChangedAction.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+
+[Obsolete("We don't track selection changes anymore")]
 public class SelectionChangedAction : BeatmapAction
 {
     private IEnumerable<BeatmapObject> oldSelection;

--- a/Assets/__Scripts/BeatmapActions/Beatmap Actions/SelectionDeletedAction.cs
+++ b/Assets/__Scripts/BeatmapActions/Beatmap Actions/SelectionDeletedAction.cs
@@ -11,8 +11,8 @@ public class SelectionDeletedAction : BeatmapAction
     {
         foreach(BeatmapObject data in Data.ToArray())
         {
-            BeatmapObjectContainerCollection.GetCollectionForType(data.beatmapType).SpawnObject(data, false);
-            SelectionController.Select(data, true, false);
+            BeatmapObjectContainerCollection.GetCollectionForType(data.beatmapType).SpawnObject(data, false, false);
+            SelectionController.Select(data, true, false, false);
         }
         SelectionController.RefreshSelectionMaterial(false);
         BeatmapObjectContainerCollection.RefreshAllPools();
@@ -20,7 +20,11 @@ public class SelectionDeletedAction : BeatmapAction
 
     public override void Redo(BeatmapActionContainer.BeatmapActionParams param)
     {
-        param.selection.Delete(false);
+        foreach(BeatmapObject data in Data.ToArray())
+        {
+            BeatmapObjectContainerCollection.GetCollectionForType(data.beatmapType).DeleteObject(data, false, false);
+        }
+
         RefreshPools(Data);
     }
 }

--- a/Assets/__Scripts/BeatmapActions/Beatmap Actions/SelectionPastedAction.cs
+++ b/Assets/__Scripts/BeatmapActions/Beatmap Actions/SelectionPastedAction.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 
 public class SelectionPastedAction : BeatmapAction
 {
@@ -25,9 +24,11 @@ public class SelectionPastedAction : BeatmapAction
 
     public override void Redo(BeatmapActionContainer.BeatmapActionParams param)
     {
+        SelectionController.DeselectAll();
         foreach (BeatmapObject obj in Data)
         {
             BeatmapObjectContainerCollection.GetCollectionForType(obj.beatmapType).SpawnObject(obj, false, false);
+            SelectionController.Select(obj, true, false, false);
         }
         foreach (BeatmapObject obj in removed)
         {

--- a/Assets/__Scripts/BeatmapActions/BeatmapAction.cs
+++ b/Assets/__Scripts/BeatmapActions/BeatmapAction.cs
@@ -10,6 +10,7 @@ using System;
 public abstract class BeatmapAction
 {
     public bool Active = true;
+    internal bool InCollection = false;
     public string Comment { get; private set; } = "No comment.";
     public IEnumerable<BeatmapObject> Data;
 

--- a/Assets/__Scripts/Map/BPM Changes/BeatmapBPMChange.cs
+++ b/Assets/__Scripts/Map/BPM Changes/BeatmapBPMChange.cs
@@ -34,8 +34,7 @@ public class BeatmapBPMChange : BeatmapObject
     protected override bool IsConflictingWithObjectAtSameTime(BeatmapObject other, bool deletion) => true;
     public override void Apply(BeatmapObject originalData)
     {
-        _time = originalData._time;
-        _customData = originalData._customData?.Clone();
+        base.Apply(originalData);
 
         if (originalData is BeatmapBPMChange bpm)
         {

--- a/Assets/__Scripts/Map/BPM Changes/BeatmapBPMChange.cs
+++ b/Assets/__Scripts/Map/BPM Changes/BeatmapBPMChange.cs
@@ -32,6 +32,18 @@ public class BeatmapBPMChange : BeatmapObject
     }
 
     protected override bool IsConflictingWithObjectAtSameTime(BeatmapObject other, bool deletion) => true;
+    public override void Apply(BeatmapObject originalData)
+    {
+        _time = originalData._time;
+        _customData = originalData._customData?.Clone();
+
+        if (originalData is BeatmapBPMChange bpm)
+        {
+            _BPM = bpm._BPM;
+            _beatsPerBar = bpm._beatsPerBar;
+            _metronomeOffset = bpm._metronomeOffset;
+        }
+    }
 
     public override Type beatmapType { get; set; } = Type.BPM_CHANGE;
     public float _BPM;

--- a/Assets/__Scripts/Map/BeatmapObject.cs
+++ b/Assets/__Scripts/Map/BeatmapObject.cs
@@ -102,5 +102,9 @@ public abstract class BeatmapObject {
         }
         return false;
     }*/
-    public abstract void Apply(BeatmapObject originalData);
+    public virtual void Apply(BeatmapObject originalData)
+    {
+        _time = originalData._time;
+        _customData = originalData._customData?.Clone();
+    }
 }

--- a/Assets/__Scripts/Map/BeatmapObject.cs
+++ b/Assets/__Scripts/Map/BeatmapObject.cs
@@ -57,14 +57,16 @@ public abstract class BeatmapObject {
         switch (originalData)
         {
             case MapEvent evt:
-                objectData = new MapEvent(evt._time, evt._type, evt._value, originalData._customData?.Clone()) as T;
+                var ev = new MapEvent(evt._time, evt._type, evt._value, originalData._customData?.Clone());
+                ev._lightGradient = evt._lightGradient?.Clone();
+                objectData = ev as T;
                 break;
             case BeatmapNote note:
                 objectData = new BeatmapNote(note._time, note._lineIndex, note._lineLayer, note._type, note._cutDirection, originalData._customData?.Clone()) as T;
                 break;
             default:
                 objectData = Activator.CreateInstance(originalData.GetType(), new object[] { originalData.ConvertToJSON() }) as T;
-                if (originalData._customData != null) objectData._customData = originalData._customData.Clone();
+                objectData._customData = originalData._customData?.Clone();
                 break;
         }
         return objectData;
@@ -100,4 +102,5 @@ public abstract class BeatmapObject {
         }
         return false;
     }*/
+    public abstract void Apply(BeatmapObject originalData);
 }

--- a/Assets/__Scripts/Map/Bookmarks/BeatmapBookmark.cs
+++ b/Assets/__Scripts/Map/Bookmarks/BeatmapBookmark.cs
@@ -24,6 +24,16 @@ public class BeatmapBookmark : BeatmapObject
     }
 
     protected override bool IsConflictingWithObjectAtSameTime(BeatmapObject other, bool deletion) => true;
+    public override void Apply(BeatmapObject originalData)
+    {
+        _time = originalData._time;
+        _customData = originalData._customData?.Clone();
+
+        if (originalData is BeatmapBookmark bm)
+        {
+            _name = bm._name;
+        }
+    }
 
     public string _name = "Invalid Bookmark";
     public override Type beatmapType { get; set; } = Type.BPM_CHANGE;

--- a/Assets/__Scripts/Map/Bookmarks/BeatmapBookmark.cs
+++ b/Assets/__Scripts/Map/Bookmarks/BeatmapBookmark.cs
@@ -26,8 +26,7 @@ public class BeatmapBookmark : BeatmapObject
     protected override bool IsConflictingWithObjectAtSameTime(BeatmapObject other, bool deletion) => true;
     public override void Apply(BeatmapObject originalData)
     {
-        _time = originalData._time;
-        _customData = originalData._customData?.Clone();
+        base.Apply(originalData);
 
         if (originalData is BeatmapBookmark bm)
         {

--- a/Assets/__Scripts/Map/Custom Events/BeatmapCustomEvent.cs
+++ b/Assets/__Scripts/Map/Custom Events/BeatmapCustomEvent.cs
@@ -38,6 +38,17 @@ public class BeatmapCustomEvent : BeatmapObject
         }
     }
 
+    public override void Apply(BeatmapObject originalData)
+    {
+        _time = originalData._time;
+        _customData = originalData._customData?.Clone();
+
+        if (originalData is BeatmapCustomEvent ev)
+        {
+            _type = ev._type;
+        }
+    }
+
     public override Type beatmapType { get; set; } = Type.CUSTOM_EVENT;
     public string _type;
 }

--- a/Assets/__Scripts/Map/Custom Events/BeatmapCustomEvent.cs
+++ b/Assets/__Scripts/Map/Custom Events/BeatmapCustomEvent.cs
@@ -40,8 +40,7 @@ public class BeatmapCustomEvent : BeatmapObject
 
     public override void Apply(BeatmapObject originalData)
     {
-        _time = originalData._time;
-        _customData = originalData._customData?.Clone();
+        base.Apply(originalData);
 
         if (originalData is BeatmapCustomEvent ev)
         {

--- a/Assets/__Scripts/Map/Events/MapEvent.cs
+++ b/Assets/__Scripts/Map/Events/MapEvent.cs
@@ -167,8 +167,7 @@ public class MapEvent : BeatmapObject {
 
     public override void Apply(BeatmapObject originalData)
     {
-        _time = originalData._time;
-        _customData = originalData._customData?.Clone();
+        base.Apply(originalData);
 
         if (originalData is MapEvent obs)
         {

--- a/Assets/__Scripts/Map/Events/MapEvent.cs
+++ b/Assets/__Scripts/Map/Events/MapEvent.cs
@@ -165,6 +165,19 @@ public class MapEvent : BeatmapObject {
         return false;
     }
 
+    public override void Apply(BeatmapObject originalData)
+    {
+        _time = originalData._time;
+        _customData = originalData._customData?.Clone();
+
+        if (originalData is MapEvent obs)
+        {
+            _type = obs._type;
+            _value = obs._value;
+            _lightGradient = obs._lightGradient?.Clone();
+        }
+    }
+
     public override Type beatmapType { get; set; } = Type.EVENT;
     public int _type;
     public int _value;
@@ -208,6 +221,8 @@ public class MapEvent : BeatmapObject {
             Duration = duration;
             EasingType = easing;
         }
+
+        public ChromaGradient Clone() => new ChromaGradient(StartColor, EndColor, Duration, EasingType);
 
         public JSONNode ToJSONNode()
         {

--- a/Assets/__Scripts/Map/Notes/BeatmapNote.cs
+++ b/Assets/__Scripts/Map/Notes/BeatmapNote.cs
@@ -119,8 +119,7 @@ public class BeatmapNote : BeatmapObject, IBeatmapObjectBounds
 
     public override void Apply(BeatmapObject originalData)
     {
-        _time = originalData._time;
-        _customData = originalData._customData?.Clone();
+        base.Apply(originalData);
 
         if (originalData is BeatmapNote note)
         {

--- a/Assets/__Scripts/Map/Notes/BeatmapNote.cs
+++ b/Assets/__Scripts/Map/Notes/BeatmapNote.cs
@@ -117,8 +117,22 @@ public class BeatmapNote : BeatmapObject, IBeatmapObjectBounds
         return false;
     }
 
+    public override void Apply(BeatmapObject originalData)
+    {
+        _time = originalData._time;
+        _customData = originalData._customData?.Clone();
+
+        if (originalData is BeatmapNote note)
+        {
+            _type = note._type;
+            _cutDirection = note._cutDirection;
+            _lineIndex = note._lineIndex;
+            _lineLayer = note._lineLayer;
+        }
+    }
+
     public bool IsMainDirection => _cutDirection == NOTE_CUT_DIRECTION_UP || _cutDirection == NOTE_CUT_DIRECTION_DOWN ||
-        _cutDirection == NOTE_CUT_DIRECTION_LEFT || _cutDirection == NOTE_CUT_DIRECTION_RIGHT;
+                                   _cutDirection == NOTE_CUT_DIRECTION_LEFT || _cutDirection == NOTE_CUT_DIRECTION_RIGHT;
 
     public override Type beatmapType { get; set; } = Type.NOTE;
     public int _lineIndex = 0;

--- a/Assets/__Scripts/Map/Obstacles/BeatmapObstacle.cs
+++ b/Assets/__Scripts/Map/Obstacles/BeatmapObstacle.cs
@@ -69,8 +69,7 @@ public class BeatmapObstacle : BeatmapObject, IBeatmapObjectBounds
 
     public override void Apply(BeatmapObject originalData)
     {
-        _time = originalData._time;
-        _customData = originalData._customData?.Clone();
+        base.Apply(originalData);
 
         if (originalData is BeatmapObstacle obs)
         {

--- a/Assets/__Scripts/Map/Obstacles/BeatmapObstacle.cs
+++ b/Assets/__Scripts/Map/Obstacles/BeatmapObstacle.cs
@@ -67,6 +67,20 @@ public class BeatmapObstacle : BeatmapObject, IBeatmapObjectBounds
         return false;
     }
 
+    public override void Apply(BeatmapObject originalData)
+    {
+        _time = originalData._time;
+        _customData = originalData._customData?.Clone();
+
+        if (originalData is BeatmapObstacle obs)
+        {
+            _type = obs._type;
+            _width = obs._width;
+            _lineIndex = obs._lineIndex;
+            _duration = obs._duration;
+        }
+    }
+
     public Vector2 GetCenter()
     {
         var bounds = GetShape();

--- a/Assets/__Scripts/MapEditor/Grid/Collections/BeatmapObjectContainerCollection.cs
+++ b/Assets/__Scripts/MapEditor/Grid/Collections/BeatmapObjectContainerCollection.cs
@@ -239,7 +239,7 @@ public abstract class BeatmapObjectContainerCollection : MonoBehaviour
             Debug.Log($"Performing conflicting check at {newObject._time}");
 
             var localWindow = GetBetween(newObject._time - 0.1f, newObject._time + 0.1f);
-            BeatmapObject conflict = localWindow.FirstOrDefault(x => x.IsConflictingWith(newObject));
+            BeatmapObject conflict = localWindow.Where(x => x.IsConflictingWith(newObject)).FirstOrDefault();
             if (conflict != null)
             {
                 conflicting.Add(conflict);

--- a/Assets/__Scripts/MapEditor/Grid/Rotation/RotationCallbackController.cs
+++ b/Assets/__Scripts/MapEditor/Grid/Rotation/RotationCallbackController.cs
@@ -18,7 +18,7 @@ public class RotationCallbackController : MonoBehaviour
     public int Rotation { get; private set; }
 
     // Start is called before the first frame update
-    void Start()
+    internal void Start()
     {
         BeatSaberSong.DifficultyBeatmapSet set = BeatSaberSongContainer.Instance.difficultyData.parentBeatmapSet;
         IsActive = enabledCharacteristics.Contains(set.beatmapCharacteristicName);

--- a/Assets/__Scripts/MapEditor/Input/BeatmapObstacleInputController.cs
+++ b/Assets/__Scripts/MapEditor/Input/BeatmapObstacleInputController.cs
@@ -19,7 +19,7 @@ public class BeatmapObstacleInputController : BeatmapInputController<BeatmapObst
             obs.obstacleData._duration += snapping;
             obs.UpdateGridPosition();
             obstacleAppearanceSO.SetObstacleAppearance(obs);
-            BeatmapActionContainer.AddAction(new BeatmapObjectModifiedAction(BeatmapObject.GenerateCopy(obs.objectData), original));
+            BeatmapActionContainer.AddAction(new BeatmapObjectModifiedAction(obs.objectData, obs.objectData, original));
         }
     }
 
@@ -29,12 +29,18 @@ public class BeatmapObstacleInputController : BeatmapInputController<BeatmapObst
         RaycastFirstObject(out BeatmapObstacleContainer obs);
         if (obs != null && context.performed)
         {
-            BeatmapObject original = BeatmapObject.GenerateCopy(obs.objectData);
-            obs.obstacleData._time += obs.obstacleData._duration;
-            obs.obstacleData._duration *= -1f;
-            obstacleAppearanceSO.SetObstacleAppearance(obs);
-            obs.UpdateGridPosition();
-            BeatmapActionContainer.AddAction(new BeatmapObjectModifiedAction(BeatmapObject.GenerateCopy(obs.objectData), original));
+            ToggleHyperWall(obs);
+        }
+    }
+
+    public void ToggleHyperWall(BeatmapObstacleContainer obs)
+    {
+        if (BeatmapObject.GenerateCopy(obs.objectData) is BeatmapObstacle edited)
+        {
+            edited._time += obs.obstacleData._duration;
+            edited._duration *= -1f;
+
+            BeatmapActionContainer.AddAction(new BeatmapObjectModifiedAction(edited, obs.objectData, obs.objectData), true);
         }
     }
 }

--- a/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/EventPlacement.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/EventPlacement.cs
@@ -18,7 +18,7 @@ public class EventPlacement : PlacementController<MapEvent, BeatmapEventContaine
     [SerializeField] private ToggleColourDropdown dropdown;
     [SerializeField] private CreateEventTypeLabels labels;
 
-    private int queuedValue = MapEvent.LIGHT_VALUE_RED_ON;
+    internal int queuedValue = MapEvent.LIGHT_VALUE_RED_ON;
     private bool negativeRotations = false;
 
     public bool PlacePrecisionRotation = false;

--- a/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/NotePlacement.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/NotePlacement.cs
@@ -78,7 +78,7 @@ public class NotePlacement : PlacementController<BeatmapNote, BeatmapNoteContain
 
     public override BeatmapAction GenerateAction(BeatmapObject spawned, IEnumerable<BeatmapObject> container)
     {
-        return new BeatmapObjectPlacementAction(BeatmapObject.GenerateCopy(spawned), container, "Placed a note.");
+        return new BeatmapObjectPlacementAction(spawned, container, "Placed a note.");
     }
 
     public override BeatmapNote GenerateOriginalData()

--- a/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/PlacementController.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/PlacementController.cs
@@ -25,7 +25,7 @@ public abstract class PlacementController<BO, BOC, BOCC> : MonoBehaviour, CMInpu
 
     [HideInInspector] protected virtual bool CanClickAndDrag { get; set; } = true;
 
-    [HideInInspector] protected virtual float RoundedTime { get; private set; } = 0;
+    [HideInInspector] internal virtual float RoundedTime { get; set; } = 0;
 
     protected bool isDraggingObject = false;
     protected bool isDraggingObjectAtTime = false;
@@ -87,7 +87,7 @@ public abstract class PlacementController<BO, BOC, BOCC> : MonoBehaviour, CMInpu
         if (instantiatedContainer != null) instantiatedContainer.gameObject.SetActive(false);
     }
 
-    protected void RefreshVisuals()
+    internal void RefreshVisuals()
     {
         instantiatedContainer = Instantiate(objectContainerPrefab,
             parentTrack).GetComponent(typeof(BOC)) as BOC;
@@ -121,7 +121,7 @@ public abstract class PlacementController<BO, BOC, BOCC> : MonoBehaviour, CMInpu
 
     internal virtual void ApplyToMap()
     {
-        objectData = BeatmapObject.GenerateCopy(queuedData);
+        objectData = queuedData;
         objectData._time = RoundedTime;
         //objectContainerCollection.RemoveConflictingObjects(new[] { objectData }, out List<BeatmapObject> conflicting);
         objectContainerCollection.SpawnObject(objectData, out List<BeatmapObject> conflicting);
@@ -205,7 +205,7 @@ public abstract class PlacementController<BO, BOC, BOCC> : MonoBehaviour, CMInpu
         if (con is null || !(con is BOC) || con.objectData.beatmapType != objectDataType || !IsActive) return false; //Filter out null objects and objects that aren't what we're targetting.
         draggedObjectData = con.objectData as BO;
         originalQueued = BeatmapObject.GenerateCopy(queuedData);
-        originalDraggedObjectData = BeatmapObject.GenerateCopy(con.objectData) as BO;
+        originalDraggedObjectData = BeatmapObject.GenerateCopy(con.objectData as BO);
         queuedData = BeatmapObject.GenerateCopy(draggedObjectData);
         draggedObjectContainer = con as BOC;
         return true;
@@ -237,15 +237,15 @@ public abstract class PlacementController<BO, BOC, BOCC> : MonoBehaviour, CMInpu
         queuedData = BeatmapObject.GenerateCopy(originalQueued);
         BeatmapAction action;
         // Don't queue an action if we didn't actually change anything
-        if (!draggedObjectData.IsConflictingWith(originalDraggedObjectData))
+        if (draggedObjectData.ToString() != originalDraggedObjectData.ToString())
         {
             if (conflicting.Any())
             {
-                action = new BeatmapObjectModifiedWithConflictingAction(BeatmapObject.GenerateCopy(draggedObjectData), originalDraggedObjectData, conflicting.First(), "Modified via alt-click and drag.");
+                action = new BeatmapObjectModifiedWithConflictingAction(draggedObjectData, draggedObjectData, originalDraggedObjectData, conflicting.First(), "Modified via alt-click and drag.");
             }
             else
             {
-                action = new BeatmapObjectModifiedAction(BeatmapObject.GenerateCopy(draggedObjectData), originalDraggedObjectData, "Modified via alt-click and drag.");
+                action = new BeatmapObjectModifiedAction(draggedObjectData, draggedObjectData, originalDraggedObjectData, "Modified via alt-click and drag.");
             }
             BeatmapActionContainer.AddAction(action);
         }

--- a/Assets/__Scripts/MapEditor/Mapping/Selection/SelectionController.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/Selection/SelectionController.cs
@@ -262,7 +262,6 @@ public class SelectionController : MonoBehaviour, CMInput.ISelectingActions, CMI
     public void Copy(bool cut = false)
     {
         if (!HasSelectedObjects()) return;
-        Debug.Log("Copied!");
         CopiedObjects.Clear();
         float firstTime = SelectedObjects.OrderBy(x => x._time).First()._time;
         foreach (BeatmapObject data in SelectedObjects)
@@ -359,7 +358,7 @@ public class SelectionController : MonoBehaviour, CMInput.ISelectingActions, CMI
         }
         if (triggersAction)
         {
-            BeatmapActionContainer.AddAction(new SelectionPastedAction(pasted.Select(o => BeatmapObject.GenerateCopy(o)), totalRemoved));
+            BeatmapActionContainer.AddAction(new SelectionPastedAction(pasted, totalRemoved));
         }
         SelectionPastedEvent?.Invoke(pasted);
         SelectionChangedEvent?.Invoke();
@@ -395,9 +394,9 @@ public class SelectionController : MonoBehaviour, CMInput.ISelectingActions, CMI
                 notesContainer.RefreshSpecialAngles(data, false, false);
             }
 
-            allActions.Add(new BeatmapObjectModifiedAction(data, original, "", false, true));
+            allActions.Add(new BeatmapObjectModifiedAction(data, data, original, "", true));
         }
-        BeatmapActionContainer.AddAction(new ActionCollectionAction(allActions, false, true, "Shifted a selection of objects."));
+        BeatmapActionContainer.AddAction(new ActionCollectionAction(allActions, true, true, "Shifted a selection of objects."));
         BeatmapObjectContainerCollection.RefreshAllPools();
     }
 
@@ -522,7 +521,7 @@ public class SelectionController : MonoBehaviour, CMInput.ISelectingActions, CMI
                 }
             }
 
-            return new BeatmapObjectModifiedAction(data, original, "", false);
+            return new BeatmapObjectModifiedAction(data, data, original, "", true);
         }).ToList();
 
         foreach (var obj in allActions)
@@ -539,7 +538,7 @@ public class SelectionController : MonoBehaviour, CMInput.ISelectingActions, CMI
         {
             BeatmapObjectContainerCollection.GetCollectionForType(unique.beatmapType).RefreshPool(true);
         }
-        BeatmapActionContainer.AddAction(new ActionCollectionAction(allActions, false, true, "Shifted a selection of objects."));
+        BeatmapActionContainer.AddAction(new ActionCollectionAction(allActions, true, true, "Shifted a selection of objects."));
         tracksManager.RefreshTracks();
     }
 

--- a/Assets/__Scripts/MapEditor/UI/Node Editor/NodeEditorController.cs
+++ b/Assets/__Scripts/MapEditor/UI/Node Editor/NodeEditorController.cs
@@ -153,20 +153,6 @@ public class NodeEditorController : MonoBehaviour, CMInput.INodeEditorActions
                 CMInputCallbackInstaller.DisableActionMaps(typeof(NodeEditorController), new[] { typeof(CMInput.INodeEditorActions) });
                 CMInputCallbackInstaller.DisableActionMaps(typeof(NodeEditorController), actionMapsDisabled);
             }
-            BeatmapAction lastAction = BeatmapActionContainer.GetLastAction();
-            if (lastAction != null && lastAction is NodeEditorTextChangedAction textChangedAction)
-            {
-                if (content != textChangedAction.CurrentText && content != textChangedAction.OldText)
-                {
-                    BeatmapActionContainer.AddAction(new NodeEditorTextChangedAction(content, nodeEditorInputField.caretPosition,
-                        oldInputText, oldCaretPosition, nodeEditorInputField));
-                }
-            }
-            else
-            {
-                BeatmapActionContainer.AddAction(new NodeEditorTextChangedAction(content, nodeEditorInputField.caretPosition,
-                        content, nodeEditorInputField.caretPosition, nodeEditorInputField));
-            }
         }
         oldInputText = content;
         oldCaretPosition = nodeEditorInputField.caretPosition;
@@ -176,6 +162,7 @@ public class NodeEditorController : MonoBehaviour, CMInput.INodeEditorActions
     {
         CMInputCallbackInstaller.ClearDisabledActionMaps(typeof(NodeEditorController), new[] { typeof(CMInput.INodeEditorActions) });
         CMInputCallbackInstaller.ClearDisabledActionMaps(typeof(NodeEditorController), actionMapsDisabled);
+
         try
         {
             if (!isEditing || !IsActive) return;
@@ -200,7 +187,7 @@ public class NodeEditorController : MonoBehaviour, CMInput.INodeEditorActions
                 collection.DeleteObject(entry.Key, false);
                 collection.SpawnObject(newObject, true, false);
                 SelectionController.Select(newObject, true, true, false);
-                beatmapActions.Add(new BeatmapObjectModifiedAction(newObject, entry.Key, $"Edited a {entry.Key.beatmapType} with Node Editor.", true, true));
+                beatmapActions.Add(new BeatmapObjectModifiedAction(newObject, entry.Key, entry.Key, $"Edited a {entry.Key.beatmapType} with Node Editor.", true));
             }
 
             foreach (var type in dict.Select(it => it.Key.beatmapType).Distinct())
@@ -211,7 +198,7 @@ public class NodeEditorController : MonoBehaviour, CMInput.INodeEditorActions
 
             UpdateJSON();
 
-            BeatmapActionContainer.AddAction(new ActionCollectionAction(beatmapActions, false, true, $"Edited ({editingObjects.Count()}) objects with Node Editor."));
+            BeatmapActionContainer.AddAction(new ActionCollectionAction(beatmapActions, true, true, $"Edited ({editingObjects.Count()}) objects with Node Editor."));
         }
         catch (Exception e)
         {

--- a/Assets/__Scripts/Platforms/PlatformDescriptor.cs
+++ b/Assets/__Scripts/Platforms/PlatformDescriptor.cs
@@ -327,9 +327,8 @@ public class PlatformDescriptor : MonoBehaviour {
         MapEvent.ChromaGradient gradient = gradientEvent._lightGradient;
         Func<float, float> easingFunc = Easing.byName[gradient.EasingType];
         float progress = 0;
-        while (progress < 1)
+        while ((progress = (atsc.CurrentBeat - gradientEvent._time) / gradient.Duration) < 1)
         {
-            progress = (atsc.CurrentBeat - gradientEvent._time) / gradient.Duration;
             Color lerped = Color.LerpUnclamped(gradient.StartColor, gradient.EndColor, easingFunc(progress));
             if (!SoloAnEventType || gradientEvent._type == SoloEventType)
             {


### PR DESCRIPTION
I didn't really want to make any huge changes during zenjectification but this kinda happened.
Makes most undo/redo actions faster by not deleting/spawning objects when we don't need to.
Huge boost to general delete performance by reverting back to before we tried to add a load of patches to fix ghost notes.
Pool refreshes on multi-actions are saved until the end of all actions.
21 new tests (350% increase) to validate most ways of editing objects do the right thing and can be undone and redone (and don't create ghost objects).
A lot of fixes to object editing found through testing.
Colours now always contain an alpha value, this makes node editor consistently show them when selecting multiple objects.

Bonus fix for playing after a gradient causing flashbangs.