### PR TITLE
Add option to outline shader to offset mesh scaling

### DIFF
--- a/Assets/_Graphics/Shaders/Editor/Instanced Toon Outline.shader
+++ b/Assets/_Graphics/Shaders/Editor/Instanced Toon Outline.shader
@@ -4,6 +4,7 @@
     {
         _OutlineColor("Outline Color", Color) = (0,0,0,1)
         _Outline("Outline width", Range(.002, 0.05)) = .005
+        _HandleScale("Handle scale", Float) = 0
     }
     SubShader
     {
@@ -27,6 +28,7 @@
             UNITY_INSTANCING_BUFFER_START(Props)
                UNITY_DEFINE_INSTANCED_PROP(fixed4, _OutlineColor)
                UNITY_DEFINE_INSTANCED_PROP(fixed, _Outline)
+			   UNITY_DEFINE_INSTANCED_PROP(fixed, _HandleScale)
             UNITY_INSTANCING_BUFFER_END(Props)
 
             struct appdata
@@ -48,7 +50,16 @@
                 UNITY_SETUP_INSTANCE_ID(v);
                 UNITY_TRANSFER_INSTANCE_ID(v, o); // necessary only if you want to access instanced properties in the fragment Shader.
 
-                o.vertex = UnityObjectToClipPos(v.vertex + (v.vertex * UNITY_ACCESS_INSTANCED_PROP(Props, _Outline)));
+                float3 scale = float3(1, 1, 1);
+                if (UNITY_ACCESS_INSTANCED_PROP(Props, _HandleScale) > 0) {
+                    scale = 1 / float3(
+                        length(float3(unity_ObjectToWorld[0].x, unity_ObjectToWorld[1].x, unity_ObjectToWorld[2].x)),
+                        length(float3(unity_ObjectToWorld[0].y, unity_ObjectToWorld[1].y, unity_ObjectToWorld[2].y)),
+                        length(float3(unity_ObjectToWorld[0].z, unity_ObjectToWorld[1].z, unity_ObjectToWorld[2].z))
+                    );
+                }
+
+                o.vertex = UnityObjectToClipPos(v.vertex + (v.vertex * scale * UNITY_ACCESS_INSTANCED_PROP(Props, _Outline)));
                 return o;
             }
 

--- a/Assets/__Scripts/Map/BeatmapObjectContainer.cs
+++ b/Assets/__Scripts/Map/BeatmapObjectContainer.cs
@@ -11,6 +11,7 @@ public abstract class BeatmapObjectContainer : MonoBehaviour
     internal static readonly int Rotation = Shader.PropertyToID("_Rotation");
     internal static readonly int Outline = Shader.PropertyToID("_Outline");
     internal static readonly int OutlineColor = Shader.PropertyToID("_OutlineColor");
+    internal static readonly int HandleScale = Shader.PropertyToID("_HandleScale");
 
     public bool OutlineVisible
     { 

--- a/Assets/__Scripts/Map/Obstacles/BeatmapObstacleContainer.cs
+++ b/Assets/__Scripts/Map/Obstacles/BeatmapObstacleContainer.cs
@@ -24,6 +24,12 @@ public class BeatmapObstacleContainer : BeatmapObjectContainer
         return container;
     }
 
+    public override void Setup()
+    {
+        base.Setup();
+        MaterialPropertyBlock.SetFloat(HandleScale, 1);
+    }
+
     public void SetColor(Color color)
     {
         MaterialPropertyBlock.SetColor(ColorTint, color);


### PR DESCRIPTION
Normally when scaling objects the toon shader's outline also scales however we use scale for walls to make them longer and it's not really intended that this would cause the selection to extend further.

To prevent this I've added an extra shader property that causes the shader to scale back to keep the outline the same size in world space. It's gated because apparently the process of reversing the scale is costly so it's set up to only be applied to walls.

![bigselection](https://user-images.githubusercontent.com/534069/125648133-0f6110cd-36cf-4338-bd00-bcfeecafb4fb.png)
![badwalls](https://user-images.githubusercontent.com/534069/125648447-257414fb-f9ee-4c70-94a3-46b989eb282e.png)

VS now:
![now](https://user-images.githubusercontent.com/534069/125649328-e1f2c7f8-bf61-4f61-b18a-3cc6b3c159e4.png)
