### PR TITLE
Make aalto happy

### DIFF
--- a/Assets/__Scripts/MapEditor/CameraController.cs
+++ b/Assets/__Scripts/MapEditor/CameraController.cs
@@ -39,7 +39,9 @@ public class CameraController : MonoBehaviour, CMInput.ICameraActions {
         get => lockOntoNoteGrid;
         set
         {
-            transform.SetParent(!value ? null : noteGridTransform);
+            var camTransform = transform;
+            camTransform.SetParent(!value ? null : noteGridTransform);
+            camTransform.localScale = Vector3.one;
             lockOntoNoteGrid = value;
         }
     }
@@ -175,7 +177,6 @@ public class CameraController : MonoBehaviour, CMInput.ICameraActions {
         if (_rotationCallbackController.IsActive && context.performed && noteGridTransform.gameObject.activeInHierarchy)
         {
             LockedOntoNoteGrid = !LockedOntoNoteGrid;
-            transform.localScale = Vector3.one;
         }
     }
 

--- a/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/EventPlacement.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/EventPlacement.cs
@@ -101,7 +101,8 @@ public class EventPlacement : PlacementController<MapEvent, BeatmapEventContaine
 
     public void UpdateQueuedValue(int value)
     {
-        if (objectContainerCollection.PropagationEditing != EventsContainer.PropMode.Off && !queuedData.IsUtilityEvent)
+        var propID = Mathf.FloorToInt(instantiatedContainer.transform.localPosition.x - 1);
+        if (objectContainerCollection.PropagationEditing != EventsContainer.PropMode.Off && propID >= 0 && !queuedData.IsUtilityEvent)
         {
             if (value != MapEvent.LIGHT_VALUE_BLUE_ON && value != MapEvent.LIGHT_VALUE_RED_ON && value != MapEvent.LIGHT_VALUE_OFF)
             {

--- a/Assets/__Scripts/UI/LightshowController.cs
+++ b/Assets/__Scripts/UI/LightshowController.cs
@@ -7,19 +7,31 @@ public class LightshowController : MonoBehaviour, CMInput.ILightshowActions
     [SerializeField] private CameraController cameraController;
 
     private bool showObjects = true;
+    private bool previouslyLocked;
 
-    public void UpdateLightshow(bool enabled)
+    public void UpdateLightshow(bool enable)
     {
-        showObjects = enabled;
-        foreach (GameObject obj in ThingsToToggle) obj.SetActive(enabled);
+        showObjects = enable;
+        foreach (GameObject obj in ThingsToToggle) obj.SetActive(enable);
     }
 
     public void OnToggleLightshowMode(InputAction.CallbackContext context)
     {
-        if (context.performed)
+        if (!context.performed) return;
+
+        // Order matters here so that we don't briefly disable the camera
+        // It has to be removed from the objects before they're disabled and added back after they're enabled again
+        if (showObjects)
         {
+            previouslyLocked = cameraController.LockedOntoNoteGrid;
             cameraController.LockedOntoNoteGrid = false;
-            UpdateLightshow(!showObjects);
+            UpdateLightshow(false);
         }
+        else
+        {
+            UpdateLightshow(true);
+            cameraController.LockedOntoNoteGrid = previouslyLocked;
+        }
+
     }
 }

--- a/Assets/__Scripts/UI/LightshowController.cs
+++ b/Assets/__Scripts/UI/LightshowController.cs
@@ -18,10 +18,7 @@ public class LightshowController : MonoBehaviour, CMInput.ILightshowActions
     {
         if (context.performed)
         {
-            if (cameraController.transform.parent != null)
-            {
-                cameraController.OnAttachtoNoteGrid(context);
-            }
+            cameraController.LockedOntoNoteGrid = false;
             UpdateLightshow(!showObjects);
         }
     }


### PR DESCRIPTION
Maybe LockedOntoNoteGrid should be re-enabled when exiting lightshow mode. But this restores the behaviour before it was broken by changing the default value.

Also allowed fade/flash to be placed in all lights lane while in prop mode