### PR TITLE
BPM change improvements

### DIFF
--- a/Assets/__Scripts/MapEditor/AudioTimeSyncController.cs
+++ b/Assets/__Scripts/MapEditor/AudioTimeSyncController.cs
@@ -299,35 +299,7 @@ public class AudioTimeSyncController : MonoBehaviour, CMInput.IPlaybackActions, 
                 // +1 beat if we're going forward, -1 beat if we're going backwards
                 float beatShiftRaw = 1f / gridMeasureSnapping * (value > 0 ? 1f : -1f);
 
-                // Grab any BPM Change at this location, calculate a BPM-modified shift in beat
-                BeatmapBPMChange currentBpmChange = bpmChangesContainer.FindLastBPM(CurrentBeat, true);
-                float beatShift = beatShiftRaw;
-                // This new beatShift value will move us 1 BPM-modified beat forward or backward
-                if (currentBpmChange != null) beatShift *= (song.beatsPerMinute / currentBpmChange._BPM);
-
-                // Now we check if the BPM Change after the shift is different.
-                BeatmapBPMChange lastBpmChange = bpmChangesContainer.FindLastBPM(CurrentBeat + beatShift, true);
-
-                if (lastBpmChange != currentBpmChange && currentBpmChange != null)
-                {
-                    if (currentBpmChange._time == CurrentBeat) // We're on top of a BPM change, move using previous BPM
-                    {
-                        beatShift = lastBpmChange == null ? beatShiftRaw : (beatShiftRaw * (song.beatsPerMinute / lastBpmChange._BPM));
-                        MoveToTimeInBeats(CurrentBeat + beatShift);
-                    }
-                    else if (beatShiftRaw < 0)
-                    {
-                        MoveToTimeInBeats(currentBpmChange._time); // If we're going backward, snap to our current bpm change.
-                    }
-                    else if (lastBpmChange != null)
-                    {
-                        MoveToTimeInBeats(lastBpmChange._time); // If we're going forward, snap to that bpm change.
-                    }
-                }
-                else
-                {
-                    MoveToTimeInBeats(CurrentBeat + beatShift);
-                }
+                MoveToTimeInBeats(CurrentBeat + bpmChangesContainer.LocalBeatsToSongBeats(beatShiftRaw, CurrentBeat));
             }
         }
     }

--- a/Assets/__Scripts/MapEditor/Grid/Collections/BPMChangesContainer.cs
+++ b/Assets/__Scripts/MapEditor/Grid/Collections/BPMChangesContainer.cs
@@ -158,6 +158,77 @@ public class BPMChangesContainer : BeatmapObjectContainerCollection
         return LoadedObjects.LastOrDefault(x => x._time + 0.01f < beatTimeInSongBPM) as BeatmapBPMChange;
     }
 
+    /// <summary>
+    /// Find the next <see cref="BeatmapBPMChange"/> after a given beat time.
+    /// </summary>
+    /// <param name="beatTimeInSongBPM">Time in raw beats (Unmodified by any BPM Changes)</param>
+    /// <param name="inclusive">Whether or not to include <see cref="BeatmapBPMChange"/>s with the same time value.</param>
+    /// <returns>The next <see cref="BeatmapBPMChange"/> after the given beat (or <see cref="null"/> if there is none).</returns>
+    public BeatmapBPMChange FindNextBPM(float beatTimeInSongBPM, bool inclusive = false)
+    {
+        if (inclusive) return LoadedObjects.FirstOrDefault(x => x._time >= beatTimeInSongBPM - 0.01f) as BeatmapBPMChange;
+        return LoadedObjects.FirstOrDefault(x => x._time - 0.01f > beatTimeInSongBPM) as BeatmapBPMChange;
+    }
+
+    /// <summary>
+    /// Calculates the number of beats in song BPM for a given number of beats in local BPM, accounting for all BPM changes, relative to a starting position
+    /// </summary>
+    /// <param name="localBeats">Number of beats in local BPM</param>
+    /// <param name="startBeat">The starting position from which to calculate. Number is in song BPM</param>
+    /// <returns>The number of beats in song BPM equivalent to the number of beats in local bpm around a starting position</returns>
+    public float LocalBeatsToSongBeats(float localBeats, float startBeat)
+    {
+        float totalSongBeats = 0;
+        float localBeatsLeft = localBeats;
+        float currentBeat = startBeat;
+        float songBPM = BeatSaberSongContainer.Instance.song.beatsPerMinute;
+        float currentBPM = FindLastBPM(startBeat, true)?._BPM ?? songBPM;
+
+        if (localBeats > 0)
+        {
+            BeatmapBPMChange nextBPMChange = FindNextBPM(startBeat, false);
+            while (localBeatsLeft > 0)
+            {
+                if (nextBPMChange is null)
+                {
+                    totalSongBeats += localBeatsLeft * songBPM / currentBPM;
+                    break;
+                }
+
+                float distance = Math.Min(localBeatsLeft * songBPM / currentBPM, nextBPMChange._time - currentBeat);
+                totalSongBeats += distance;
+                localBeatsLeft -= distance * currentBPM / songBPM;
+
+                currentBeat = nextBPMChange._time;
+                currentBPM = nextBPMChange._BPM;
+                nextBPMChange = FindNextBPM(currentBeat, false);
+            }
+        }
+        else
+        {
+            BeatmapBPMChange lastBPMChange = FindLastBPM(startBeat, false);
+            while (localBeatsLeft < 0)
+            {
+                if (lastBPMChange is null)
+                {
+                    totalSongBeats += localBeatsLeft;
+                    break;
+                }
+
+                currentBPM = lastBPMChange._BPM;
+
+                float distance = Math.Max(localBeatsLeft * songBPM / currentBPM, lastBPMChange._time - currentBeat);
+                totalSongBeats += distance;
+                localBeatsLeft -= distance * currentBPM / songBPM;
+
+                currentBeat = lastBPMChange._time;
+                lastBPMChange = FindLastBPM(currentBeat, false);
+            }
+        }
+
+        return totalSongBeats;
+    }
+
     public override BeatmapObjectContainer CreateContainer() => BeatmapBPMChangeContainer.SpawnBPMChange(null, ref bpmPrefab);
 
     protected override void UpdateContainerData(BeatmapObjectContainer con, BeatmapObject obj)

