### PR TITLE
Fix plugin loading with unicode paths

### DIFF
--- a/Assets/__Scripts/PluginLoader/PluginLoader.cs
+++ b/Assets/__Scripts/PluginLoader/PluginLoader.cs
@@ -36,7 +36,7 @@ internal class PluginLoader : MonoBehaviour
             Directory.CreateDirectory(PLUGIN_DIR);
         foreach(string file in Directory.GetFiles(PLUGIN_DIR, "*.dll", SearchOption.AllDirectories))
         {
-            Assembly assembly = Assembly.LoadFile(file);
+            Assembly assembly = Assembly.LoadFile(Path.GetFullPath(file));
             foreach (Type type in assembly.GetExportedTypes())
             {
                 PluginAttribute pluginAttribute = null;


### PR DESCRIPTION
Fix plugin loading when paths contain unicode characters

Test code from a plugin:
```
Debug.Log(Assembly.GetCallingAssembly().Location);
Debug.Log(Assembly.GetExecutingAssembly().Location);
```
Old behaviour
```
C:\Users\micro\Downloads\姚明\chromapper\ChroMapper_Data\Managed\Main.dll
C:\Users\micro\Downloads\??\chromapper\Plugins\ErrorChecker\ErrorChecker.dll
```
New behaviour
```
C:\Users\micro\Downloads\姚明\chromapper\ChroMapper_Data\Managed\Main.dll
C:\Users\micro\Downloads\姚明\chromapper\Plugins\ErrorChecker\ErrorChecker.dll
```