### PR TITLE
My attempt at fixing audio sync late into songs

### DIFF
--- a/Assets/__Scripts/MapEditor/AudioTimeSyncController.cs
+++ b/Assets/__Scripts/MapEditor/AudioTimeSyncController.cs
@@ -130,22 +130,22 @@ public class AudioTimeSyncController : MonoBehaviour, CMInput.IPlaybackActions, 
             if (!levelLoaded) return;
             if (IsPlaying)
             {
-                float time = currentSeconds;
+                var time = currentSeconds;
 
-                float correction = 1f;
+                // Slightly more accurate than songAudioSource.time
+                var trackTime = songAudioSource.timeSamples / (float) songAudioSource.clip.frequency;
 
                 // Sync correction
-                if (CurrentSeconds > 1)
-                {
-                    correction = songAudioSource.time / CurrentSeconds;
-                }
+                var correction = CurrentSeconds > 1 ? trackTime / CurrentSeconds : 1f;
 
-                if (Mathf.Abs(correction - 1) >= Time.smoothDeltaTime)
+                // Snap forward if we are more than a 2 frames out of sync as we're trying to make it one frame out?
+                if (Mathf.Abs(trackTime - CurrentSeconds) >= 2 * Time.smoothDeltaTime * (songSpeed / 10f))
                 {
-                    time = songAudioSource.time;
+                    time = trackTime;
                     correction = 1;
                 }
 
+                // Add frame time to current time
                 CurrentSeconds = time + (correction * (Time.deltaTime * (songSpeed / 10f)));
 
                 if (!songAudioSource.isPlaying) TogglePlaying();


### PR DESCRIPTION
I'm not super confident with what's going on in this method but it seems like using the time ratios will approach 1 as the current time tends towards infinity. This means for large time values their distance from 1 will never be >= smoothDeltaTime. This is bad as it means we can de-sync and never correct for it. I _think_ most of this desync in the map I'm testing is caused as playback starts (putting events into the queue, finding the current lighting state etc.) so if we can trigger a single correction this is all we need.

I think this may also be related to the skipping issue some people have reported and while I can't really reproduce it I hope this may improve that behaviour.

I've also replaced the usage of songAudioSource.time with timeSamples, this is marginally more accurate and is probably unnecessary but I'd already been testing with it anyway.