### PR TITLE
Bug fixes

### DIFF
--- a/Assets/__Scenes/00_FirstBoot.unity
+++ b/Assets/__Scenes/00_FirstBoot.unity
@@ -679,174 +679,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: -110}
   m_SizeDelta: {x: 600, y: 80}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!21 &418982221
-Material:
-  serializedVersion: 6
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: Inherited From Round Corners
-  m_Shader: {fileID: 4800000, guid: d3beb88e61f88ca4393acdefb005fa70, type: 3}
-  m_ShaderKeywords: 
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _BaseMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _BumpMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _EmissionMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _MetallicGlossMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _OcclusionMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _SpecGlossMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Floats:
-    - _AlphaClip: 0
-    - _Blend: 0
-    - _BumpScale: 1
-    - _ColorMask: 15
-    - _Cull: 2
-    - _Cutoff: 0.5
-    - _DstBlend: 0
-    - _EnvironmentReflections: 1
-    - _GlossMapScale: 0
-    - _Glossiness: 0
-    - _GlossyReflections: 0
-    - _Metallic: 0
-    - _OcclusionStrength: 1
-    - _QueueOffset: 0
-    - _ReceiveShadows: 1
-    - _Smoothness: 0.5
-    - _SmoothnessTextureChannel: 0
-    - _SpecularHighlights: 1
-    - _SrcBlend: 1
-    - _Stencil: 0
-    - _StencilComp: 8
-    - _StencilOp: 0
-    - _StencilReadMask: 255
-    - _StencilWriteMask: 255
-    - _Surface: 0
-    - _UseUIAlphaClip: 0
-    - _WorkflowMode: 1
-    - _ZWrite: 1
-    m_Colors:
-    - _BaseColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
-    - _Color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
-    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
-    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
-    - _halfSize: {r: 250, g: 20, b: 0, a: 0}
-    - _r: {r: 0, g: 0, b: 4, a: 4}
-    - _rect2props: {r: 0.000030517578, g: 2, b: 189.50462, a: 189.50462}
---- !u!21 &423390700
-Material:
-  serializedVersion: 6
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: Inherited From Round Corners
-  m_Shader: {fileID: 4800000, guid: d3beb88e61f88ca4393acdefb005fa70, type: 3}
-  m_ShaderKeywords: 
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _BaseMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _BumpMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _EmissionMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _MetallicGlossMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _OcclusionMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _SpecGlossMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Floats:
-    - _AlphaClip: 0
-    - _Blend: 0
-    - _BumpScale: 1
-    - _ColorMask: 15
-    - _Cull: 2
-    - _Cutoff: 0.5
-    - _DstBlend: 0
-    - _EnvironmentReflections: 1
-    - _GlossMapScale: 0
-    - _Glossiness: 0
-    - _GlossyReflections: 0
-    - _Metallic: 0
-    - _OcclusionStrength: 1
-    - _QueueOffset: 0
-    - _ReceiveShadows: 1
-    - _Smoothness: 0.5
-    - _SmoothnessTextureChannel: 0
-    - _SpecularHighlights: 1
-    - _SrcBlend: 1
-    - _Stencil: 0
-    - _StencilComp: 8
-    - _StencilOp: 0
-    - _StencilReadMask: 255
-    - _StencilWriteMask: 255
-    - _Surface: 0
-    - _UseUIAlphaClip: 0
-    - _WorkflowMode: 1
-    - _ZWrite: 1
-    m_Colors:
-    - _BaseColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
-    - _Color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
-    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
-    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
-    - _halfSize: {r: 250, g: 15, b: 0, a: 0}
-    - _r: {r: 4, g: 4, b: 0, a: 0}
-    - _rect2props: {r: 0.000030517578, g: -2, b: 185.9691, a: 185.9691}
 --- !u!1 &592537255
 GameObject:
   m_ObjectHideFlags: 0
