### PR TITLE
RGB Lighting option affects blocks on grid

### DIFF
--- a/Assets/__Scripts/Map/Events/BeatmapEventContainer.cs
+++ b/Assets/__Scripts/Map/Events/BeatmapEventContainer.cs
@@ -156,7 +156,7 @@ public class BeatmapEventContainer : BeatmapObjectContainer
     {
         if (EventData.LightGradient != null && !EventData.IsUtilityEvent)
         {
-            if (EventData.Value != MapEvent.LightValueOff)
+            if (Settings.Instance.EmulateChromaLite && EventData.Value != MapEvent.LightValueOff)
             {
                 ChangeColor(EventData.LightGradient.StartColor);
                 ChangeBaseColor(EventData.LightGradient.StartColor);

--- a/Assets/__Scripts/Map/Events/EventAppearanceSO.cs
+++ b/Assets/__Scripts/Map/Events/EventAppearanceSO.cs
@@ -111,7 +111,7 @@ public class EventAppearanceSO : ScriptableObject
         {
             color = offColor;
         }
-        if (e.EventData.CustomData?["_color"] != null && e.EventData.Value > 0)
+        if (Settings.Instance.EmulateChromaLite && e.EventData.CustomData?["_color"] != null && e.EventData.Value > 0)
             color = e.EventData.CustomData["_color"];
 
         e.EventModel = Settings.Instance.EventModel;

--- a/Assets/__Scripts/Platforms/PlatformDescriptor.cs
+++ b/Assets/__Scripts/Platforms/PlatformDescriptor.cs
@@ -312,7 +312,7 @@ public class PlatformDescriptor : MonoBehaviour
         }
 
         //Check if it is a PogU new Chroma event
-        if (e.CustomData?.HasKey("_color") ?? (false && Settings.Instance.EmulateChromaLite))
+        if ((e.CustomData?.HasKey("_color") ?? false) && Settings.Instance.EmulateChromaLite)
         {
             mainColor = invertedColor = e.CustomData["_color"];
             chromaCustomColors.Remove(group);

--- a/Assets/__Scripts/Platforms/RotatingLights.cs
+++ b/Assets/__Scripts/Platforms/RotatingLights.cs
@@ -79,7 +79,7 @@ public class RotatingLights : RotatingLightsBase
         //Rotate by Rotation variable
         //In most cases, it is randomized, except in certain environments (see above)
         if (!lockRotation &&
-            (this.speed > 0 || (customData?.HasKey("_preciseSpeed") ?? (false && customData["_preciseSpeed"] >= 0))))
+            (this.speed > 0 || ((customData?.HasKey("_preciseSpeed") ?? false) && customData["_preciseSpeed"] >= 0)))
         {
             transform.Rotate(rotationVector, rotation, Space.Self);
         }


### PR DESCRIPTION
This makes it easier to see the underlying vanilla colours: 
![image](https://user-images.githubusercontent.com/68104413/137124566-152528b8-d685-4d1d-b64b-01a108161730.png)
Also fixing brackets.