### PR TITLE
Raycasting fixes

### DIFF
--- a/Assets/__Scripts/Intersections/Implementations/Internal.cs
+++ b/Assets/__Scripts/Intersections/Implementations/Internal.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System;
+using UnityEngine;
 
 /// <summary>
 /// A custom class that offers a super-fast way of checking intersections against a ray without using Physics.Raycast.
@@ -10,6 +11,7 @@ public static partial class Intersections
     // Doing things this way loses a little bit of speed, but increases accuracy on non-cube meshes.
     private static bool RaycastIndividual_Internal(IntersectionCollider collider, in Vector3 rayDirection, in Vector3 rayOrigin, out float distance)
     {
+        var success = false;
         distance = 0;
 
         var localToWorldMatrix = collider.transform.localToWorldMatrix;
@@ -26,14 +28,15 @@ public static partial class Intersections
             var vert3 = localToWorldMatrix.FastMultiplyPoint3x4(in meshVertices[meshTriangles[i + 2]]);
 
             // If our ray intersects this triangle, the entire collider intersects, no more work to be done.
-            if (RayTriangleIntersect(in vert1, in vert2, in vert3, in rayDirection, in rayOrigin, out distance))
+            if (RayTriangleIntersect(in vert1, in vert2, in vert3, in rayDirection, in rayOrigin, out var localDistance) && (!success || localDistance < distance))
             {
-                return true;
+                success = true;
+                distance = localDistance;
             }
         }
 
         // The ray did not intersect any triangles; the ray did not collide.
-        return false;
+        return success;
     }
 
     // (These vectors are moved outside of the Ray-Triangle intersection algorithm to keep runtime allocations at bay)

--- a/Assets/__Scripts/Intersections/Implementations/Raycast.cs
+++ b/Assets/__Scripts/Intersections/Implementations/Raycast.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 
@@ -66,14 +67,20 @@ public static partial class Intersections
             if (groupedCollidersInLayer.Count <= 0) continue;
 
             var groupKeys = groupedCollidersInLayer.Keys;
-            var lowestKey = groupKeys.Min();
-            var highestKey = groupKeys.Max();
+            var (lowestKey, highestKey) = (groupKeys.Min(), groupKeys.Max());
 
             var groupID = Mathf.Clamp(CurrentGroup, lowestKey, highestKey);
+            var rounds = Math.Max(groupID - lowestKey, highestKey - groupID) * 2;
 
-            while (groupID >= lowestKey - 1 && groupID <= highestKey + 1)
+            for (var k = 0; k < rounds; k++)
             //while (groupedCollidersInLayer.TryGetValue(startingGroup, out var collidersInLayer))
             {
+                if (groupID < lowestKey || groupID > highestKey)
+                {
+                    groupID = NextGroupSearchFunction(groupID);
+                    continue;
+                }
+
                 hits.Clear();
 
                 if (groupedCollidersInLayer.TryGetValue(groupID, out var collidersInLayer) && collidersInLayer.Count > 0)

--- a/Assets/__Scripts/Intersections/Implementations/Raycast.cs
+++ b/Assets/__Scripts/Intersections/Implementations/Raycast.cs
@@ -62,6 +62,7 @@ public static partial class Intersections
 
         for (int currentLayer = layerMin; currentLayer < layerMax; currentLayer++)
         {
+            hits.Clear();
             var groupedCollidersInLayer = groupedColliders[currentLayer];
 
             if (groupedCollidersInLayer.Count <= 0) continue;
@@ -80,8 +81,6 @@ public static partial class Intersections
                     groupID = NextGroupSearchFunction(groupID);
                     continue;
                 }
-
-                hits.Clear();
 
                 if (groupedCollidersInLayer.TryGetValue(groupID, out var collidersInLayer) && collidersInLayer.Count > 0)
                 {
@@ -107,25 +106,25 @@ public static partial class Intersections
                     }
                 }
 
-                if (hits.Count > 0)
+                groupID = NextGroupSearchFunction(groupID);
+            }
+
+            if (hits.Count > 0)
+            {
+                var hitsCount = hits.Count;
+
+                for (int i = 0; i < hitsCount; i++)
                 {
-                    var hitsCount = hits.Count;
+                    var newHit = hits[i];
 
-                    for (int i = 0; i < hitsCount; i++)
+                    if (newHit.Distance < distance)
                     {
-                        var newHit = hits[i];
-
-                        if (newHit.Distance < distance)
-                        {
-                            hit = newHit;
-                            distance = newHit.Distance;
-                        }
+                        hit = newHit;
+                        distance = newHit.Distance;
                     }
-
-                    return true;
                 }
 
-                groupID = NextGroupSearchFunction(groupID);
+                return true;
             }
         }
 

--- a/Assets/__Scripts/Intersections/Intersections.cs
+++ b/Assets/__Scripts/Intersections/Intersections.cs
@@ -62,6 +62,7 @@ public static partial class Intersections
             if (groupDictionary.TryGetValue(group, out var list))
             {
                 successful |= list.Remove(collider);
+                if (list.Count == 0) groupDictionary.Remove(group);
             }
         }
 

--- a/Assets/__Scripts/Map/Obstacles/BeatmapObstacleContainer.cs
+++ b/Assets/__Scripts/Map/Obstacles/BeatmapObstacleContainer.cs
@@ -111,29 +111,6 @@ public class BeatmapObstacleContainer : BeatmapObjectContainer
             transform.RotateAround(rectWorldPos, transform.forward, localRotation.z);
         }
 
