### PR TITLE
Bug fixes

### DIFF
--- a/Assets/Tests/StrobeGeneratorTest.cs
+++ b/Assets/Tests/StrobeGeneratorTest.cs
@@ -1,0 +1,162 @@
+﻿using NUnit.Framework;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using SimpleJSON;
+using Tests.Util;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Tests
+{
+    public class StrobeGeneratorTest
+    {
+        [UnityOneTimeSetUp]
+        public IEnumerator LoadMap() => TestUtils.LoadMapper();
+
+        [TearDown]
+        public void ContainerCleanup()
+        {
+            BeatmapActionContainer.RemoveAllActionsOfType<BeatmapAction>();
+            TestUtils.CleanupEvents();
+        }
+
+        public static void CheckEvent(BeatmapObjectContainerCollection container, int idx, float time, int type, int value, JSONNode customData = null)
+        {
+            var newObjA = container.LoadedObjects.Skip(idx).First();
+            Assert.IsInstanceOf<MapEvent>(newObjA);
+            if (newObjA is MapEvent newNoteA)
+            {
+                Assert.AreEqual(time, newNoteA._time);
+                Assert.AreEqual(type, newNoteA._type);
+                Assert.AreEqual(value, newNoteA._value);
+
+                // ConvertToJSON causes gradient to get updated
+                if (customData != null) Assert.AreEqual(customData.ToString(), newNoteA.ConvertToJSON()["_customData"].ToString());
+            }
+        }
+
+        [Test]
+        public void ChromaStepGradient()
+        {
+            var containerCollection = BeatmapObjectContainerCollection.GetCollectionForType(BeatmapObject.Type.EVENT);
+            if (containerCollection is EventsContainer eventsContainer)
+            {
+                var root = eventsContainer.transform.root;
+                var eventPlacement = root.GetComponentInChildren<EventPlacement>();
+
+                var eventA = new MapEvent(2, MapEvent.EVENT_TYPE_RING_LIGHTS, MapEvent.LIGHT_VALUE_RED_ON, new JSONObject
+                {
+                    ["_color"] = new Color(0, 1, 0)
+                });
+                var eventB = new MapEvent(3, MapEvent.EVENT_TYPE_RING_LIGHTS, MapEvent.LIGHT_VALUE_RED_ON, new JSONObject
+                {
+                    ["_color"] = new Color(0, 0, 1)
+                });
+                var eventC = new MapEvent(3, MapEvent.EVENT_TYPE_RING_LIGHTS, MapEvent.LIGHT_VALUE_RED_ON, new JSONObject
+                {
+                    ["_lightID"] = 1,
+                    ["_color"] = new Color(1, 0, 0)
+                });
+
+                foreach (var mapEvent in new MapEvent[] { eventA, eventB, eventC })
+                {
+                    eventPlacement.queuedData = mapEvent;
+                    eventPlacement.queuedValue = eventPlacement.queuedData._value;
+                    eventPlacement.RoundedTime = eventPlacement.queuedData._time;
+                    eventPlacement.ApplyToMap();
+                }
+
+                SelectionController.Select(eventA);
+                SelectionController.Select(eventB, true);
+                // eventC is not selected
+
+                var strobeGenerator = Object.FindObjectOfType<StrobeGenerator>();
+                strobeGenerator.GenerateStrobe(new List<StrobeGeneratorPass>()
+                {
+                    new StrobeStepGradientPass(MapEvent.LIGHT_VALUE_BLUE_ON, false, 2, Easing.Linear)
+                });
+
+                CheckEvent(eventsContainer, 1, 2.5f, MapEvent.EVENT_TYPE_RING_LIGHTS, MapEvent.LIGHT_VALUE_BLUE_ON, new JSONObject
+                {
+                    ["_color"] = new Color(0, 0.5f, 0.5f)
+                });
+            }
+        }
+
+        [Test]
+        public void LightIDChromaStepGradient()
+        {
+            var containerCollection = BeatmapObjectContainerCollection.GetCollectionForType(BeatmapObject.Type.EVENT);
+            if (containerCollection is EventsContainer eventsContainer)
+            {
+                var root = eventsContainer.transform.root;
+                var eventPlacement = root.GetComponentInChildren<EventPlacement>();
+
+                var eventA = new MapEvent(2, MapEvent.EVENT_TYPE_RING_LIGHTS, MapEvent.LIGHT_VALUE_RED_ON, new JSONObject
+                {
+                    ["_color"] = new Color(0, 1, 0)
+                });
+                var eventB = new MapEvent(3, MapEvent.EVENT_TYPE_RING_LIGHTS, MapEvent.LIGHT_VALUE_RED_ON, new JSONObject
+                {
+                    ["_color"] = new Color(0, 0, 1)
+                });
+                var eventC = new MapEvent(3, MapEvent.EVENT_TYPE_RING_LIGHTS, MapEvent.LIGHT_VALUE_RED_ON, new JSONObject
+                {
+                    ["_lightID"] = 1,
+                    ["_color"] = new Color(1, 0, 0)
+                });
+                var eventD = new MapEvent(2, MapEvent.EVENT_TYPE_RING_LIGHTS, MapEvent.LIGHT_VALUE_RED_ON, new JSONObject
+                {
+                    ["_lightID"] = 1,
+                    ["_color"] = new Color(1, 1, 0)
+                });
+                var eventE = new MapEvent(4, MapEvent.EVENT_TYPE_RING_LIGHTS, MapEvent.LIGHT_VALUE_RED_ON, new JSONObject
+                {
+                    ["_lightID"] = new JSONArray()
+                    {
+                        [0] = 1,
+                        [1] = 2
+                    },
+                    ["_color"] = new Color(1, 0, 1)
+                });
+                var eventF = new MapEvent(3, MapEvent.EVENT_TYPE_RING_LIGHTS, MapEvent.LIGHT_VALUE_RED_ON, new JSONObject
+                {
+                    ["_lightID"] = 3,
+                    ["_color"] = new Color(0, 1, 1)
+                });
+
+                foreach (var mapEvent in new MapEvent[] { eventA, eventB, eventC, eventD, eventE, eventF })
+                {
+                    eventPlacement.queuedData = mapEvent;
+                    eventPlacement.queuedValue = eventPlacement.queuedData._value;
+                    eventPlacement.RoundedTime = eventPlacement.queuedData._time;
+                    eventPlacement.ApplyToMap();
+                }
+
+                SelectionController.Select(eventC);
+                SelectionController.Select(eventD, true);
+                SelectionController.Select(eventE, true);
+
+                var strobeGenerator = Object.FindObjectOfType<StrobeGenerator>();
+                strobeGenerator.GenerateStrobe(new List<StrobeGeneratorPass>()
+                {
+                    new StrobeStepGradientPass(MapEvent.LIGHT_VALUE_BLUE_ON, false, 2, Easing.Linear)
+                });
+
+                // Current _lightID from the first event is used. As eventC is added first here we always get a single light id
+                // If this changes in future then update below, this test wasn't really meant to enforce this behaviour
+                CheckEvent(eventsContainer, 2, 2.5f, MapEvent.EVENT_TYPE_RING_LIGHTS, MapEvent.LIGHT_VALUE_BLUE_ON, new JSONObject
+                {
+                    ["_color"] = new Color(1, 0.5f, 0),
+                    ["_lightID"] = 1
+                });
+                CheckEvent(eventsContainer, 6, 3.5f, MapEvent.EVENT_TYPE_RING_LIGHTS, MapEvent.LIGHT_VALUE_BLUE_ON, new JSONObject
+                {
+                    ["_color"] = new Color(1, 0, 0.5f),
+                    ["_lightID"] = 1
+                });
+            }
+        }
+    }
+}

