### PR TITLE
Preview/Playing camera mode changes

### DIFF
--- a/Assets/__Scenes/03_Mapper.unity
+++ b/Assets/__Scenes/03_Mapper.unity
@@ -1431,6 +1431,7 @@ MonoBehaviour:
   noteAppearanceSO: {fileID: 11400000, guid: 2e49cb79fe1ae9e448bc9363be6040c5, type: 2}
   tracksManager: {fileID: 25550679}
   countersPlus: {fileID: 471772270}
+  uiMode: {fileID: 1799035893}
 --- !u!114 &25550674
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1742,6 +1743,85 @@ Animator:
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorControllerStateOnDisable: 0
+--- !u!21 &44678119
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Inherited From Round Corners
+  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AlphaClip: 0
+    - _Blend: 0
+    - _BumpScale: 1
+    - _ColorMask: 15
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _ReceiveShadows: 1
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _Surface: 0
+    - _UseUIAlphaClip: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+    - _WidthHeightRadius: {r: 46.281853, g: 16.4, b: 4, a: 0}
+    - _halfSize: {r: 29, g: 10, b: 0, a: 0}
+    - _r: {r: 3, g: 3, b: 3, a: 3}
+    - _rect2props: {r: 0.0000019073486, g: -0.0000038146973, b: 25.455845, a: 25.455845}
+  m_BuildTextureStacks: []
 --- !u!1 &51856404
 GameObject:
   m_ObjectHideFlags: 0
@@ -4023,6 +4103,7 @@ MonoBehaviour:
   notesContainer: {fileID: 25550673}
   eventsContainer: {fileID: 25550674}
   timeSyncController: {fileID: 570484802}
+  uiMode: {fileID: 1799035893}
   useOffsetFromConfig: 0
   useDespawnOffset: 0
   offset: 0
@@ -11691,6 +11772,85 @@ PrefabInstance:
       objectReference: {fileID: 2100000, guid: 714c52575879a884685fa7c22c92f9d0, type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 755d36d1fe178c64dbdb2cc4a9c07af6, type: 3}
+--- !u!21 &380771867
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Inherited From Round Corners
+  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AlphaClip: 0
+    - _Blend: 0
+    - _BumpScale: 1
+    - _ColorMask: 15
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _ReceiveShadows: 1
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _Surface: 0
+    - _UseUIAlphaClip: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+    - _WidthHeightRadius: {r: 43, g: 13.514961, b: 2, a: 0}
+    - _halfSize: {r: 29, g: 10, b: 0, a: 0}
+    - _r: {r: 3, g: 3, b: 3, a: 3}
+    - _rect2props: {r: 0.0000019073486, g: -0.0000038146973, b: 25.455845, a: 25.455845}
+  m_BuildTextureStacks: []
 --- !u!1 &382595991
 GameObject:
   m_ObjectHideFlags: 0
@@ -22918,85 +23078,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 710122796}
   m_CullTransparentMesh: 0
---- !u!21 &711318682
-Material:
-  serializedVersion: 6
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: Inherited From Round Corners
-  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
-  m_ShaderKeywords: 
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _BumpMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _EmissionMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _MetallicGlossMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _OcclusionMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _SpecGlossMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Ints: []
-    m_Floats:
-    - _AlphaClip: 0
-    - _Blend: 0
-    - _BumpScale: 1
-    - _ColorMask: 15
-    - _Cull: 2
-    - _Cutoff: 0.5
-    - _DstBlend: 0
-    - _GlossMapScale: 1
-    - _Glossiness: 0.5
-    - _GlossyReflections: 1
-    - _Metallic: 0
-    - _OcclusionStrength: 1
-    - _ReceiveShadows: 1
-    - _SmoothnessTextureChannel: 0
-    - _SpecularHighlights: 1
-    - _SrcBlend: 1
-    - _Stencil: 0
-    - _StencilComp: 8
-    - _StencilOp: 0
-    - _StencilReadMask: 255
-    - _StencilWriteMask: 255
-    - _Surface: 0
-    - _UseUIAlphaClip: 0
-    - _WorkflowMode: 1
-    - _ZWrite: 1
-    m_Colors:
-    - _Color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
-    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
-    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
-    - _WidthHeightRadius: {r: 43, g: 13.514961, b: 2, a: 0}
-    - _halfSize: {r: 29, g: 10, b: 0, a: 0}
-    - _r: {r: 3, g: 3, b: 3, a: 3}
-    - _rect2props: {r: 0.0000019073486, g: -0.0000038146973, b: 25.455845, a: 25.455845}
-  m_BuildTextureStacks: []
 --- !u!1 &723581226
 GameObject:
   m_ObjectHideFlags: 0
