### PR TITLE
Add lower bound to resync trigger to prevent lots of syncs happening at high framerates

### DIFF
--- a/Assets/__Scripts/MapEditor/AudioTimeSyncController.cs
+++ b/Assets/__Scripts/MapEditor/AudioTimeSyncController.cs
@@ -139,7 +139,8 @@ public class AudioTimeSyncController : MonoBehaviour, CMInput.IPlaybackActions, 
                 var correction = CurrentSeconds > 1 ? trackTime / CurrentSeconds : 1f;
 
                 // Snap forward if we are more than a 2 frames out of sync as we're trying to make it one frame out?
-                if (Mathf.Abs(trackTime - CurrentSeconds) >= 2 * Time.smoothDeltaTime * (songSpeed / 10f))
+                float frameTime = Mathf.Max(0.04f, Time.smoothDeltaTime * 2);
+                if (Mathf.Abs(trackTime - CurrentSeconds) >= frameTime * (songSpeed / 10f))
                 {
                     time = trackTime;
                     correction = 1;


### PR DESCRIPTION
Using smoothDeltaTime I think? that at higher framerates the sync threshold gets smaller.
This just adds a lower bound of 0.04s so that any sync better than that won't trigger a resync even if that means more total frames are wrong.