### PR TITLE
fix accumulating floating point errors on track z-position

### DIFF
--- a/Assets/__Scripts/MapEditor/Grid/Tracks/Track.cs
+++ b/Assets/__Scripts/MapEditor/Grid/Tracks/Track.cs
@@ -8,7 +8,6 @@ public class Track : MonoBehaviour
 
     public Vector3 RotationValue = Vector3.zero;
     private Vector3 rotationPoint = LoadInitialMap.PlatformOffset;
-    private float oldPosition = 0;
 
     public Action OnTimeChanged;
 
@@ -22,9 +21,7 @@ public class Track : MonoBehaviour
 
     public void UpdatePosition(float position)
     {
-        ObjectParentTransform.localPosition += new Vector3(0, 0, position - oldPosition);
-        oldPosition = position;
-
+        ObjectParentTransform.localPosition = new Vector3(ObjectParentTransform.localPosition.x, ObjectParentTransform.localPosition.y, position);
         OnTimeChanged?.Invoke();
     }
 


### PR DESCRIPTION
Fixes an elusive bug that's been around for a while where under some conditions the note track could become persistently slightly offset causing notes to become transparent when they shouldn't.