@@ -1038,6 +870,90 @@ MonoBehaviour:
   - {fileID: 0}
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!21 &601444050
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Inherited From Round Corners
+  m_Shader: {fileID: 4800000, guid: d3beb88e61f88ca4393acdefb005fa70, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _AlphaClip: 0
+    - _Blend: 0
+    - _BumpScale: 1
+    - _ColorMask: 15
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DstBlend: 0
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 0
+    - _Glossiness: 0
+    - _GlossyReflections: 0
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Smoothness: 0.5
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _Surface: 0
+    - _UseUIAlphaClip: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+    - _Color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+    - _halfSize: {r: 250, g: 20, b: 0, a: 0}
+    - _r: {r: 0, g: 0, b: 4, a: 4}
+    - _rect2props: {r: 0.000030517578, g: 2, b: 189.50462, a: 189.50462}
 --- !u!1 &780529417
 GameObject:
   m_ObjectHideFlags: 0
@@ -3140,6 +3056,90 @@ MonoBehaviour:
   m_ChildControlHeight: 1
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
+--- !u!21 &1384473946
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Inherited From Round Corners
+  m_Shader: {fileID: 4800000, guid: d3beb88e61f88ca4393acdefb005fa70, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _AlphaClip: 0
+    - _Blend: 0
+    - _BumpScale: 1
+    - _ColorMask: 15
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DstBlend: 0
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 0
+    - _Glossiness: 0
+    - _GlossyReflections: 0
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Smoothness: 0.5
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _Surface: 0
+    - _UseUIAlphaClip: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+    - _Color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+    - _halfSize: {r: 250, g: 15, b: 0, a: 0}
+    - _r: {r: 4, g: 4, b: 0, a: 0}
+    - _rect2props: {r: 0.000030517578, g: -2, b: 185.9691, a: 185.9691}
 --- !u!1 &1535728092
 GameObject:
   m_ObjectHideFlags: 0
@@ -3802,6 +3802,11 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1757455336493702345, guid: 16c79367c31039f489988c1894e49e3f,
+        type: 3}
+      propertyPath: forceStartupValidationAlign
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 2265580838388122429, guid: 16c79367c31039f489988c1894e49e3f,
         type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -4365,7 +4370,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   r: {x: 4, y: 4, z: 0, w: 0}
   material: {fileID: 2100000, guid: 10a07d7929615dc42b79174fca2634b1, type: 2}
-  mat: {fileID: 423390700}
+  mat: {fileID: 1384473946}
   cloneMaterial: 1
   rect2props: {x: 0.000030517578, y: -2, z: 185.9691, w: 185.9691}
 --- !u!114 &1713886078
@@ -4380,7 +4385,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Material: {fileID: 423390700}
+  m_Material: {fileID: 1384473946}
   m_Color: {r: 0.11320752, g: 0.11320752, b: 0.11320752, a: 1}
   m_RaycastTarget: 0
   m_Maskable: 1
@@ -4868,7 +4873,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   r: {x: 0, y: 0, z: 4, w: 4}
   material: {fileID: 2100000, guid: 10a07d7929615dc42b79174fca2634b1, type: 2}
-  mat: {fileID: 418982221}
+  mat: {fileID: 601444050}
   cloneMaterial: 1
   rect2props: {x: 0.000030517578, y: 2, z: 189.50462, w: 189.50462}
 --- !u!114 &2120207441
@@ -4883,7 +4888,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Material: {fileID: 418982221}
+  m_Material: {fileID: 601444050}
   m_Color: {r: 0.11372549, g: 0.11372549, b: 0.11372549, a: 1}
   m_RaycastTarget: 0
   m_Maskable: 1

--- a/Assets/__Scripts/BeatSaberSong.cs
+++ b/Assets/__Scripts/BeatSaberSong.cs
@@ -215,6 +215,7 @@ public class BeatSaberSong
     public string songName = "New Song";
     public string cleanSongName => Path.GetInvalidFileNameChars().Aggregate(songName, (res, el) => res.Replace(el.ToString(), string.Empty));
 
+    private string stagedDirectory;
     public string directory;
     public JSONNode json;
 
@@ -256,6 +257,7 @@ public class BeatSaberSong
         directory = null;
         json = null;
         if (!(string.IsNullOrEmpty(name) || string.IsNullOrWhiteSpace(name))) songName = name;
+        stagedDirectory = cleanSongName;
         isWIPMap = wipmap;
         TouchEditorValues();
         editors = new Editors(null);
@@ -274,7 +276,7 @@ public class BeatSaberSong
         try
         {
             if (string.IsNullOrEmpty(directory))
-                directory = $"{(isWIPMap ? Settings.Instance.CustomWIPSongsFolder : Settings.Instance.CustomSongsFolder)}/{cleanSongName}";
+                directory = Path.Combine(isWIPMap ? Settings.Instance.CustomWIPSongsFolder : Settings.Instance.CustomSongsFolder, stagedDirectory ?? cleanSongName);
             if (!Directory.Exists(directory)) Directory.CreateDirectory(directory);
             if (json == null) json = new JSONObject();
             if (customData == null) customData = new JSONObject();

--- a/Assets/__Scripts/BeatmapActions/Beatmap Action Containers/BeatmapActionContainer.cs
+++ b/Assets/__Scripts/BeatmapActions/Beatmap Action Containers/BeatmapActionContainer.cs
@@ -90,4 +90,9 @@ public class BeatmapActionContainer : MonoBehaviour, CMInput.IActionsActions
             tracksManager = container.tracksManager;
         }
     }