--- a/Assets/__Scripts/MapEditor/Input/BeatmapBPMChangeInputController.cs
+++ b/Assets/__Scripts/MapEditor/Input/BeatmapBPMChangeInputController.cs
@@ -33,6 +33,15 @@ public class BeatmapBPMChangeInputController : BeatmapInputController<BeatmapBPM
                 bpmChanges.RefreshGridShaders();
 
                 BeatmapActionContainer.AddAction(new BeatmapObjectModifiedAction(containerToEdit.objectData, containerToEdit.objectData, original));
+
+                // Update cursor position
+                AudioTimeSyncController atsc = bpmChanges.AudioTimeSyncController;
+                BeatmapBPMChange lastBpmChange = bpmChanges.FindLastBPM(atsc.CurrentBeat, true);
+                if (lastBpmChange == containerToEdit.bpmData)
+                {
+                    float newTime = lastBpmChange._time + (atsc.CurrentBeat - lastBpmChange._time) * (lastBpmChange._BPM - modifier) / lastBpmChange._BPM;
+                    atsc.MoveToTimeInBeats(newTime);
+                }
             }
         }
     }

--- a/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/BPMChangePlacement.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/BPMChangePlacement.cs
@@ -41,8 +41,9 @@ public class BPMChangePlacement : PlacementController<BeatmapBPMChange, BeatmapB
             }
             return;
         }
+        float lastBPM = objectContainerCollection.FindLastBPM(RoundedTime, false)?._BPM ?? BeatSaberSongContainer.Instance.song.beatsPerMinute;
         PersistentUI.Instance.ShowInputBox("Mapper", "bpm.dialog", AttemptPlaceBPMChange,
-            "", BeatSaberSongContainer.Instance.song.beatsPerMinute.ToString());
+            "", lastBPM.ToString());
     }
 
     private void AttemptPlaceBPMChange(string obj)
@@ -60,8 +61,9 @@ public class BPMChangePlacement : PlacementController<BeatmapBPMChange, BeatmapB
         }
         else
         {
+            float lastBPM = objectContainerCollection.FindLastBPM(RoundedTime, false)?._BPM ?? BeatSaberSongContainer.Instance.song.beatsPerMinute;
             PersistentUI.Instance.ShowInputBox("Mapper", "bpm.dialog.invalid",
-                AttemptPlaceBPMChange, "", BeatSaberSongContainer.Instance.song.beatsPerMinute.ToString());
+                AttemptPlaceBPMChange, "", lastBPM.ToString());
         }
     }
 }


### PR DESCRIPTION
Makes the cursor follow the grid on BPM change tweak (Alt+scroll), makes BPM change placement default to the previous BPM, and improves scrolling behavior around BPM changes.

About moving cursor on BPM change tweak:
- Only applies on BPM tweak
- Does not affect undo/redo
- Does not affect other means of editing BPM changes

The reasoning for this is as follows:
- The main use is in mapping BPM slides, where you are likely to use BPM tweak
- Always moving cursor when a BPM change is added or modified would be inconsistent with the behavior of map objects (notes, lights, etc.) which remain stationary
- Moving the cursor on undo/redo would require the above, unless a new action type was created specifically for BPM tweak
- Desired behavior of undo/redo becomes less clear when the cursor is moved before undo/redo