### PR TITLE
Be lazier loading diffs

### DIFF
--- a/Assets/__Scripts/UI/SongEditMenu/DifficultySelect.cs
+++ b/Assets/__Scripts/UI/SongEditMenu/DifficultySelect.cs
@@ -21,6 +21,8 @@ public class DifficultySelect : MonoBehaviour
     private Dictionary<string, DifficultySettings> diffs;
     public Dictionary<string, Dictionary<string, DifficultySettings>> Characteristics;
 
+    public BeatSaberMap CurrentDiff => diffs[selected.Name].Map;
+
     private Dictionary<string, int> diffRankLookup = new Dictionary<string, int>()
     {
         { "Easy", 1 },

--- a/Assets/__Scripts/UI/SongEditMenu/DifficultySettings.cs
+++ b/Assets/__Scripts/UI/SongEditMenu/DifficultySettings.cs
@@ -100,7 +100,7 @@ public class DifficultySettings
 
         if (_map.Value != null)
         {
-            enhancements.AddRange(_map.Value._envEnhancements);
+            enhancements.AddRange(_map.Value._envEnhancements.Select(it => it.Clone()));
         }
 
         return enhancements;

--- a/Assets/__Scripts/UI/SongEditMenu/EnvEnhancement.cs
+++ b/Assets/__Scripts/UI/SongEditMenu/EnvEnhancement.cs
@@ -73,4 +73,51 @@ public class EnvEnhancement
 
         return node;
     }
+
+    public EnvEnhancement Clone() =>
+        new EnvEnhancement(ID)
+        {
+            LookupMethod = LookupMethod,
+            Duplicate = Duplicate,
+            Active = Active,
+            Scale = Scale,
+            Position = Position,
+            LocalPosition = LocalPosition,
+            Rotation = Rotation,
+            LocalRotation = LocalRotation,
+            Track = Track
+        };
+
+    protected bool Equals(EnvEnhancement other)
+    {
+        return ID == other.ID && LookupMethod == other.LookupMethod && Duplicate == other.Duplicate && Active == other.Active && Nullable.Equals(Scale, other.Scale) &&
+               Nullable.Equals(Position, other.Position) && Nullable.Equals(LocalPosition, other.LocalPosition) && Nullable.Equals(Rotation, other.Rotation) &&
+               Nullable.Equals(LocalRotation, other.LocalRotation) && Track == other.Track;
+    }
+
+    public override bool Equals(object obj)
+    {
+        if (ReferenceEquals(null, obj)) return false;
+        if (ReferenceEquals(this, obj)) return true;
+        if (obj.GetType() != this.GetType()) return false;
+        return Equals((EnvEnhancement) obj);
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hashCode = (ID != null ? ID.GetHashCode() : 0);
+            hashCode = (hashCode * 397) ^ (int) LookupMethod;
+            hashCode = (hashCode * 397) ^ Duplicate;
+            hashCode = (hashCode * 397) ^ Active.GetHashCode();
+            hashCode = (hashCode * 397) ^ Scale.GetHashCode();
+            hashCode = (hashCode * 397) ^ Position.GetHashCode();
+            hashCode = (hashCode * 397) ^ LocalPosition.GetHashCode();
+            hashCode = (hashCode * 397) ^ Rotation.GetHashCode();
+            hashCode = (hashCode * 397) ^ LocalRotation.GetHashCode();
+            hashCode = (hashCode * 397) ^ (Track != null ? Track.GetHashCode() : 0);
+            return hashCode;
+        }
+    }
 }

--- a/Assets/__Scripts/UI/SongInfoEditUI.cs
+++ b/Assets/__Scripts/UI/SongInfoEditUI.cs
@@ -529,7 +529,7 @@ public class SongInfoEditUI : MenuBase
     {
         if (r == 0)
         {
-            BeatSaberMap map = Song.GetMapFromDifficultyBeatmap(BeatSaberSongContainer.Instance.difficultyData);
+            var map = difficultySelect.CurrentDiff;
             PersistentUI.UpdateBackground(Song);
 
             Debug.Log("Transitioning...");


### PR DESCRIPTION
I realised that I was constructing a Lazy and then immediately calling a method that tries to access its value. The idea was that even though we need to load the diff file to get the new env enhancements that we wouldn't load diffs unless we needed to display this data.

Changed it so that instead a null value is used internally to denote no change has been made. The map will be loaded and value populated when the diff is selected (this could further be optimised so that it only loads when showing the enhancements tab).

Also changed the "Open Editor" button so that it pulls from the lazy value.

Combined this means that for a full spread instead of loading diff files 6 (every diff on screen + one of them twice) times before you get to the editor we now load 1 time (or as many as you click on).