### PR TITLE
More accurate audio preview

### DIFF
--- a/Assets/__Scripts/UI/PreviewSong.cs
+++ b/Assets/__Scripts/UI/PreviewSong.cs
@@ -15,6 +15,7 @@ public class PreviewSong : MonoBehaviour
     [SerializeField] private Sprite stopSprite;
 
     float length = 10f;
+    float lengthOffset = 1.4f;
     double startTime = 0;
     bool playing = true;
 
@@ -37,6 +38,9 @@ public class PreviewSong : MonoBehaviour
 
         if (float.TryParse(previewDuration.text, out length))
         {
+            // Beat Saber seems to run the audio shorter than specified preview length
+            length -= lengthOffset; 
+
             if (float.TryParse(previewStartTime.text, out float start))
             {
                 if (audioSource.clip == null)
@@ -69,13 +73,10 @@ public class PreviewSong : MonoBehaviour
         {
             PlayClip();
         }
-        else if (timeRemaining < 1)
+        else if (timeRemaining < 1.25)
         {
-            audioSource.volume = timeRemaining;
-        }
-        else if (time < 0.25)
-        {
-            audioSource.volume = time * 4;
+            // Quadratic ease
+            audioSource.volume = 0.64f * timeRemaining * timeRemaining;
         }
         else
         {

--- a/Assets/__Scripts/UI/PreviewSong.cs
+++ b/Assets/__Scripts/UI/PreviewSong.cs
@@ -78,6 +78,10 @@ public class PreviewSong : MonoBehaviour
             // Quadratic ease
             audioSource.volume = 0.64f * timeRemaining * timeRemaining;
         }
+        else if (time < 0.2)
+        {
+            audioSource.volume = 5f * time;
+        }
         else
         {
             audioSource.volume = 1;


### PR DESCRIPTION
Currently, this is how the preview sounds like:
![image](https://user-images.githubusercontent.com/68104413/114524036-372b4500-9c88-11eb-8c40-7ff4bccb35bb.png)

Now, it looks like this:
![image](https://user-images.githubusercontent.com/68104413/114524891-f54ece80-9c88-11eb-9df5-0fca5c998e42.png)