### PR TITLE
More tweeks

### DIFF
--- a/Assets/__Scripts/MapEditor/Input/BeatmapEventInputController.cs
+++ b/Assets/__Scripts/MapEditor/Input/BeatmapEventInputController.cs
@@ -34,6 +34,10 @@ public class BeatmapEventInputController : BeatmapInputController<BeatmapEventCo
                 tracksManager?.RefreshTracks();
             }
         }
+        else if (e.eventData._type == MapEvent.EVENT_TYPE_BOOST_LIGHTS)
+        {
+            e.eventData._value = e.eventData._value > 0 ? 0 : 1;
+        }
         else if (e.eventData.IsUtilityEvent)
         {
             return;

--- a/Assets/__Scripts/Platforms/PlatformDescriptor.cs
+++ b/Assets/__Scripts/Platforms/PlatformDescriptor.cs
@@ -170,13 +170,13 @@ public class PlatformDescriptor : MonoBehaviour {
             case 12:
                 foreach (RotatingLightsBase l in LightingManagers[MapEvent.EVENT_TYPE_LEFT_LASERS].RotatingLights)
                 {
-                    l.UpdateOffset(e._value, UnityEngine.Random.Range(0, 180), UnityEngine.Random.Range(0, 1) == 1, obj._customData);
+                    l.UpdateOffset(true, e._value, UnityEngine.Random.Range(0, 180), UnityEngine.Random.Range(0, 1) == 1, obj._customData);
                 }
                 break;
             case 13:
                 foreach (RotatingLightsBase r in LightingManagers[MapEvent.EVENT_TYPE_RIGHT_LASERS].RotatingLights)
                 {
-                    r.UpdateOffset(e._value, UnityEngine.Random.Range(0, 180), UnityEngine.Random.Range(0, 1) == 1, obj._customData);
+                    r.UpdateOffset(false, e._value, UnityEngine.Random.Range(0, 180), UnityEngine.Random.Range(0, 1) == 1, obj._customData);
                 }
                 break;
             case 5:

--- a/Assets/__Scripts/Platforms/RotatingLights.cs
+++ b/Assets/__Scripts/Platforms/RotatingLights.cs
@@ -48,7 +48,7 @@ public class RotatingLights : RotatingLightsBase
     }
 
     // If you have any complaints about CM's inaccurate lasers, please look through this and tell me what the hell is wrong.
-    public override void UpdateOffset(int Speed, float Rotation, bool RotateForwards, JSONNode customData = null)
+    public override void UpdateOffset(bool isLeftEvent, int Speed, float Rotation, bool RotateForwards, JSONNode customData = null)
     {
         speed = Speed;
         bool lockRotation = false;
@@ -73,7 +73,7 @@ public class RotatingLights : RotatingLightsBase
         {
             transform.Rotate(rotationVector, Rotation, Space.Self);
         }
-        rotationSpeed = speed * multiplier * (RotateForwards ? 1 : -1); //Set rotation speed
+        rotationSpeed = speed * multiplier * ((RotateForwards ^ isLeftEvent) ? -1 : 1); //Set rotation speed
     }
 
     public override bool IsOverrideLightGroup()

--- a/Assets/__Scripts/Platforms/RotatingLightsBase.cs
+++ b/Assets/__Scripts/Platforms/RotatingLightsBase.cs
@@ -2,7 +2,7 @@
 using SimpleJSON;
 
 public abstract class RotatingLightsBase : MonoBehaviour {
-    public abstract void UpdateOffset(int Speed, float Rotation, bool RotateForwards, JSONNode customData = null);
+    public abstract void UpdateOffset(bool isLeftEvent, int Speed, float Rotation, bool RotateForwards, JSONNode customData = null);
 
     public abstract bool IsOverrideLightGroup();
 }

--- a/Assets/__Scripts/Platforms/RotatingLightsLP.cs
+++ b/Assets/__Scripts/Platforms/RotatingLightsLP.cs
@@ -10,7 +10,7 @@ public class RotatingLightsLP : RotatingLightsBase
 
     [SerializeField] public float multiplier = 20;
     private float startRotationAngle = 0f;
-    [SerializeField] public bool left = false;
+    [SerializeField] public bool Left = false;
     [SerializeField] protected RotatingLightsRandom rotatingLightsRandom;
 
     private float songSpeed = 1;
@@ -26,7 +26,7 @@ public class RotatingLightsLP : RotatingLightsBase
     private void Start()
     {
         startRotation = gameObject.transform.localRotation;
-        startRotationAngle = left ? -rotatingLightsRandom.startRotationAngle : rotatingLightsRandom.startRotationAngle;
+        startRotationAngle = Left ? -rotatingLightsRandom.startRotationAngle : rotatingLightsRandom.startRotationAngle;
         startRotationAngle *= 4;
 
         // TODO: Remove
@@ -62,7 +62,7 @@ public class RotatingLightsLP : RotatingLightsBase
         rotationAngle = rotatingLightsRandom._randomStartRotation;
         rotationSpeed = Mathf.Abs(rotatingLightsRandom._rotationSpeed);
 
-        if (!left)
+        if (!Left)
         {
             rotationAngle = 0f - rotationAngle;
             rotationSpeed = 0f - rotationSpeed;
@@ -71,10 +71,10 @@ public class RotatingLightsLP : RotatingLightsBase
         rotationAngle += startRotationAngle;
     }
 
-    public override void UpdateOffset(int Speed, float Rotation, bool RotateForwards, JSONNode customData = null)
+    public override void UpdateOffset(bool isLeftEvent, int Speed, float Rotation, bool RotateForwards, JSONNode customData = null)
     {
-        rotatingLightsRandom.RandomUpdate(left);
-        if (left)
+        rotatingLightsRandom.RandomUpdate(Left);
+        if (Left)
         {
             UpdateRotationData(Speed, rotatingLightsRandom._randomStartRotation, rotatingLightsRandom._randomDirection);
         }
@@ -97,7 +97,7 @@ public class RotatingLightsLP : RotatingLightsBase
             rotationAngle = startRotationOffset + startRotationAngle;
             transform.localRotation = startRotation * Quaternion.Euler(_rotationVector * rotationAngle);
             rotationSpeed = beatmapEventDataValue * 20f * direction;
-            if (left)
+            if (Left)
             {
                 rotatingLightsRandom._rotationSpeed = rotationSpeed;
             }

--- a/Assets/__Scripts/UI/SongEditMenu/DifficultySelect.cs
+++ b/Assets/__Scripts/UI/SongEditMenu/DifficultySelect.cs
@@ -163,17 +163,20 @@ public class DifficultySelect : MonoBehaviour
     /// <param name="row">UI row that was clicked on</param>
     private void SaveDiff(DifficultyRow row)
     {
+        var localSong = BeatSaberSongContainer.Instance.song;
+        if (localSong.directory == null)
+            localSong.SaveSong();
+
         var localDiff = diffs[row.Name];
         var firstSave = localDiff.ForceDirty;
         localDiff.Commit();
         row.ShowDirtyObjects(false, true);
 
-        var Song = BeatSaberSongContainer.Instance.song;
         var diff = localDiff.DifficultyBeatmap;
 
-        if (!Song.difficultyBeatmapSets.Contains(currentCharacteristic))
+        if (!localSong.difficultyBeatmapSets.Contains(currentCharacteristic))
         {
-            Song.difficultyBeatmapSets.Add(currentCharacteristic);
+            localSong.difficultyBeatmapSets.Add(currentCharacteristic);
         }
         if (!currentCharacteristic.difficultyBeatmaps.Contains(diff))
         {
@@ -187,7 +190,7 @@ public class DifficultySelect : MonoBehaviour
         string oldPath = map?.directoryAndFile;
 
         diff.UpdateName();
-        map.directoryAndFile = Path.Combine(Song.directory, diff.beatmapFilename);
+        map.directoryAndFile = Path.Combine(localSong.directory, diff.beatmapFilename);
         if (File.Exists(oldPath) && oldPath != map.directoryAndFile && !File.Exists(map.directoryAndFile))
         {
             if (firstSave)
@@ -206,7 +209,7 @@ public class DifficultySelect : MonoBehaviour
 
         diff.RefreshRequirementsAndWarnings(map);
 
-        Song.SaveSong();
+        localSong.SaveSong();
         characteristicSelect.Recalculate();
 
         Debug.Log("Saved " + row.Name);


### PR DESCRIPTION
### This will have merge conflicts with the interscope changes

- Middle click to invert boost lights
Just QOL change per https://discord.com/channels/702230714585710602/702231982335197264/797983545276628993
- Fix #277 by passing the event type to invert rotation direction (this is what will conflict with interscope)
- Save song before diff if needed
Previously if you created a new map and then created and saved a diff before saving the map it would throw an error, now it just saves the blank map (without any changes in the UI) first.