### PR TITLE
Add logging around failing test

### DIFF
--- a/Assets/Tests/Util/TestUtils.cs
+++ b/Assets/Tests/Util/TestUtils.cs
@@ -14,6 +14,8 @@ namespace Tests.Util
             if (SceneManager.GetActiveScene().name.StartsWith("03"))
                 yield break;
 
+            Settings.Instance.Reminder_Loading360Levels = false;
+
             CMInputCallbackInstaller.TestMode = true;
             yield return SceneManager.LoadSceneAsync("00_FirstBoot", LoadSceneMode.Single);
             PersistentUI.Instance.enableTransitions = false;

--- a/Assets/__Scripts/Platforms/LightsManager.cs
+++ b/Assets/__Scripts/Platforms/LightsManager.cs
@@ -23,7 +23,7 @@ public class LightsManager : MonoBehaviour
 
     private IEnumerator Start()
     {
-        yield return new WaitForEndOfFrame();
+        yield return null;
         // Multiple CM prop ids could align with the same game prop ids
         EditorToGamePropIDMap = EditorToGamePropIDMap.Distinct().ToList();
         EditorToGameLightIDMap = EditorToGameLightIDMap.Distinct().ToList();


### PR DESCRIPTION
WaitForEndOfFrame hangs forever in batch tests, null gets run slightly earlier in the loop but it seems to load the lights fine.

Any thoughts if this could have any other side effects?