### PR TITLE
Bug fix

### DIFF
--- a/Assets/__Scripts/MapEditor/Mapping/Selection/BoxSelectionPlacementController.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/Selection/BoxSelectionPlacementController.cs
@@ -152,11 +152,7 @@ public class BoxSelectionPlacementController : PlacementController<MapEvent, Bea
             {
                 if (!selected.Contains(combinedObj) && !alreadySelected.Contains(combinedObj))
                 {
-                    //Id imagine if you select an object, and that object is unloaded, then it should stay selected...?
-                    if (BeatmapObjectContainerCollection.GetCollectionForType(combinedObj.beatmapType).LoadedContainers.ContainsKey(combinedObj))
-                    {
-                        SelectionController.Deselect(combinedObj, false);
-                    }
+                    SelectionController.Deselect(combinedObj, false);
                 }
             }
             selected.Clear();

--- a/Assets/__Scripts/UI/SongSelectMenu/SongList.cs
+++ b/Assets/__Scripts/UI/SongSelectMenu/SongList.cs
@@ -203,7 +203,11 @@ public class SongList : MonoBehaviour {
             this._comparison = comparison;
         }
 
-        public virtual int Compare(T x, T y) => _comparison(x, y);
+        public virtual int Compare(T x, T y)
+        {
+            var result = _comparison(x, y);
+            return result == 0 && x != null ? x.GetHashCode().CompareTo(y?.GetHashCode()) : result;
+        }
     }
 
     private class WithFavouriteComparer : FuncComparer<BeatSaberSong>


### PR DESCRIPTION
- Rewrite conflict check to handle stacked objects better
I don't know if this is how people have been triggering ghost notes, seems pretty hard to do by accident but this should plug the gap.
See https://discord.com/channels/702230714585710602/702232127755780197/8464757028446536391
- Allow box selection to deselect unloaded objects
Seems to have been intentional at some point, probably back when it was collider based as it would have deselected stuff within the boundary. However this no longer happens as we use a different method to find selected objects.
See: https://discord.com/channels/702230714585710602/702232127755780197/845784766246158356
- Prevent song list items being merged if they share the sorted attribute
See: https://discord.com/channels/702230714585710602/702232127755780197/848140571112505384