### PR TITLE
Various improvements

### DIFF
--- a/Assets/__Scenes/03_Mapper.unity
+++ b/Assets/__Scenes/03_Mapper.unity
@@ -33335,6 +33335,83 @@ Transform:
   m_Father: {fileID: 120631927}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
+--- !u!21 &1107494154
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Inherited From Round Corners
+  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _AlphaClip: 0
+    - _Blend: 0
+    - _BumpScale: 1
+    - _ColorMask: 15
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _ReceiveShadows: 1
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _Surface: 0
+    - _UseUIAlphaClip: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+    - _WidthHeightRadius: {r: 43, g: 13.514961, b: 2, a: 0}
+    - _halfSize: {r: 29, g: 10, b: 0, a: 0}
+    - _r: {r: 3, g: 3, b: 3, a: 3}
+    - _rect2props: {r: 0.0000019073486, g: -0.0000038146973, b: 25.455845, a: 25.455845}
 --- !u!1 &1115569245
 GameObject:
   m_ObjectHideFlags: 0
@@ -48882,83 +48959,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1346036653}
   m_CullTransparentMesh: 0
---- !u!21 &1348972123
-Material:
-  serializedVersion: 6
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: Inherited From Round Corners
-  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
-  m_ShaderKeywords: 
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _BumpMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _EmissionMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _MetallicGlossMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _OcclusionMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _SpecGlossMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Floats:
-    - _AlphaClip: 0
-    - _Blend: 0
-    - _BumpScale: 1
-    - _ColorMask: 15
-    - _Cull: 2
-    - _Cutoff: 0.5
-    - _DstBlend: 0
-    - _GlossMapScale: 1
-    - _Glossiness: 0.5
-    - _GlossyReflections: 1
-    - _Metallic: 0
-    - _OcclusionStrength: 1
-    - _ReceiveShadows: 1
-    - _SmoothnessTextureChannel: 0
-    - _SpecularHighlights: 1
-    - _SrcBlend: 1
-    - _Stencil: 0
-    - _StencilComp: 8
-    - _StencilOp: 0
-    - _StencilReadMask: 255
-    - _StencilWriteMask: 255
-    - _Surface: 0
-    - _UseUIAlphaClip: 0
-    - _WorkflowMode: 1
-    - _ZWrite: 1
-    m_Colors:
-    - _Color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
-    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
-    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
-    - _WidthHeightRadius: {r: 46.281853, g: 16.4, b: 4, a: 0}
-    - _halfSize: {r: 29, g: 10, b: 0, a: 0}
-    - _r: {r: 3, g: 3, b: 3, a: 3}
-    - _rect2props: {r: 0.0000019073486, g: -0.0000038146973, b: 25.455845, a: 25.455845}
 --- !u!1 &1353637506
 GameObject:
   m_ObjectHideFlags: 0
@@ -56707,6 +56707,83 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1604884699}
   m_CullTransparentMesh: 0
+--- !u!21 &1609233709
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Inherited From Round Corners
+  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _AlphaClip: 0
+    - _Blend: 0
+    - _BumpScale: 1
+    - _ColorMask: 15
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _ReceiveShadows: 1
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _Surface: 0
+    - _UseUIAlphaClip: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+    - _WidthHeightRadius: {r: 46.281853, g: 16.4, b: 4, a: 0}
+    - _halfSize: {r: 29, g: 10, b: 0, a: 0}
+    - _r: {r: 3, g: 3, b: 3, a: 3}
+    - _rect2props: {r: 0.0000019073486, g: -0.0000038146973, b: 25.455845, a: 25.455845}
 --- !u!1 &1613983677
 GameObject:
   m_ObjectHideFlags: 0
@@ -60045,83 +60122,6 @@ Material:
     - _halfSize: {r: 29, g: 10, b: 0, a: 0}
     - _r: {r: 3, g: 3, b: 3, a: 3}
     - _rect2props: {r: 0.0000019073486, g: -0.0000038146973, b: 25.455845, a: 25.455845}
