### PR TITLE
Placement bug fix

### DIFF
--- a/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/PlacementController.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/PlacementController.cs
@@ -180,7 +180,7 @@ public abstract class PlacementController<BO, BOC, BOCC> : MonoBehaviour, CMInpu
         if (customStandaloneInputModule.IsPointerOverGameObject<GraphicRaycaster>(-1, true) || !KeybindsController.IsMouseInWindow || !context.performed) return;
         if (!isDraggingObject && !isDraggingObjectAtTime && isOnPlacement && instantiatedContainer != null && IsValid
             && !PersistentUI.Instance.DialogBox_IsEnabled &&
-            queuedData?._time >= 0 && !applicationFocusChanged) ApplyToMap();
+            queuedData?._time >= 0 && !applicationFocusChanged && instantiatedContainer.gameObject.activeSelf) ApplyToMap();
     }
 
     public void OnInitiateClickandDrag(InputAction.CallbackContext context)


### PR DESCRIPTION
If the event grid or track is clicked through the note grid (or vice versa but that's much harder to do) an event is placed when it shouldn't be. This can happen without the mapper noticing and cause a lot of misplaced events. This PR fixes that by simply checking if instantiatedContainer is active before calling ApplyToMap.