@@ -30071,6 +30152,7 @@ MonoBehaviour:
   notesContainer: {fileID: 25550673}
   eventsContainer: {fileID: 25550674}
   timeSyncController: {fileID: 570484802}
+  uiMode: {fileID: 1799035893}
   useOffsetFromConfig: 0
   useDespawnOffset: 0
   offset: 0
@@ -47844,6 +47926,7 @@ MonoBehaviour:
   notesContainer: {fileID: 25550673}
   eventsContainer: {fileID: 25550674}
   timeSyncController: {fileID: 570484802}
+  uiMode: {fileID: 1799035893}
   useOffsetFromConfig: 1
   useDespawnOffset: 1
   offset: -1
@@ -51996,85 +52079,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1399515393}
   m_CullTransparentMesh: 0
---- !u!21 &1403601285
-Material:
-  serializedVersion: 6
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: Inherited From Round Corners
-  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
-  m_ShaderKeywords: 
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _BumpMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _EmissionMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _MetallicGlossMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _OcclusionMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _SpecGlossMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Ints: []
-    m_Floats:
-    - _AlphaClip: 0
-    - _Blend: 0
-    - _BumpScale: 1
-    - _ColorMask: 15
-    - _Cull: 2
-    - _Cutoff: 0.5
-    - _DstBlend: 0
-    - _GlossMapScale: 1
-    - _Glossiness: 0.5
-    - _GlossyReflections: 1
-    - _Metallic: 0
-    - _OcclusionStrength: 1
-    - _ReceiveShadows: 1
-    - _SmoothnessTextureChannel: 0
-    - _SpecularHighlights: 1
-    - _SrcBlend: 1
-    - _Stencil: 0
-    - _StencilComp: 8
-    - _StencilOp: 0
-    - _StencilReadMask: 255
-    - _StencilWriteMask: 255
-    - _Surface: 0
-    - _UseUIAlphaClip: 0
-    - _WorkflowMode: 1
-    - _ZWrite: 1
-    m_Colors:
-    - _Color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
-    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
-    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
-    - _WidthHeightRadius: {r: 46.281853, g: 16.4, b: 4, a: 0}
-    - _halfSize: {r: 29, g: 10, b: 0, a: 0}
-    - _r: {r: 3, g: 3, b: 3, a: 3}
-    - _rect2props: {r: 0.0000019073486, g: -0.0000038146973, b: 25.455845, a: 25.455845}
-  m_BuildTextureStacks: []
 --- !u!1 &1409107371
 GameObject:
   m_ObjectHideFlags: 0
@@ -62332,6 +62336,7 @@ MonoBehaviour:
   notesContainer: {fileID: 25550673}
   eventsContainer: {fileID: 25550674}
   timeSyncController: {fileID: 570484802}
+  uiMode: {fileID: 1799035893}
   useOffsetFromConfig: 1
   useDespawnOffset: 0
   offset: 4