---- !u!21 &1717141593
-Material:
-  serializedVersion: 6
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: Inherited From Round Corners
-  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
-  m_ShaderKeywords: 
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _BumpMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _EmissionMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _MetallicGlossMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _OcclusionMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _SpecGlossMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Floats:
-    - _AlphaClip: 0
-    - _Blend: 0
-    - _BumpScale: 1
-    - _ColorMask: 15
-    - _Cull: 2
-    - _Cutoff: 0.5
-    - _DstBlend: 0
-    - _GlossMapScale: 1
-    - _Glossiness: 0.5
-    - _GlossyReflections: 1
-    - _Metallic: 0
-    - _OcclusionStrength: 1
-    - _ReceiveShadows: 1
-    - _SmoothnessTextureChannel: 0
-    - _SpecularHighlights: 1
-    - _SrcBlend: 1
-    - _Stencil: 0
-    - _StencilComp: 8
-    - _StencilOp: 0
-    - _StencilReadMask: 255
-    - _StencilWriteMask: 255
-    - _Surface: 0
-    - _UseUIAlphaClip: 0
-    - _WorkflowMode: 1
-    - _ZWrite: 1
-    m_Colors:
-    - _Color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
-    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
-    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
-    - _WidthHeightRadius: {r: 43, g: 13.514961, b: 2, a: 0}
-    - _halfSize: {r: 29, g: 10, b: 0, a: 0}
-    - _r: {r: 3, g: 3, b: 3, a: 3}
-    - _rect2props: {r: 0.0000019073486, g: -0.0000038146973, b: 25.455845, a: 25.455845}
 --- !u!1 &1717377308
 GameObject:
   m_ObjectHideFlags: 0
@@ -61312,8 +61312,9 @@ MonoBehaviour:
   - {fileID: 236088294}
   - {fileID: 2070574234}
   - {fileID: 2140046693}
-  - {fileID: 1277691434}
+  - {fileID: 120631926}
   - {fileID: 322207089}
+  - {fileID: 458724369}
   thingsThatRequireAMoveForPreview:
   - {fileID: 617466177}
   - {fileID: 1125491375}

--- a/Assets/__Scripts/Map/BeatmapObject.cs
+++ b/Assets/__Scripts/Map/BeatmapObject.cs
@@ -107,4 +107,12 @@ public abstract class BeatmapObject {
         _time = originalData._time;
         _customData = originalData._customData?.Clone();
     }
+
+    public JSONNode GetOrCreateCustomData()
+    {
+        if (_customData == null)
+            _customData = new JSONObject();
+
+        return _customData;
+    }
 }

--- a/Assets/__Scripts/Map/Events/MapEvent.cs
+++ b/Assets/__Scripts/Map/Events/MapEvent.cs
@@ -108,7 +108,7 @@ public class MapEvent : BeatmapObject {
             var x = mode == EventsContainer.PropMode.Prop ? PropId : -1;
 
             if (x < 0)
-                x = labels.LightIDToEditor(_type, LightId[0]);
+                x = LightId.Length > 0 ? labels.LightIDToEditor(_type, LightId[0]) : -1;
 
             return new Vector2(
                 x + 1.5f,

--- a/Assets/__Scripts/MapEditor/Audio/AudioManager.cs
+++ b/Assets/__Scripts/MapEditor/Audio/AudioManager.cs
@@ -275,6 +275,8 @@ public class AudioManager : MonoBehaviour
                             data[index++] = bandColors[x][y];
                         }
                     }
+                } catch (NullReferenceException) {
+                    // Cancelled some other way
                 } catch (InvalidOperationException) {
                     // NativeArray has been deallocated :(
                 }

--- a/Assets/__Scripts/MapEditor/Audio/SpectrogramChunk.cs
+++ b/Assets/__Scripts/MapEditor/Audio/SpectrogramChunk.cs
@@ -177,8 +177,8 @@ public class SpectrogramChunk : MonoBehaviour
             {
                 Vector3 it = verts[i];
                 uv[i] = new Vector2(
-                    Mathf.Clamp(it.z, 0.01f, 0.99f),
-                    Mathf.Clamp(it.x, 0.01f, 0.99f)
+                    Mathf.Clamp(it.z, 0.001f, 0.999f),
+                    Mathf.Clamp(it.x, 0.001f, 0.999f)
                 );
             }
             mesh.uv = uv;