-        UpdateCollisionGroupsWithDuration(duration);
-    }
-
-    private void UpdateCollisionGroupsWithDuration(float duration)
-    {
-        var chunkStart = ChunkID;
-
-        var chunkEnd = (int)((obstacleData._time + duration) / Intersections.ChunkSize);
-
-        if (chunkStart > chunkEnd)
-        {
-            // me and the boys casually flipping shit
-            (chunkStart, chunkEnd) = (chunkEnd, chunkStart);
-        }
-
-        var range = Enumerable.Range(chunkStart, Mathf.Max(chunkEnd - chunkStart, 1));
-
-        foreach (var collider in colliders)
-        {
-            var unregistered = Intersections.UnregisterColliderFromGroups(collider);
-            collider.CollisionGroups.Clear();
-            collider.CollisionGroups.AddRange(range);
-            if (unregistered) Intersections.RegisterColliderToGroups(collider);
-        }
+        UpdateCollisionGroups();
     }
 }

--- a/Assets/__Scripts/MapEditor/CameraPositionToChunk.cs
+++ b/Assets/__Scripts/MapEditor/CameraPositionToChunk.cs
@@ -16,9 +16,7 @@ public class CameraPositionToChunk : MonoBehaviour
     {
         var offset = x - Intersections.CurrentGroup;
 
-        var index = (int)Mathf.Max(1, (Mathf.Abs(offset) * 2) - ((Mathf.Sign(offset) - 1) / 2f));
-
-        return Intersections.CurrentGroup + (Mathf.CeilToInt(index / 2f) * ((index % 2 * 2) - 1));
+        return Intersections.CurrentGroup - (offset > 0 ? offset : offset - 1);
     };
 
     [SerializeField] private AudioTimeSyncController atsc;
@@ -26,34 +24,16 @@ public class CameraPositionToChunk : MonoBehaviour
 
     private Transform t;
 
-    private void Start() => t = transform;
+    private void Start()
+    {
+        t = transform;
+        Intersections.NextGroupSearchFunction = AlternatingChunkFunc;
+    }
 
     private void Update()
     {
         var beat = trackTransform.InverseTransformPoint(t.position).z / EditorScaleController.EditorScale;
         var chunk = (int)(beat / Intersections.ChunkSize);
-
-        var forward = trackTransform.forward;
-        var cameraForward = t.forward;
-
-        // Use fancy dot product math to determine which chunk method to use for best performance.
-        var dot = VectorUtils.FastDot(in forward, in cameraForward);
-
-        // If we're facing down the track towards positive time, use increasing chunk IDs
-        if (dot > 0.5f)
-        {
-            Intersections.NextGroupSearchFunction = IncreasingChunkFunc;
-        }
-        // If we're facing down the track towards negative time, use decreasing chunk IDs
-        else if (dot < -0.5f)
-        {
-            Intersections.NextGroupSearchFunction = DecreasingChunkFunc;
-        }
-        // If we're in a weird middle state, use an alternating combination
-        else
-        {
-            Intersections.NextGroupSearchFunction = AlternatingChunkFunc;
-        }
 
         Intersections.CurrentGroup = chunk;
     }

--- a/Assets/__Scripts/MapEditor/Input/BeatmapInputController.cs
+++ b/Assets/__Scripts/MapEditor/Input/BeatmapInputController.cs
@@ -1,8 +1,15 @@
 ﻿using System.Collections;
+using System.Diagnostics;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.InputSystem;
 using UnityEngine.UI;
+using Debug = UnityEngine.Debug;
+
+public class GlobalIntersectionCache
+{
+    internal static GameObject firstHit = null;
+}
 
 public class BeatmapInputController<T> : MonoBehaviour, CMInput.IBeatmapObjectsActions where T : BeatmapObjectContainer
 {
@@ -29,6 +36,7 @@ public class BeatmapInputController<T> : MonoBehaviour, CMInput.IBeatmapObjectsA
     void Update()
     {
         if (customStandaloneInputModule.IsPointerOverGameObject<GraphicRaycaster>(-1, true)) return;
+        GlobalIntersectionCache.firstHit = null;
         if (ObstaclePlacement.IsPlacing)
         {
             timeWhenFirstSelecting = Time.time;
@@ -52,9 +60,17 @@ public class BeatmapInputController<T> : MonoBehaviour, CMInput.IBeatmapObjectsA
     protected void RaycastFirstObject(out T firstObject)
     {
         Ray ray = mainCamera.ScreenPointToRay(mousePosition);
-        if (Intersections.Raycast(ray, 9, out var hit))
+        if (GlobalIntersectionCache.firstHit == null)
         {
-            T obj = hit.GameObject.GetComponentInParent<T>();
+            if (Intersections.Raycast(ray, 9, out var hit))
+            {
+                GlobalIntersectionCache.firstHit = hit.GameObject;
+            }
+        }
+
+        if (GlobalIntersectionCache.firstHit != null)
+        {
+            T obj = GlobalIntersectionCache.firstHit.GetComponentInParent<T>();
             if (obj != null)
             {
                 firstObject = obj;


### PR DESCRIPTION
I was having some problems with selecting notes and events.

There are three modes depending on camera direction sadly the forward and backwards modes don't consider high FOV values so objects at the edge of the window that are "behind" the camera can't be selected.

The alternating mode works reasonably well in the middle of a map but at the start it would stop processing as soon as it considered a chunk before 0 so if the camera is over chunk 0 it checks 0, 1, -1, 2 -> stop. Because alternating has reached -1 objects in 3 or higher are inaccessible.

### In this PR
Just removed the forward/backward modes as high fov sadly makes them useless. We always alternate.

Code for getting the next group id simplified (I can't even read the old code)

We always do enough loops to reach the end in the furthest direction and skip iterations that are outside the bounds (possibly could just remove this check as it should fall through the trygetvalue afterward). lowestKey and highestKey are now accurate for loaded containers as when deregistering unused keys are removed.