### PR TITLE
Allow audio clip to be released when ATSC is destroyed

### DIFF
--- a/Assets/__Scripts/MapEditor/AudioTimeSyncController.cs
+++ b/Assets/__Scripts/MapEditor/AudioTimeSyncController.cs
@@ -121,6 +121,7 @@ public class AudioTimeSyncController : MonoBehaviour, CMInput.IPlaybackActions, 
 
     private void OnDestroy()
     {
+        clip = null;
         LoadInitialMap.LevelLoadedEvent -= OnLevelLoaded;
         Settings.ClearSettingNotifications("SongSpeed");
         Settings.ClearSettingNotifications("SongVolume");


### PR DESCRIPTION
Wouldn't have thought this would do much but some dependency chain here meant that AudioClips were kept in memory.
Should reduce memory buildup if you load multiple maps in CM