--- a/Assets/__Scripts/MapEditor/CameraController.cs
+++ b/Assets/__Scripts/MapEditor/CameraController.cs
@@ -89,7 +89,7 @@ public class CameraController : MonoBehaviour, CMInput.ICameraActions {
             z = z < 0 ? 0.25f : 1.8f;
             x = x < 0 ? -2f : x > 0 ? 2f : 0;
 
-            transform.position = new Vector3(x,z,0);
+            transform.position = new Vector3(x,z, -7f);
             transform.rotation = Quaternion.Euler(new Vector3(0,-x,0));
             
             return;

--- a/Assets/__Scripts/MapEditor/Detection/BeatmapObjectCallbackController.cs
+++ b/Assets/__Scripts/MapEditor/Detection/BeatmapObjectCallbackController.cs
@@ -10,6 +10,7 @@ public class BeatmapObjectCallbackController : MonoBehaviour {
     [SerializeField] EventsContainer eventsContainer;
 
     [SerializeField] AudioTimeSyncController timeSyncController;
+    [SerializeField] UIMode uiMode;
 
     [SerializeField] private bool useOffsetFromConfig = true;
     [Tooltip("Whether or not to use the Despawn or Spawn offset from settings.")]
@@ -55,9 +56,22 @@ public class BeatmapObjectCallbackController : MonoBehaviour {
     {
         if (useOffsetFromConfig)
         {
-            if (useDespawnOffset) offset = Settings.Instance.Offset_Despawning * -1;
+            if (useDespawnOffset) offset = (uiMode.selectedMode == UIModeType.PLAYING || uiMode.selectedMode == UIModeType.PREVIEW) ? 0 : Settings.Instance.Offset_Despawning * -1;
+            else if (uiMode.selectedMode == UIModeType.PLAYING || uiMode.selectedMode == UIModeType.PREVIEW)
+            {
+                float songNoteJumpSpeed = BeatSaberSongContainer.Instance.difficultyData.noteJumpMovementSpeed;
+                float bpm = BeatSaberSongContainer.Instance.song.beatsPerMinute;
+                float num = 60f / bpm;
+                float halfJumpDuration = 4;
+                while (songNoteJumpSpeed * num * halfJumpDuration > 18)
+                    halfJumpDuration /= 2;
+                float songNoteJumpStartBeatOffset = BeatSaberSongContainer.Instance.difficultyData.noteJumpStartBeatOffset;
+                //float jumpDistance = songNoteJumpSpeed * num * halfJumpDuration * 2;
+                offset = num * halfJumpDuration * 2;
+            }
             else offset = Settings.Instance.Offset_Spawning;
         }
+        
         if (timeSyncController.IsPlaying) {
             curTime = useAudioTime ? timeSyncController.CurrentSongBeats : timeSyncController.CurrentBeat;
             RecursiveCheckNotes(true, true);

--- a/Assets/__Scripts/MapEditor/EditorScaleController.cs
+++ b/Assets/__Scripts/MapEditor/EditorScaleController.cs
@@ -58,6 +58,29 @@ public class EditorScaleController : MonoBehaviour, CMInput.IEditorScaleActions 
         }
     }
 
+    private void UpdateByUIMode(object mode)
+    {
+        UIModeType selectedMode = (UIModeType)mode;
+        switch (selectedMode)
+        {
+            case UIModeType.NORMAL:
+                SetAccurateEditorScale(Settings.Instance.NoteJumpSpeedForEditorScale);
+                break;
+            case UIModeType.HIDE_UI:
+                SetAccurateEditorScale(Settings.Instance.NoteJumpSpeedForEditorScale);       
+                break;
+            case UIModeType.HIDE_GRIDS:
+                SetAccurateEditorScale(Settings.Instance.NoteJumpSpeedForEditorScale);
+                break;
+            case UIModeType.PREVIEW:              
+                SetAccurateEditorScale(true);
+                break;
+            case UIModeType.PLAYING:             
+                SetAccurateEditorScale(true);
+                break;
+        }
+    }
+
     private void Apply()
     {
         foreach (BeatmapObjectContainerCollection collection in collections)
@@ -82,6 +105,7 @@ public class EditorScaleController : MonoBehaviour, CMInput.IEditorScaleActions 
         Settings.NotifyBySettingName("EditorScale", UpdateEditorScale);
         Settings.NotifyBySettingName("EditorScaleBPMIndependent", RecalcEditorScale);
         Settings.NotifyBySettingName("NoteJumpSpeedForEditorScale", SetAccurateEditorScale);
+        UIMode.NotifyOnUIModeChange(UpdateByUIMode);
 	}
 
     private void OnDestroy()
@@ -89,6 +113,7 @@ public class EditorScaleController : MonoBehaviour, CMInput.IEditorScaleActions 
         Settings.ClearSettingNotifications("EditorScale");
         Settings.ClearSettingNotifications("EditorScaleBPMIndependent");
         Settings.ClearSettingNotifications("NoteJumpSpeedForEditorScale");
+        UIMode.ClearUIModeNotifications();
     }
 
     public void OnDecreaseEditorScale(InputAction.CallbackContext context)

--- a/Assets/__Scripts/MapEditor/UI/UIMode.cs
+++ b/Assets/__Scripts/MapEditor/UI/UIMode.cs
@@ -23,6 +23,8 @@ public class UIMode : MonoBehaviour, CMInput.IUIModeActions
     private MapEditorUI _mapEditorUi;
     private CanvasGroup _canvasGroup;
 
+    private static List<Action<object>> actions = new List<Action<object>>();
+
     private List<TextMeshProUGUI> _modes = new List<TextMeshProUGUI>();
     private Coroutine _slideSelectionCoroutine;
     private Coroutine _showUI;
@@ -61,12 +63,10 @@ public class UIMode : MonoBehaviour, CMInput.IUIModeActions
     public void SetUIMode(int modeID, bool showUIChange = true)
     {
         selectedMode = (UIModeType) modeID;
-        SelectedMode = selectedMode;
         UIModeSwitched?.Invoke(selectedMode);
         selected.SetParent(_modes[modeID].transform, true);
         _slideSelectionCoroutine = StartCoroutine(SlideSelection());
         if(showUIChange) _showUI = StartCoroutine(ShowUI());
-        
         switch (selectedMode)
         {
             case UIModeType.NORMAL:
@@ -88,6 +88,7 @@ public class UIMode : MonoBehaviour, CMInput.IUIModeActions
                 _cameraController.SetLockState(true);
                 break;
         }
+        foreach (Action<object> boy in actions) boy?.Invoke(selectedMode);
     }
 
     private void HideStuff(bool showUI, bool showExtras, bool showMainGrid, bool showCanvases, bool showPlacement)
@@ -222,7 +223,30 @@ public class UIMode : MonoBehaviour, CMInput.IUIModeActions
             SetUIMode(selectedOption);
         }
     }
+
+    /// <summary>
+    /// Attach an <see cref="Action"/> that will be triggered when the UI mode has been changed.
+    /// </summary>
+    public static void NotifyOnUIModeChange(Action<object> callback)
+    {
+        if (callback != null)
+        {
+            actions.Add(callback);
+        }
+    }
+
+    /// <summary>
+    /// Clear all <see cref="Action"/>s associated with a UI mode change
+    /// </summary>
+    public static void ClearUIModeNotifications()
+    {
+        actions.Clear();
+    }
 }
+
+
+
+
 
 /// <inheritdoc />
 public enum UIModeType


### PR DESCRIPTION
Changes a few things in the "preview" and "playing" camera modes only

- Moves the "playing" camera position backwards
- Makes notes disappear instead of going translucent when they pass through the grid
- Sets the spawn offset to something hopefully closer to the in game spawn distance
- Sets the editor scale to accurate mode (But does not change the actual setting as to preserve the users original settings when they go back to a different camera mode)