+
+    public void OnUndoMethod1(InputAction.CallbackContext context) => OnUndo(context);
+    public void OnUndoMethod2(InputAction.CallbackContext context) => OnUndo(context);
+    public void OnRedoMethod1(InputAction.CallbackContext context) => OnRedo(context);
+    public void OnRedoMethod2(InputAction.CallbackContext context) => OnRedo(context);
 }

--- a/Assets/__Scripts/BeatmapActions/Beatmap Actions/SelectionDeletedAction.cs
+++ b/Assets/__Scripts/BeatmapActions/Beatmap Actions/SelectionDeletedAction.cs
@@ -15,7 +15,7 @@ public class SelectionDeletedAction : BeatmapAction
             SelectionController.Select(data, true, false, false);
         }
         SelectionController.RefreshSelectionMaterial(false);
-        BeatmapObjectContainerCollection.RefreshAllPools();
+        RefreshPools(Data);
     }
 
     public override void Redo(BeatmapActionContainer.BeatmapActionParams param)

--- a/Assets/__Scripts/BeatmapActions/BeatmapAction.cs
+++ b/Assets/__Scripts/BeatmapActions/BeatmapAction.cs
@@ -25,6 +25,11 @@ public abstract class BeatmapAction
         {
             BeatmapObjectContainerCollection collection = BeatmapObjectContainerCollection.GetCollectionForType(unique.beatmapType);
             collection.RefreshPool(true);
+
+            if (collection is BPMChangesContainer con)
+            {
+                con.RefreshGridShaders();
+            }
         }
     }
 

--- a/Assets/__Scripts/Input/Master.cs
+++ b/Assets/__Scripts/Input/Master.cs
@@ -449,7 +449,7 @@ public class @CMInput : IInputActionCollection, IDisposable
             ""id"": ""3e26cae6-c1ff-441d-96fc-9f7505133eed"",
             ""actions"": [
                 {
-                    ""name"": ""Undo"",
+                    ""name"": ""Undo (Method 1)"",
                     ""type"": ""Button"",
                     ""id"": ""fedad900-9c47-459d-bddd-f46d2be3e180"",
                     ""expectedControlType"": """",
@@ -457,10 +457,26 @@ public class @CMInput : IInputActionCollection, IDisposable
                     ""interactions"": ""Press""
                 },
                 {
-                    ""name"": ""Redo"",
+                    ""name"": ""Undo (Method 2)"",
+                    ""type"": ""Button"",
+                    ""id"": ""c62387e5-adc8-4366-b018-e897233be233"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": ""Press""
+                },
+                {
+                    ""name"": ""Redo (Method 1)"",
                     ""type"": ""Button"",
                     ""id"": ""7d4b7471-e9f7-4b02-86f8-93f38fad7792"",
                     ""expectedControlType"": """",
+                    ""processors"": """",
+                    ""interactions"": ""Press""
+                },
+                {
+                    ""name"": ""Redo (Method 2)"",
+                    ""type"": ""Button"",
+                    ""id"": ""06f077ed-f9cc-43ae-87f3-7be30bd3ff5b"",
+                    ""expectedControlType"": ""Button"",
                     ""processors"": """",
                     ""interactions"": ""Press""
                 }
@@ -473,7 +489,7 @@ public class @CMInput : IInputActionCollection, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""Undo"",
+                    ""action"": ""Undo (Method 1)"",
                     ""isComposite"": true,
                     ""isPartOfComposite"": false
                 },
@@ -484,7 +500,7 @@ public class @CMInput : IInputActionCollection, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": ""ChroMapper Default"",
-                    ""action"": ""Undo"",
+                    ""action"": ""Undo (Method 1)"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": true
                 },