--- a/Assets/__Scripts/MapEditor/Grid/Collections/CustomEventsContainer.cs
+++ b/Assets/__Scripts/MapEditor/Grid/Collections/CustomEventsContainer.cs
@@ -141,8 +141,7 @@ public class CustomEventsContainer : BeatmapObjectContainerCollection, CMInput.I
         }
         foreach (BeatmapObject obj in SelectionController.SelectedObjects)
         {
-            if (obj._customData == null) obj._customData = new SimpleJSON.JSONObject();
-            obj._customData["_track"] = res;
+            obj.GetOrCreateCustomData()["_track"] = res;
         }
     }
 

--- a/Assets/__Scripts/MapEditor/Input/BeatmapEventInputController.cs
+++ b/Assets/__Scripts/MapEditor/Input/BeatmapEventInputController.cs
@@ -10,9 +10,9 @@ public class BeatmapEventInputController : BeatmapInputController<BeatmapEventCo
 
     public void OnInvertEventValue(InputAction.CallbackContext context)
     {
-        if (customStandaloneInputModule.IsPointerOverGameObject<GraphicRaycaster>(-1, true)) return;
+        if (customStandaloneInputModule.IsPointerOverGameObject<GraphicRaycaster>(-1, true) || !KeybindsController.IsMouseInWindow || !context.performed) return;
         RaycastFirstObject(out BeatmapEventContainer e);
-        if (e != null && context.performed)
+        if (e != null)
         {
             InvertEvent(e);
         }

--- a/Assets/__Scripts/MapEditor/Input/BeatmapNoteInputController.cs
+++ b/Assets/__Scripts/MapEditor/Input/BeatmapNoteInputController.cs
@@ -38,8 +38,7 @@ public class BeatmapNoteInputController : BeatmapInputController<BeatmapNoteCont
     //Do some shit later lmao
     public void OnInvertNoteColors(InputAction.CallbackContext context)
     {
-        if (customStandaloneInputModule.IsPointerOverGameObject<GraphicRaycaster>(-1, true)) return;
-        if (!context.performed) return;
+        if (customStandaloneInputModule.IsPointerOverGameObject<GraphicRaycaster>(-1, true) || !KeybindsController.IsMouseInWindow || !context.performed) return;
 
         RaycastFirstObject(out BeatmapNoteContainer note);
         if (note != null)

--- a/Assets/__Scripts/MapEditor/Mapping/KeybindsController.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/KeybindsController.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using UnityEditor;
+﻿using UnityEditor;
 using UnityEngine;
 using UnityEngine.InputSystem;
 
@@ -56,20 +52,6 @@ public class KeybindsController : MonoBehaviour, CMInput.IUtilsActions
     public void OnMouseMovement(InputAction.CallbackContext context)
     {
         mousePos = context.ReadValue<Vector2>();
-        bool mouseInWindow = IsMouseInBounds();
-        //Disable/reenable input if the mouse is outside or inside the screen.
-        if (mouseInWindow != IsMouseInWindow)
-        {
-            IEnumerable<Type> cmtypes = typeof(CMInput).GetNestedTypes().Where(x => x.IsInterface && x != typeof(CMInput.IUtilsActions));
-            if (mouseInWindow)
-            {
-                CMInputCallbackInstaller.ClearDisabledActionMaps(typeof(KeybindsController), cmtypes);
-            }
-            else
-            {
-                CMInputCallbackInstaller.DisableActionMaps(typeof(KeybindsController), cmtypes);
-            }
-            IsMouseInWindow = mouseInWindow;
-        }
+        IsMouseInWindow = IsMouseInBounds();
     }
 }

--- a/Assets/__Scripts/MapEditor/Mapping/LegacyNotesConverter.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/LegacyNotesConverter.cs
@@ -42,8 +42,7 @@ public class LegacyNotesConverter : MonoBehaviour {
                 }
                 if (chroma != null && e._value != MapEvent.LIGHT_VALUE_OFF)
                 {
-                    if (e._customData == null) e._customData = new JSONObject();
-                    e._customData["_color"] = chroma;
+                    e.GetOrCreateCustomData()["_color"] = chroma;
                 }
             }
             else