--- a/Assets/Tests/StrobeGeneratorTest.cs.meta
+++ b/Assets/Tests/StrobeGeneratorTest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ebbebe3bd95148e7ab85432222c925c0
+timeCreated: 1625057333

--- a/Assets/__Scripts/Map/Events/EventAppearanceSO.cs
+++ b/Assets/__Scripts/Map/Events/EventAppearanceSO.cs
@@ -75,6 +75,7 @@ public class EventAppearanceSO : ScriptableObject
                 }
                 e.UpdateOffset(Vector3.forward * 1.05f, false);
                 e.ChangeFadeSize(cubeBoostEventFadeSize, false);
+                e.UpdateMaterials();
                 return;
             }
             else

--- a/Assets/__Scripts/MapEditor/Mapping/Strobe Generator/StrobeGenerator.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/Strobe Generator/StrobeGenerator.cs
@@ -49,8 +49,7 @@ public class StrobeGenerator : MonoBehaviour {
 
                         IEnumerable<MapEvent> containersBetween = eventsContainer.LoadedObjects.GetViewBetween(start, end).Cast<MapEvent>().Where(x =>
                             x._type == start._type && //Grab all events between start and end point.
-                            // This check isn't perfect but I think it covers anything that could occur without manual mischief
-                            (propMode != EventsContainer.PropMode.Light || start.IsLightIdEvent == x.IsLightIdEvent && (!start.IsLightIdEvent || x.LightId.Contains(start.LightId[0])))
+                            (!start.IsLightIdEvent && !x.IsLightIdEvent) || (start.IsLightIdEvent && x.LightId.Contains(start.LightId[0]))
                         );
                         oldEvents.AddRange(containersBetween);
 

--- a/Assets/__Scripts/UI/SongEditMenu/EnvEnhancement.cs
+++ b/Assets/__Scripts/UI/SongEditMenu/EnvEnhancement.cs
@@ -7,7 +7,7 @@ public class EnvEnhancement
     public string ID;
     private ELookupMethod LookupMethod;
     private int Duplicate;
-    private bool Active;
+    private bool? Active;
 
     private Vector3? Scale;
     private Vector3? Position;
@@ -30,7 +30,7 @@ public class EnvEnhancement
         Enum.TryParse(node["_lookupMethod"].Value, out LookupMethod);
 
         Duplicate = node["_duplicate"].AsInt;
-        Active = !node.HasKey("_active") || node["_active"].IsNull || node["_active"].AsBool;
+        Active = !node.HasKey("_active") || node["_active"].IsNull ? (bool?) null : node["_active"].AsBool;
         Scale = ReadVector3OrNull(node, "_scale");
         Position = ReadVector3OrNull(node, "_position");
         LocalPosition = ReadVector3OrNull(node, "_localPosition");
@@ -63,7 +63,7 @@ public class EnvEnhancement
         node["_id"] = ID;
         node["_lookupMethod"] = LookupMethod.ToString();
         if (Duplicate > 0) node["_duplicate"] = Duplicate;
-        if (!Active) node["_active"] = Active;
+        if (Active.HasValue) node["_active"] = Active.Value;
         WriteVector3(node, "_scale", Scale);
         WriteVector3(node, "_position", Position);
         WriteVector3(node, "_localPosition", LocalPosition);

--- a/Assets/__Scripts/UI/SongSelectMenu/SongList.cs
+++ b/Assets/__Scripts/UI/SongSelectMenu/SongList.cs
@@ -98,6 +98,7 @@ public class SongList : MonoBehaviour {
 
     public void TriggerRefresh()
     {
+        StopAllCoroutines();
         StartCoroutine(RefreshSongList());
     }
 

--- a/Assets/__Scripts/UI/SongSelectMenu/SongListItem.cs
+++ b/Assets/__Scripts/UI/SongSelectMenu/SongListItem.cs
@@ -170,6 +170,9 @@ public class SongListItem : RecyclingListViewItem, IPointerEnterHandler, IPointe
         if (_saveRunning) yield break;
         _saveRunning = true;
 
+        if (!File.Exists(_durationCachePath))
+            Directory.CreateDirectory(Path.GetDirectoryName(_durationCachePath) ?? throw new InvalidOperationException("Directory was null?"));
+
         yield return new WaitForSeconds(3);
         using (var writer = new StreamWriter(_durationCachePath, false))
             writer.Write(_songCoreCache.ToString());


### PR DESCRIPTION
- Don't remove _active if it's false, contrary to the docs this actually does something
See: https://discord.com/channels/702230714585710602/702232127755780197/856579355899199530
- Fix boost event materials not updating [CM-70]
- Avoid error when writing duration cache if it doesn't exist yet
- Change lightid filtering in gradient generator, add tests
See: https://discord.com/channels/702230714585710602/702232127755780197/857335694723907585
- Cancel previous song loads when triggering a new one
See: https://discord.com/channels/702230714585710602/702232127755780197/857429175191470141