@@ -495,51 +511,7 @@ public class @CMInput : IInputActionCollection, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": ""ChroMapper Default"",
-                    ""action"": ""Undo"",
-                    ""isComposite"": false,
-                    ""isPartOfComposite"": true
-                },
-                {
-                    ""name"": ""Method 2"",
-                    ""id"": ""8d2a0118-7d90-404b-bc4b-7e75c6c16e77"",
-                    ""path"": ""ButtonWithTwoModifiers"",
-                    ""interactions"": """",
-                    ""processors"": """",
-                    ""groups"": """",
-                    ""action"": ""Undo"",
-                    ""isComposite"": true,
-                    ""isPartOfComposite"": false
-                },
-                {
-                    ""name"": ""modifier1"",
-                    ""id"": ""c820fc98-a631-4ba2-8872-cd9483499893"",
-                    ""path"": ""<Keyboard>/ctrl"",
-                    ""interactions"": """",
-                    ""processors"": """",
-                    ""groups"": ""ChroMapper Default"",
-                    ""action"": ""Undo"",
-                    ""isComposite"": false,
-                    ""isPartOfComposite"": true
-                },
-                {
-                    ""name"": ""modifier2"",
-                    ""id"": ""5a28b45b-80a4-42a5-83e5-ac4f005fa771"",
-                    ""path"": ""<Keyboard>/shift"",
-                    ""interactions"": """",
-                    ""processors"": """",
-                    ""groups"": ""ChroMapper Default"",
-                    ""action"": ""Undo"",
-                    ""isComposite"": false,
-                    ""isPartOfComposite"": true
-                },
-                {
-                    ""name"": ""button"",
-                    ""id"": ""c1ddbbb8-0a6d-4c3a-8669-a50557a09c5c"",
-                    ""path"": ""<Keyboard>/y"",
-                    ""interactions"": """",
-                    ""processors"": """",
-                    ""groups"": ""ChroMapper Default"",
-                    ""action"": ""Undo"",
+                    ""action"": ""Undo (Method 1)"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": true
                 },
@@ -550,7 +522,7 @@ public class @CMInput : IInputActionCollection, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""Redo"",
+                    ""action"": ""Redo (Method 1)"",
                     ""isComposite"": true,
                     ""isPartOfComposite"": false
                 },
@@ -561,7 +533,7 @@ public class @CMInput : IInputActionCollection, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": ""ChroMapper Default"",
-                    ""action"": ""Redo"",
+                    ""action"": ""Redo (Method 1)"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": true
                 },
@@ -572,7 +544,51 @@ public class @CMInput : IInputActionCollection, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": ""ChroMapper Default"",
-                    ""action"": ""Redo"",
+                    ""action"": ""Redo (Method 1)"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": true
+                },
+                {
+                    ""name"": ""Method 2"",
+                    ""id"": ""8d2a0118-7d90-404b-bc4b-7e75c6c16e77"",
+                    ""path"": ""ButtonWithTwoModifiers"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""Undo (Method 2)"",
+                    ""isComposite"": true,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": ""modifier1"",
+                    ""id"": ""c820fc98-a631-4ba2-8872-cd9483499893"",
+                    ""path"": ""<Keyboard>/ctrl"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""ChroMapper Default"",
+                    ""action"": ""Undo (Method 2)"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": true
+                },
+                {
+                    ""name"": ""modifier2"",
+                    ""id"": ""5a28b45b-80a4-42a5-83e5-ac4f005fa771"",
+                    ""path"": ""<Keyboard>/shift"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""ChroMapper Default"",
+                    ""action"": ""Undo (Method 2)"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": true
+                },
+                {
+                    ""name"": ""button"",
+                    ""id"": ""c1ddbbb8-0a6d-4c3a-8669-a50557a09c5c"",
+                    ""path"": ""<Keyboard>/y"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""ChroMapper Default"",
+                    ""action"": ""Undo (Method 2)"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": true
                 },
@@ -583,7 +599,7 @@ public class @CMInput : IInputActionCollection, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""Redo"",
+                    ""action"": ""Redo (Method 2)"",
                     ""isComposite"": true,
                     ""isPartOfComposite"": false
                 },
@@ -594,7 +610,7 @@ public class @CMInput : IInputActionCollection, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": ""ChroMapper Default"",
-                    ""action"": ""Redo"",
+                    ""action"": ""Redo (Method 2)"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": true
                 },
@@ -605,7 +621,7 @@ public class @CMInput : IInputActionCollection, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": ""ChroMapper Default"",
-                    ""action"": ""Redo"",
+                    ""action"": ""Redo (Method 2)"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": true
                 },
@@ -616,7 +632,7 @@ public class @CMInput : IInputActionCollection, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": ""ChroMapper Default"",
-                    ""action"": ""Redo"",
+                    ""action"": ""Redo (Method 2)"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": true
                 }
@@ -3268,8 +3284,10 @@ public class @CMInput : IInputActionCollection, IDisposable
         m_Utils_MouseMovement = m_Utils.FindAction("Mouse Movement", throwIfNotFound: true);
         // Actions
         m_Actions = asset.FindActionMap("Actions", throwIfNotFound: true);
-        m_Actions_Undo = m_Actions.FindAction("Undo", throwIfNotFound: true);
-        m_Actions_Redo = m_Actions.FindAction("Redo", throwIfNotFound: true);
+        m_Actions_UndoMethod1 = m_Actions.FindAction("Undo (Method 1)", throwIfNotFound: true);
+        m_Actions_UndoMethod2 = m_Actions.FindAction("Undo (Method 2)", throwIfNotFound: true);
+        m_Actions_RedoMethod1 = m_Actions.FindAction("Redo (Method 1)", throwIfNotFound: true);
+        m_Actions_RedoMethod2 = m_Actions.FindAction("Redo (Method 2)", throwIfNotFound: true);
         // Placement Controllers
         m_PlacementControllers = asset.FindActionMap("Placement Controllers", throwIfNotFound: true);
         m_PlacementControllers_PlaceObject = m_PlacementControllers.FindAction("Place Object", throwIfNotFound: true);
@@ -3651,14 +3669,18 @@ public class @CMInput : IInputActionCollection, IDisposable
     // Actions
     private readonly InputActionMap m_Actions;
     private IActionsActions m_ActionsActionsCallbackInterface;
-    private readonly InputAction m_Actions_Undo;
-    private readonly InputAction m_Actions_Redo;
+    private readonly InputAction m_Actions_UndoMethod1;
+    private readonly InputAction m_Actions_UndoMethod2;
+    private readonly InputAction m_Actions_RedoMethod1;
+    private readonly InputAction m_Actions_RedoMethod2;
     public struct ActionsActions
     {
         private @CMInput m_Wrapper;
         public ActionsActions(@CMInput wrapper) { m_Wrapper = wrapper; }
-        public InputAction @Undo => m_Wrapper.m_Actions_Undo;
-        public InputAction @Redo => m_Wrapper.m_Actions_Redo;
+        public InputAction @UndoMethod1 => m_Wrapper.m_Actions_UndoMethod1;
+        public InputAction @UndoMethod2 => m_Wrapper.m_Actions_UndoMethod2;
+        public InputAction @RedoMethod1 => m_Wrapper.m_Actions_RedoMethod1;
+        public InputAction @RedoMethod2 => m_Wrapper.m_Actions_RedoMethod2;
         public InputActionMap Get() { return m_Wrapper.m_Actions; }
         public void Enable() { Get().Enable(); }
         public void Disable() { Get().Disable(); }
@@ -3668,22 +3690,34 @@ public class @CMInput : IInputActionCollection, IDisposable
         {
             if (m_Wrapper.m_ActionsActionsCallbackInterface != null)
             {
-                @Undo.started -= m_Wrapper.m_ActionsActionsCallbackInterface.OnUndo;
-                @Undo.performed -= m_Wrapper.m_ActionsActionsCallbackInterface.OnUndo;
-                @Undo.canceled -= m_Wrapper.m_ActionsActionsCallbackInterface.OnUndo;
-                @Redo.started -= m_Wrapper.m_ActionsActionsCallbackInterface.OnRedo;
-                @Redo.performed -= m_Wrapper.m_ActionsActionsCallbackInterface.OnRedo;
-                @Redo.canceled -= m_Wrapper.m_ActionsActionsCallbackInterface.OnRedo;
+                @UndoMethod1.started -= m_Wrapper.m_ActionsActionsCallbackInterface.OnUndoMethod1;
+                @UndoMethod1.performed -= m_Wrapper.m_ActionsActionsCallbackInterface.OnUndoMethod1;
+                @UndoMethod1.canceled -= m_Wrapper.m_ActionsActionsCallbackInterface.OnUndoMethod1;
+                @UndoMethod2.started -= m_Wrapper.m_ActionsActionsCallbackInterface.OnUndoMethod2;
+                @UndoMethod2.performed -= m_Wrapper.m_ActionsActionsCallbackInterface.OnUndoMethod2;
+                @UndoMethod2.canceled -= m_Wrapper.m_ActionsActionsCallbackInterface.OnUndoMethod2;
+                @RedoMethod1.started -= m_Wrapper.m_ActionsActionsCallbackInterface.OnRedoMethod1;
+                @RedoMethod1.performed -= m_Wrapper.m_ActionsActionsCallbackInterface.OnRedoMethod1;
+                @RedoMethod1.canceled -= m_Wrapper.m_ActionsActionsCallbackInterface.OnRedoMethod1;
+                @RedoMethod2.started -= m_Wrapper.m_ActionsActionsCallbackInterface.OnRedoMethod2;
+                @RedoMethod2.performed -= m_Wrapper.m_ActionsActionsCallbackInterface.OnRedoMethod2;
+                @RedoMethod2.canceled -= m_Wrapper.m_ActionsActionsCallbackInterface.OnRedoMethod2;
             }
             m_Wrapper.m_ActionsActionsCallbackInterface = instance;
             if (instance != null)
             {
-                @Undo.started += instance.OnUndo;
-                @Undo.performed += instance.OnUndo;
-                @Undo.canceled += instance.OnUndo;
-                @Redo.started += instance.OnRedo;
-                @Redo.performed += instance.OnRedo;
-                @Redo.canceled += instance.OnRedo;
+                @UndoMethod1.started += instance.OnUndoMethod1;
+                @UndoMethod1.performed += instance.OnUndoMethod1;
+                @UndoMethod1.canceled += instance.OnUndoMethod1;
+                @UndoMethod2.started += instance.OnUndoMethod2;
+                @UndoMethod2.performed += instance.OnUndoMethod2;
+                @UndoMethod2.canceled += instance.OnUndoMethod2;
+                @RedoMethod1.started += instance.OnRedoMethod1;
+                @RedoMethod1.performed += instance.OnRedoMethod1;
+                @RedoMethod1.canceled += instance.OnRedoMethod1;
+                @RedoMethod2.started += instance.OnRedoMethod2;
+                @RedoMethod2.performed += instance.OnRedoMethod2;
+                @RedoMethod2.canceled += instance.OnRedoMethod2;
             }
         }
     }
@@ -5241,8 +5275,10 @@ public class @CMInput : IInputActionCollection, IDisposable
     }
     public interface IActionsActions
     {
-        void OnUndo(InputAction.CallbackContext context);
-        void OnRedo(InputAction.CallbackContext context);
+        void OnUndoMethod1(InputAction.CallbackContext context);
+        void OnUndoMethod2(InputAction.CallbackContext context);
+        void OnRedoMethod1(InputAction.CallbackContext context);
+        void OnRedoMethod2(InputAction.CallbackContext context);
     }
     public interface IPlacementControllersActions
     {

--- a/Assets/__Scripts/Input/Master.inputactions
+++ b/Assets/__Scripts/Input/Master.inputactions
@@ -436,7 +436,7 @@
             "id": "3e26cae6-c1ff-441d-96fc-9f7505133eed",
             "actions": [
                 {
-                    "name": "Undo",
+                    "name": "Undo (Method 1)",
                     "type": "Button",
                     "id": "fedad900-9c47-459d-bddd-f46d2be3e180",
                     "expectedControlType": "",
@@ -444,10 +444,26 @@
                     "interactions": "Press"
                 },
                 {
-                    "name": "Redo",
+                    "name": "Undo (Method 2)",
+                    "type": "Button",
+                    "id": "c62387e5-adc8-4366-b018-e897233be233",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "Press"
+                },
+                {
+                    "name": "Redo (Method 1)",
                     "type": "Button",
                     "id": "7d4b7471-e9f7-4b02-86f8-93f38fad7792",
                     "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "Press"
+                },
+                {
+                    "name": "Redo (Method 2)",
+                    "type": "Button",
+                    "id": "06f077ed-f9cc-43ae-87f3-7be30bd3ff5b",
+                    "expectedControlType": "Button",
                     "processors": "",
                     "interactions": "Press"
                 }
@@ -460,7 +476,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "Undo",
+                    "action": "Undo (Method 1)",
                     "isComposite": true,
                     "isPartOfComposite": false
                 },
@@ -471,7 +487,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "ChroMapper Default",
-                    "action": "Undo",
+                    "action": "Undo (Method 1)",
                     "isComposite": false,
                     "isPartOfComposite": true
                 },
@@ -482,51 +498,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "ChroMapper Default",
-                    "action": "Undo",
-                    "isComposite": false,
-                    "isPartOfComposite": true
-                },
-                {
-                    "name": "Method 2",
-                    "id": "8d2a0118-7d90-404b-bc4b-7e75c6c16e77",
-                    "path": "ButtonWithTwoModifiers",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "",
-                    "action": "Undo",
-                    "isComposite": true,
-                    "isPartOfComposite": false
-                },
-                {
-                    "name": "modifier1",
-                    "id": "c820fc98-a631-4ba2-8872-cd9483499893",
-                    "path": "<Keyboard>/ctrl",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "ChroMapper Default",
-                    "action": "Undo",
-                    "isComposite": false,
-                    "isPartOfComposite": true
-                },
-                {
-                    "name": "modifier2",
-                    "id": "5a28b45b-80a4-42a5-83e5-ac4f005fa771",
-                    "path": "<Keyboard>/shift",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "ChroMapper Default",
-                    "action": "Undo",
-                    "isComposite": false,
-                    "isPartOfComposite": true
-                },
-                {
-                    "name": "button",
-                    "id": "c1ddbbb8-0a6d-4c3a-8669-a50557a09c5c",
-                    "path": "<Keyboard>/y",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "ChroMapper Default",
-                    "action": "Undo",
+                    "action": "Undo (Method 1)",
                     "isComposite": false,
                     "isPartOfComposite": true
                 },
@@ -537,7 +509,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "Redo",
+                    "action": "Redo (Method 1)",
                     "isComposite": true,
                     "isPartOfComposite": false
                 },
@@ -548,7 +520,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "ChroMapper Default",
-                    "action": "Redo",
+                    "action": "Redo (Method 1)",
                     "isComposite": false,
                     "isPartOfComposite": true
                 },
@@ -559,7 +531,51 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "ChroMapper Default",
-                    "action": "Redo",
+                    "action": "Redo (Method 1)",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "Method 2",
+                    "id": "8d2a0118-7d90-404b-bc4b-7e75c6c16e77",
+                    "path": "ButtonWithTwoModifiers",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Undo (Method 2)",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "modifier1",
+                    "id": "c820fc98-a631-4ba2-8872-cd9483499893",
+                    "path": "<Keyboard>/ctrl",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "ChroMapper Default",
+                    "action": "Undo (Method 2)",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "modifier2",
+                    "id": "5a28b45b-80a4-42a5-83e5-ac4f005fa771",
+                    "path": "<Keyboard>/shift",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "ChroMapper Default",
+                    "action": "Undo (Method 2)",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "button",
+                    "id": "c1ddbbb8-0a6d-4c3a-8669-a50557a09c5c",
+                    "path": "<Keyboard>/y",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "ChroMapper Default",
+                    "action": "Undo (Method 2)",
                     "isComposite": false,
                     "isPartOfComposite": true
                 },
@@ -570,7 +586,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "Redo",
+                    "action": "Redo (Method 2)",
                     "isComposite": true,
                     "isPartOfComposite": false
                 },
@@ -581,7 +597,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "ChroMapper Default",
-                    "action": "Redo",
+                    "action": "Redo (Method 2)",
                     "isComposite": false,
                     "isPartOfComposite": true
                 },
@@ -592,7 +608,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "ChroMapper Default",
-                    "action": "Redo",
+                    "action": "Redo (Method 2)",
                     "isComposite": false,
                     "isPartOfComposite": true
                 },
@@ -603,7 +619,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "ChroMapper Default",
-                    "action": "Redo",
+                    "action": "Redo (Method 2)",
                     "isComposite": false,
                     "isPartOfComposite": true
                 }

--- a/Assets/__Scripts/MapEditor/Mapping/Selection/SelectionController.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/Selection/SelectionController.cs
@@ -351,6 +351,11 @@ public class SelectionController : MonoBehaviour, CMInput.ISelectingActions, CMI
         foreach (BeatmapObjectContainerCollection collection in collections.Values)
         {
             collection.RefreshPool();
+
+            if (collection is BPMChangesContainer con)
+            {
+                con.RefreshGridShaders();
+            }
         }
         if (CopiedObjects.Any(x => (x is MapEvent e) && e.IsRotationEvent))
         {

--- a/Assets/__Scripts/UI/FirstBootMenu.cs
+++ b/Assets/__Scripts/UI/FirstBootMenu.cs
@@ -344,11 +344,15 @@ public class FirstBootMenu : MonoBehaviour {
 
     public void OpenFolderBrowser()
     {
-        var paths = StandaloneFileBrowser.OpenFolderPanel("Installation Directory", "", false);
-        var installation = paths[0];
-        directoryField.text = installation;
-        Settings.Instance.BeatSaberInstallation = Settings.ConvertToDirectory(installation);
-        validation.SetValidationState(true, Settings.ValidateDirectory(ErrorFeedback));
+        StandaloneFileBrowser.OpenFolderPanelAsync("Installation Directory", "", false, paths =>
+        {
+            if (paths.Length <= 0) return;
+            
+            var installation = paths[0];
+            directoryField.text = installation;
+            Settings.Instance.BeatSaberInstallation = Settings.ConvertToDirectory(installation);
+            validation.SetValidationState(true, Settings.ValidateDirectory(ErrorFeedback));
+        });
     }
 
     public void ValidateQuiet()

--- a/Assets/__Scripts/UI/InputBoxFileValidator.cs
+++ b/Assets/__Scripts/UI/InputBoxFileValidator.cs
@@ -21,6 +21,7 @@ public class InputBoxFileValidator : MonoBehaviour
     [SerializeField] private string[] extensions;
 
     [SerializeField] private bool enableValidation = false;
+    [SerializeField] private bool forceStartupValidationAlign = false;
 
     private Vector2 startOffset;
 
@@ -31,7 +32,7 @@ public class InputBoxFileValidator : MonoBehaviour
         // This will get un-done on start, but will stop negative text scroll
         // Shouldn't really be in awake but it needs to run before SongInfoEditUI sets the text value
         var song = BeatSaberSongContainer.Instance?.song;
-        if (enableValidation && song?.directory != null)
+        if (forceStartupValidationAlign || (enableValidation && song?.directory != null))
         {
             transform.offsetMax = new Vector2(startOffset.x - 36, startOffset.y);
         }
@@ -49,7 +50,11 @@ public class InputBoxFileValidator : MonoBehaviour
         string filename = input.text;
         if (!enableValidation || filename.Length == 0 || song?.directory == null)
         {
-            SetValidationState(false);
+            if (!forceStartupValidationAlign)
+            {
+                SetValidationState(false);
+            }
+
             return;
         }
 

--- a/Assets/__Scripts/UI/SongSelectMenu/CreateNewSong.cs
+++ b/Assets/__Scripts/UI/SongSelectMenu/CreateNewSong.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿using System;
+using System.IO;
+using System.Linq;
 using UnityEngine;
 
 public class CreateNewSong : MonoBehaviour {
@@ -14,13 +16,19 @@ public class CreateNewSong : MonoBehaviour {
     private void HandleNewSongName(string res)
     {
         if (res is null) return;
-        if (list.songs.Any(x => x.songName == res))
+
+        var song = new BeatSaberSong(list.WIPLevels, res);
+
+        if (list.songs.Any(x => Path.GetFullPath(x.directory).Equals(
+            Path.GetFullPath(Path.Combine(list.WIPLevels ? Settings.Instance.CustomWIPSongsFolder : Settings.Instance.CustomSongsFolder, song.cleanSongName)),
+            StringComparison.CurrentCultureIgnoreCase
+        )))
         {
             PersistentUI.Instance.ShowInputBox("SongSelectMenu", "newmap.dialog.duplicate", HandleNewSongName, "newmap.dialog.default");
             return;
         }
-        BeatSaberSong song = new BeatSaberSong(list.WIPLevels, res);
-        BeatSaberSong.DifficultyBeatmapSet standardSet = new BeatSaberSong.DifficultyBeatmapSet();
+
+        var standardSet = new BeatSaberSong.DifficultyBeatmapSet();
         song.difficultyBeatmapSets.Add(standardSet);
         BeatSaberSongContainer.Instance.SelectSongForEditing(song);
         PersistentUI.Instance.DisplayMessage("SongSelectMenu", "newmap.message", PersistentUI.DisplayMessageType.BOTTOM);


### PR DESCRIPTION
- CM-61 - Improved the check in the new level dialog and locked the folder name to match so we don't have TOCTOU problems
- Split undo / redo bindings into separate actions as otherwise the InputSystemPatch doesn't work properly (Ctrl + Shift + Z was undoing and then redoing for me while testing bpm changes)
- Fix BPM changes not updating the grid when undoing/redoing/pasting
- Fix an error from the folder browser dialog I got on OSX relating to the playerloop. Internet says the async methods are better 🤷 and fix misalignment of the text on the first boot screen (I really hate this unity bug)