--- a/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/BombPlacement.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/BombPlacement.cs
@@ -45,8 +45,7 @@ public class BombPlacement : PlacementController<BeatmapNote, BeatmapNoteContain
         if (CanPlaceChromaObjects && dropdown.Visible)
         {
             // Doing the same a Chroma 2.0 events but with notes insted
-            if (queuedData._customData == null) queuedData._customData = new JSONObject();
-            queuedData._customData["_color"] = colorPicker.CurrentColor;
+            queuedData.GetOrCreateCustomData()["_color"] = colorPicker.CurrentColor;
         }
         else
         {

--- a/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/EventPlacement.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/EventPlacement.cs
@@ -75,25 +75,19 @@ public class EventPlacement : PlacementController<MapEvent, BeatmapEventContaine
             var propID = Mathf.FloorToInt(instantiatedContainer.transform.localPosition.x - 1);
             queuedData._type = objectContainerCollection.EventTypeToPropagate;
 
-            if (queuedData._customData == null || queuedData._customData?.Children.Count() == 0)
-            {
-                queuedData._customData = new JSONObject();
-            }
-
             if (propID >= 0)
             {
                 var lightIdToApply = objectContainerCollection.PropagationEditing == EventsContainer.PropMode.Prop ?
                     labels.PropIdToLightIdsJ(objectContainerCollection.EventTypeToPropagate, propID) :
                     (JSONNode) labels.EditorToLightID(objectContainerCollection.EventTypeToPropagate, propID);
-                queuedData._customData?.Add("_lightID", lightIdToApply);
+                queuedData.GetOrCreateCustomData().Add("_lightID", lightIdToApply);
             }
-            else queuedData._customData?.Remove("_lightID");
+            else queuedData.GetOrCreateCustomData().Remove("_lightID");
         }
 
         if (CanPlaceChromaEvents && !queuedData.IsUtilityEvent && queuedData._value != MapEvent.LIGHT_VALUE_OFF)
         {
-            if (queuedData._customData == null) queuedData._customData = new JSONObject();
-            queuedData._customData["_color"] = colorPicker.CurrentColor;
+            queuedData.GetOrCreateCustomData()["_color"] = colorPicker.CurrentColor;
         }
         else
         {

--- a/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/NotePlacement.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/NotePlacement.cs
@@ -95,9 +95,7 @@ public class NotePlacement : PlacementController<BeatmapNote, BeatmapNoteContain
         if (CanPlaceChromaObjects && dropdown.Visible)
         {
             // Doing the same a Chroma 2.0 events but with notes insted
-            JSONArray color = new JSONArray();
-            if (queuedData._customData == null) queuedData._customData = new JSONObject();
-            queuedData._customData["_color"] = colorPicker.CurrentColor;
+            queuedData.GetOrCreateCustomData()["_color"] = colorPicker.CurrentColor;
         }
         else
         {
@@ -119,12 +117,10 @@ public class NotePlacement : PlacementController<BeatmapNote, BeatmapNoteContain
 
             instantiatedContainer.transform.localPosition = roundedHit;
 
-            if (queuedData._customData == null) queuedData._customData = new JSONObject();
-
             JSONArray position = new JSONArray(); //We do some manual array stuff to get rounding decimals to work.
             position[0] = Math.Round(roundedHit.x - 0.5f, 3);
             position[1] = Math.Round(roundedHit.y - 0.5f, 3);
-            queuedData._customData["_position"] = position;
+            queuedData.GetOrCreateCustomData()["_position"] = position;
 
             precisionPlacement.TogglePrecisionPlacement(true);
             precisionPlacement.UpdateMousePosition(hit.point);

--- a/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/ObstaclePlacement.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/ObstaclePlacement.cs
@@ -72,9 +72,7 @@ public class ObstaclePlacement : PlacementController<BeatmapObstacle, BeatmapObs
         if (CanPlaceChromaObjects && dropdown.Visible)
         {
             // Doing the same a Chroma 2.0 events but with notes insted
-            JSONArray color = new JSONArray();
-            if (queuedData._customData == null) queuedData._customData = new JSONObject();
-            queuedData._customData["_color"] = colorPicker.CurrentColor;
+            queuedData.GetOrCreateCustomData()["_color"] = colorPicker.CurrentColor;
         }
         else
         {

--- a/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/PlacementController.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/PlacementController.cs
@@ -177,7 +177,7 @@ public abstract class PlacementController<BO, BOC, BOCC> : MonoBehaviour, CMInpu
 
     public void OnPlaceObject(InputAction.CallbackContext context)
     {
-        if (customStandaloneInputModule.IsPointerOverGameObject<GraphicRaycaster>(-1, true) || !context.performed) return;
+        if (customStandaloneInputModule.IsPointerOverGameObject<GraphicRaycaster>(-1, true) || !KeybindsController.IsMouseInWindow || !context.performed) return;
         if (!isDraggingObject && !isDraggingObjectAtTime && isOnPlacement && instantiatedContainer != null && IsValid
             && !PersistentUI.Instance.DialogBox_IsEnabled &&
             queuedData?._time >= 0 && !applicationFocusChanged) ApplyToMap();
@@ -333,8 +333,7 @@ public abstract class PlacementController<BO, BOC, BOCC> : MonoBehaviour, CMInpu
             if (customStandaloneInputModule.IsPointerOverGameObject<GraphicRaycaster>(-1, true)) return;
             if (BeatmapObjectContainerCollection.TrackFilterID != null && !objectContainerCollection.IgnoreTrackFilter)
             {
-                if (queuedData._customData == null) queuedData._customData = new SimpleJSON.JSONObject();
-                queuedData._customData["track"] = BeatmapObjectContainerCollection.TrackFilterID;
+                queuedData.GetOrCreateCustomData()["track"] = BeatmapObjectContainerCollection.TrackFilterID;
             }
             else queuedData?._customData?.Remove("track");
             CalculateTimes(hit, out Vector3 roundedHit, out float roundedTime);

--- a/Assets/__Scripts/MapEditor/Mapping/Selection/SelectionController.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/Selection/SelectionController.cs
@@ -479,7 +479,7 @@ public class SelectionController : MonoBehaviour, CMInput.ISelectingActions, CMI
                 }
                 else if (eventPlacement.objectContainerCollection.PropagationEditing == EventsContainer.PropMode.Prop)
                 {
-                    var oldId = labels.LightIdsToPropId(events.EventTypeToPropagate, e.LightId) ?? -1;
+                    var oldId = (e.IsLightIdEvent ? labels.LightIdsToPropId(events.EventTypeToPropagate, e.LightId) : null) ?? -1;
                     var max = events.platformDescriptor.LightingManagers[events.EventTypeToPropagate].LightsGroupedByZ.Length;
                     var newId = Math.Min(oldId + leftRight, max - 1);
 
@@ -489,7 +489,7 @@ public class SelectionController : MonoBehaviour, CMInput.ISelectingActions, CMI
                     }
                     else
                     {
-                        data._customData["_lightID"] = labels.PropIdToLightIdsJ(events.EventTypeToPropagate, newId);
+                        data.GetOrCreateCustomData()["_lightID"] = labels.PropIdToLightIdsJ(events.EventTypeToPropagate, newId);
                     }
                 }
                 else

--- a/Assets/__Scripts/MapEditor/UI/Chroma/PaintSelectedObjects.cs
+++ b/Assets/__Scripts/MapEditor/UI/Chroma/PaintSelectedObjects.cs
@@ -42,18 +42,14 @@ public class PaintSelectedObjects : MonoBehaviour
                 return true;
             }
         }
-        if (obj._customData == null || obj._customData.Count == 0 || obj._customData.Children.Count() == 0) //TODO: Look into making BeatmapObject._customData nullable
-        {
-            obj._customData = new JSONObject();
-        }
 
         if (!obj._customData.HasKey("_color"))
         {
-            obj._customData.Add("_color", picker.CurrentColor);
+            obj.GetOrCreateCustomData().Add("_color", picker.CurrentColor);
         }
         else
         {
-            obj._customData["_color"] = picker.CurrentColor;
+            obj.GetOrCreateCustomData()["_color"] = picker.CurrentColor;
         }
 
         return true;


### PR DESCRIPTION
Fix inconsistent grid visibility in hide grid mode
![image](https://user-images.githubusercontent.com/534069/113438258-205f3580-93e0-11eb-84c0-d0442033c94b.png)

Add another digit to stop stretching between spectro chunks
Allow most inputs when mouse is outside window (placement is blacklisted as I assume that's why it was originally disabled?)
Add helper for safely accessing object customdata
Add more defensive coding around lightid editing

Try and fix errors from spectro generation again