### PR TITLE
improvements to the "playing" ui mode (and some other things)

### DIFF
--- a/Assets/_Graphics/Shaders/Editor/Note.shader
+++ b/Assets/_Graphics/Shaders/Editor/Note.shader
@@ -78,6 +78,8 @@ Shader "Custom/Note"
 			#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl"
 			#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/SurfaceInput.hlsl"
 
+			uniform float _EnableNoteSurfaceGridLine = 1;
+
 			struct Attributes
 			{
 				float4 positionOS   : POSITION;
@@ -201,7 +203,7 @@ Shader "Custom/Note"
 				float outlineWidth = UNITY_ACCESS_INSTANCED_PROP(Props, _OutlineWidth);
 				float rotatedZ = abs(IN.rotatedPos.z);
 
-				surfaceData.albedo = (rotatedZ < outlineWidth && isTranslucent < 1) ? interfaceColor : noteColor.rgb;
+				surfaceData.albedo = (_EnableNoteSurfaceGridLine > 0 && rotatedZ < outlineWidth && isTranslucent < 1) ? interfaceColor : noteColor.rgb;
 
 				// For the sake of simplicity I'm not supporting the metallic/specular map or occlusion map
 				// for an example of that see : https://github.com/Unity-Technologies/Graphics/blob/master/com.unity.render-pipelines.universal/Shaders/LitInput.hlsl

--- a/Assets/_Graphics/Shaders/Editor/Obstacle.shader
+++ b/Assets/_Graphics/Shaders/Editor/Obstacle.shader
@@ -29,8 +29,8 @@
             #include "UnityCG.cginc"
 
             // These are global properties and should not be instanced
-            uniform float _EditorScale = 4;
             uniform float _OutsideAlpha = 1;
+            uniform float _ObstacleFadeRadius = 8;
 
             // Define instanced properties
             UNITY_INSTANCING_BUFFER_START(Props)
@@ -147,8 +147,8 @@
                     color = normal * sqrt(mag);
                 }
 
-                float circleRadius = _EditorScale * 2;
                 float fadeSize = UNITY_ACCESS_INSTANCED_PROP(Props, _FadeSize);
+                float circleRadius = _ObstacleFadeRadius - fadeSize;
 
                 float distance = abs(i.rotatedPos.z);
 

--- a/Assets/__Scenes/03_Mapper.unity
+++ b/Assets/__Scenes/03_Mapper.unity
@@ -5745,85 +5745,6 @@ MonoBehaviour:
   Atsc: {fileID: 570484802}
   Tipc: {fileID: 1649845923}
   timelineCanvas: {fileID: 1919095322}
---- !u!21 &203199593
-Material:
-  serializedVersion: 6
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: Inherited From Round Corners
-  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
-  m_ShaderKeywords: 
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _BumpMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _EmissionMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _MetallicGlossMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _OcclusionMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _SpecGlossMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Ints: []
-    m_Floats:
-    - _AlphaClip: 0
-    - _Blend: 0
-    - _BumpScale: 1
-    - _ColorMask: 15
-    - _Cull: 2
-    - _Cutoff: 0.5
-    - _DstBlend: 0
-    - _GlossMapScale: 1
-    - _Glossiness: 0.5
-    - _GlossyReflections: 1
-    - _Metallic: 0
-    - _OcclusionStrength: 1
-    - _ReceiveShadows: 1
-    - _SmoothnessTextureChannel: 0
-    - _SpecularHighlights: 1
-    - _SrcBlend: 1
-    - _Stencil: 0
-    - _StencilComp: 8
-    - _StencilOp: 0
-    - _StencilReadMask: 255
-    - _StencilWriteMask: 255
-    - _Surface: 0
-    - _UseUIAlphaClip: 0
-    - _WorkflowMode: 1
-    - _ZWrite: 1
-    m_Colors:
-    - _Color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
-    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
-    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
-    - _WidthHeightRadius: {r: 37, g: 14, b: 2, a: 0}
-    - _halfSize: {r: 29, g: 10, b: 0, a: 0}
-    - _r: {r: 3, g: 3, b: 3, a: 3}
-    - _rect2props: {r: 0.0000019073486, g: -0.0000038146973, b: 25.455845, a: 25.455845}
-  m_BuildTextureStacks: []
 --- !u!1 &210755191
 GameObject:
   m_ObjectHideFlags: 0
@@ -19752,6 +19673,85 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 654366148}
   m_CullTransparentMesh: 0
+--- !u!21 &657023920
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Inherited From Round Corners
+  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AlphaClip: 0
+    - _Blend: 0
+    - _BumpScale: 1
+    - _ColorMask: 15
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _ReceiveShadows: 1
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _Surface: 0
+    - _UseUIAlphaClip: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+    - _WidthHeightRadius: {r: 37, g: 14, b: 2, a: 0}
+    - _halfSize: {r: 29, g: 10, b: 0, a: 0}
+    - _r: {r: 3, g: 3, b: 3, a: 3}
+    - _rect2props: {r: 0.0000019073486, g: -0.0000038146973, b: 25.455845, a: 25.455845}
+  m_BuildTextureStacks: []
 --- !u!1 &657854459
 GameObject:
   m_ObjectHideFlags: 0
@@ -25397,85 +25397,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 838757516}
   m_CullTransparentMesh: 0
---- !u!21 &840669148
-Material:
-  serializedVersion: 6
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: Inherited From Round Corners
-  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
-  m_ShaderKeywords: 
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _BumpMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _EmissionMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _MetallicGlossMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _OcclusionMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _SpecGlossMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Ints: []
-    m_Floats:
-    - _AlphaClip: 0
-    - _Blend: 0
-    - _BumpScale: 1
-    - _ColorMask: 15
-    - _Cull: 2
-    - _Cutoff: 0.5
-    - _DstBlend: 0
-    - _GlossMapScale: 1
-    - _Glossiness: 0.5
-    - _GlossyReflections: 1
-    - _Metallic: 0
-    - _OcclusionStrength: 1
-    - _ReceiveShadows: 1
-    - _SmoothnessTextureChannel: 0
-    - _SpecularHighlights: 1
-    - _SrcBlend: 1
-    - _Stencil: 0
-    - _StencilComp: 8
-    - _StencilOp: 0
-    - _StencilReadMask: 255
-    - _StencilWriteMask: 255
-    - _Surface: 0
-    - _UseUIAlphaClip: 0
-    - _WorkflowMode: 1
-    - _ZWrite: 1
-    m_Colors:
-    - _Color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
-    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
-    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
-    - _WidthHeightRadius: {r: 34.4, g: 16.4, b: 4, a: 0}
-    - _halfSize: {r: 29, g: 10, b: 0, a: 0}
-    - _r: {r: 3, g: 3, b: 3, a: 3}
-    - _rect2props: {r: 0.0000019073486, g: -0.0000038146973, b: 25.455845, a: 25.455845}
-  m_BuildTextureStacks: []
 --- !u!1 &843763612
 GameObject:
   m_ObjectHideFlags: 0
@@ -28624,8 +28545,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 13585791}
   m_HandleRect: {fileID: 13585789}
   m_Direction: 2
-  m_Value: 0
-  m_Size: 0.9999999
+  m_Value: 1
+  m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -51484,6 +51405,85 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+--- !u!21 &1691679805
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Inherited From Round Corners
+  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AlphaClip: 0
+    - _Blend: 0
+    - _BumpScale: 1
+    - _ColorMask: 15
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _ReceiveShadows: 1
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _Surface: 0
+    - _UseUIAlphaClip: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+    - _WidthHeightRadius: {r: 34.4, g: 16.4, b: 4, a: 0}
+    - _halfSize: {r: 29, g: 10, b: 0, a: 0}
+    - _r: {r: 3, g: 3, b: 3, a: 3}
+    - _rect2props: {r: 0.0000019073486, g: -0.0000038146973, b: 25.455845, a: 25.455845}
+  m_BuildTextureStacks: []
 --- !u!1 &1695690031
 GameObject:
   m_ObjectHideFlags: 0
@@ -54314,6 +54314,7 @@ MonoBehaviour:
   - {fileID: 617466177}
   - {fileID: 1125491375}
   - {fileID: 565602430}
+  - {fileID: 866552293}
   rotationCallbackController: {fileID: 226696885}
   atsc: {fileID: 570484802}
   Keybind: Ctrl+H

--- a/Assets/__Scripts/Map/Obstacles/BeatmapObstacleContainer.cs
+++ b/Assets/__Scripts/Map/Obstacles/BeatmapObstacleContainer.cs
@@ -48,17 +48,11 @@ public class BeatmapObstacleContainer : BeatmapObjectContainer
         //Take half jump duration into account if the setting is enabled.
         if (ObstacleData.Duration < 0 && Settings.Instance.ShowMoreAccurateFastWalls)
         {
-            var num = 60f / BeatSaberSongContainer.Instance.Song.BeatsPerMinute;
-            float halfJumpDuration = 4;
+            var bpm = BeatSaberSongContainer.Instance.Song.BeatsPerMinute;
             var songNoteJumpSpeed = BeatSaberSongContainer.Instance.DifficultyData.NoteJumpMovementSpeed;
             var songStartBeatOffset = BeatSaberSongContainer.Instance.DifficultyData.NoteJumpStartBeatOffset;
 
-            while (songNoteJumpSpeed * num * halfJumpDuration > 18)
-                halfJumpDuration /= 2;
-
-            halfJumpDuration += songStartBeatOffset;
-
-            if (halfJumpDuration < 0.25f) halfJumpDuration = 0.25f;
+            var halfJumpDuration = SpawnParameterHelper.CalculateHalfJumpDuration(songNoteJumpSpeed, songStartBeatOffset, bpm);
 
             duration -= duration * Mathf.Abs(duration / halfJumpDuration);
         }

--- a/Assets/__Scripts/Map/SpawnParameterHelper.cs
+++ b/Assets/__Scripts/Map/SpawnParameterHelper.cs
@@ -1,6 +1,4 @@
-﻿using UnityEngine;
-
-public class SpawnParameterHelper : MonoBehaviour
+﻿public static class SpawnParameterHelper
 {
     public static float CalculateHalfJumpDuration(float noteJumpSpeed, float startBeatOffset, float bpm) {
         var halfJumpDuration = 4f;

--- a/Assets/__Scripts/Map/SpawnParameterHelper.cs
+++ b/Assets/__Scripts/Map/SpawnParameterHelper.cs
@@ -1,0 +1,24 @@
+﻿using UnityEngine;
+
+public class SpawnParameterHelper : MonoBehaviour
+{
+    public static float CalculateHalfJumpDuration(float noteJumpSpeed, float startBeatOffset, float bpm) {
+        var halfJumpDuration = 4f;
+        var num = 60 / bpm;
+
+        while (noteJumpSpeed * num * halfJumpDuration > 18)
+            halfJumpDuration /= 2;
+
+        halfJumpDuration += startBeatOffset;
+
+        if (halfJumpDuration < 0.25f) halfJumpDuration = 0.25f;
+
+        return halfJumpDuration;
+    }
+
+    public static float CalculateJumpDistance(float noteJumpSpeed, float startBeatOffset, float bpm)
+    {
+        var num = 60 / bpm;
+        return CalculateHalfJumpDuration(noteJumpSpeed, startBeatOffset, bpm) * num * noteJumpSpeed * 2;
+    }
+}

--- a/Assets/__Scripts/Map/SpawnParameterHelper.cs.meta
+++ b/Assets/__Scripts/Map/SpawnParameterHelper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 893d576b4dc9f6c4284a99a8d981261f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/__Scripts/MapEditor/CameraController.cs
+++ b/Assets/__Scripts/MapEditor/CameraController.cs
@@ -81,7 +81,6 @@ public class CameraController : MonoBehaviour, CMInput.ICameraActions
 
         if (UIMode.SelectedMode == UIModeType.Playing)
         {
-            SetLockState(true);
             var posY = z < 0 ? 0.25f : 1.8f;
             var posX = x < 0 ? -2f : x > 0 ? 2f : 0;
 

--- a/Assets/__Scripts/MapEditor/CameraController.cs
+++ b/Assets/__Scripts/MapEditor/CameraController.cs
@@ -84,7 +84,7 @@ public class CameraController : MonoBehaviour, CMInput.ICameraActions
             var posY = z < 0 ? 0.25f : 1.8f;
             var posX = x < 0 ? -2f : x > 0 ? 2f : 0;
 
-            transform.SetPositionAndRotation(new Vector3(posX, posY, -7), Quaternion.Euler(new Vector3(0, -posX, 0)));
+            transform.SetPositionAndRotation(new Vector3(posX, posY, -6), Quaternion.Euler(new Vector3(0, -posX, 0)));
 
             return;
         }

--- a/Assets/__Scripts/MapEditor/CameraController.cs
+++ b/Assets/__Scripts/MapEditor/CameraController.cs
@@ -81,6 +81,7 @@ public class CameraController : MonoBehaviour, CMInput.ICameraActions
 
         if (UIMode.SelectedMode == UIModeType.Playing)
         {
+            SetLockState(true);
             var posY = z < 0 ? 0.25f : 1.8f;
             var posX = x < 0 ? -2f : x > 0 ? 2f : 0;
 

--- a/Assets/__Scripts/MapEditor/CameraController.cs
+++ b/Assets/__Scripts/MapEditor/CameraController.cs
@@ -81,10 +81,10 @@ public class CameraController : MonoBehaviour, CMInput.ICameraActions
 
         if (UIMode.SelectedMode == UIModeType.Playing)
         {
-            z = z < 0 ? 0.25f : 1.8f;
-            x = x < 0 ? -2f : x > 0 ? 2f : 0;
+            var posY = z < 0 ? 0.25f : 1.8f;
+            var posX = x < 0 ? -2f : x > 0 ? 2f : 0;
 
-            transform.SetPositionAndRotation(new Vector3(x, z, -7), Quaternion.Euler(new Vector3(0, -x, 0)));
+            transform.SetPositionAndRotation(new Vector3(posX, posY, -7), Quaternion.Euler(new Vector3(0, -posX, 0)));
 
             return;
         }

--- a/Assets/__Scripts/MapEditor/Detection/BeatmapObjectCallbackController.cs
+++ b/Assets/__Scripts/MapEditor/Detection/BeatmapObjectCallbackController.cs
@@ -72,6 +72,8 @@ public class BeatmapObjectCallbackController : MonoBehaviour
                     ? Settings.Instance.Offset_Despawning * -1
                     : Settings.Instance.Offset_Spawning;
             }
+
+            if (!useDespawnOffset) Shader.SetGlobalFloat("_ObstacleFadeRadius", Offset * EditorScaleController.EditorScale);
         }
 
         if (timeSyncController.IsPlaying)

--- a/Assets/__Scripts/MapEditor/Detection/BeatmapObjectCallbackController.cs
+++ b/Assets/__Scripts/MapEditor/Detection/BeatmapObjectCallbackController.cs
@@ -60,16 +60,10 @@ public class BeatmapObjectCallbackController : MonoBehaviour
                 }
                 else
                 {
-
                     var songNoteJumpSpeed = BeatSaberSongContainer.Instance.DifficultyData.NoteJumpMovementSpeed;
+                    var songStartBeatOffset = BeatSaberSongContainer.Instance.DifficultyData.NoteJumpStartBeatOffset;
                     var bpm = BeatSaberSongContainer.Instance.Song.BeatsPerMinute;
-                    var num = 60f / bpm;
-                    var halfJumpDuration = 4;
-
-                    while (songNoteJumpSpeed * num * halfJumpDuration > 18)
-                        halfJumpDuration /= 2;
-
-                    Offset = num * halfJumpDuration * 2;
+                    Offset = SpawnParameterHelper.CalculateHalfJumpDuration(songNoteJumpSpeed, songStartBeatOffset, bpm);
                 }
             }
             else

--- a/Assets/__Scripts/MapEditor/UI/UIMode.cs
+++ b/Assets/__Scripts/MapEditor/UI/UIMode.cs
@@ -56,6 +56,8 @@ public class UIMode : MonoBehaviour, CMInput.IUIModeActions
             if (r.Length != 0) renderers.AddRange(r);
             else canvases.AddRange(go.GetComponentsInChildren<Canvas>());
         }
+
+        atsc.PlayToggle += OnPlayToggle;
     }
 
     public void OnToggleUIMode(InputAction.CallbackContext context)
@@ -93,6 +95,21 @@ public class UIMode : MonoBehaviour, CMInput.IUIModeActions
         }
     }
 
+    private void OnPlayToggle(bool playing)
+    {
+        if (SelectedMode == UIModeType.Playing)
+        {
+            foreach (var group in mapEditorUi.MainUIGroup)
+            {
+                if (group.name == "Song Timeline")
+                {
+                    mapEditorUi.ToggleUIVisible(!playing, group);
+                }
+            }
+            cameraController.SetLockState(playing);
+        }
+    }
+
     public void SetUIMode(UIModeType mode, bool showUIChange = true) => SetUIMode((int)mode, showUIChange);
 
     public void SetUIMode(int modeID, bool showUIChange = true)
@@ -115,8 +132,11 @@ public class UIMode : MonoBehaviour, CMInput.IUIModeActions
                 HideStuff(false, false, true, true, true);
                 break;
             case UIModeType.Preview:
+                HideStuff(false, false, false, false, false);
+                break;
             case UIModeType.Playing:
                 HideStuff(false, false, false, false, false);
+                OnPlayToggle(atsc.IsPlaying); // kinda jank but it works
                 break;
         }
 

--- a/Assets/__Scripts/MapEditor/UI/UIMode.cs
+++ b/Assets/__Scripts/MapEditor/UI/UIMode.cs
@@ -107,8 +107,9 @@ public class UIMode : MonoBehaviour, CMInput.IUIModeActions
                     mapEditorUi.ToggleUIVisible(!playing, group);
                 }
             }
-            cameraController.SetLockState(playing);
         }
+
+        if (SelectedMode == UIModeType.Playing) cameraController.SetLockState(playing);
     }
 
     public void SetUIMode(UIModeType mode, bool showUIChange = true) => SetUIMode((int)mode, showUIChange);

--- a/Assets/__Scripts/MapEditor/UI/UIMode.cs
+++ b/Assets/__Scripts/MapEditor/UI/UIMode.cs
@@ -98,7 +98,7 @@ public class UIMode : MonoBehaviour, CMInput.IUIModeActions
 
     private void OnPlayToggle(bool playing)
     {
-        if (SelectedMode == UIModeType.Playing)
+        if (SelectedMode == UIModeType.Playing || SelectedMode == UIModeType.Preview)
         {
             foreach (var group in mapEditorUi.MainUIGroup)
             {
@@ -133,8 +133,6 @@ public class UIMode : MonoBehaviour, CMInput.IUIModeActions
                 HideStuff(false, false, true, true, true);
                 break;
             case UIModeType.Preview:
-                HideStuff(false, false, false, false, false);
-                break;
             case UIModeType.Playing:
                 HideStuff(false, false, false, false, false);
                 OnPlayToggle(atsc.IsPlaying); // kinda jank but it works

--- a/Assets/__Scripts/MapEditor/UI/UIMode.cs
+++ b/Assets/__Scripts/MapEditor/UI/UIMode.cs
@@ -200,34 +200,26 @@ public class UIMode : MonoBehaviour, CMInput.IUIModeActions
     {
         if (showUI != null) StopCoroutine(showUI);
 
-        var startTime = Time.time;
-        while (true)
-        {
-            if (canvasGroup.alpha >= 0.98f)
-            {
-                canvasGroup.alpha = 1f;
-                break;
-            }
+        const float transitionTime = 0.2f;
+        const float delayTime = 1f;
 
-            var alpha = canvasGroup.alpha;
-            alpha = Mathf.Lerp(alpha, 1, Time.time / startTime * 0.1f);
-            canvasGroup.alpha = alpha;
+        var startTime = Time.time;
+        var startAlpha = canvasGroup.alpha;
+        while (canvasGroup.alpha != 1f)
+        {
+            var t = Mathf.Clamp01((Time.time - startTime) / transitionTime);
+            canvasGroup.alpha = Mathf.Lerp(startAlpha, 1, t);
             yield return new WaitForFixedUpdate();
         }
 
-        yield return new WaitForSeconds(3);
+        yield return new WaitForSeconds(delayTime);
 
-        while (true)
+        startTime = Time.time;
+        startAlpha = canvasGroup.alpha;
+        while (canvasGroup.alpha != 0)
         {
-            if (canvasGroup.alpha <= 0.05f)
-            {
-                canvasGroup.alpha = 0f;
-                break;
-            }
-
-            var alpha = canvasGroup.alpha;
-            alpha = Mathf.Lerp(alpha, 0, Time.time / startTime * 0.1f);
-            canvasGroup.alpha = alpha;
+            var t = Mathf.Clamp01((Time.time - startTime) / transitionTime);
+            canvasGroup.alpha = Mathf.Lerp(startAlpha, 0, t);
             yield return new WaitForFixedUpdate();
         }
     }
@@ -236,20 +228,15 @@ public class UIMode : MonoBehaviour, CMInput.IUIModeActions
     {
         if (slideSelectionCoroutine != null) StopCoroutine(slideSelectionCoroutine);
 
+        const float transitionTime = 0.5f;
+
         var startTime = Time.time;
-
-        while (true)
+        var startLocalPosition = selected.localPosition;
+        while (selected.localPosition.x != 0)
         {
-            var localPosition = selected.localPosition;
-            localPosition = Vector3.Lerp(localPosition, Vector3.zero, Time.time / startTime * 0.15f);
-            selected.localPosition = localPosition;
-            if (Math.Abs(selected.localPosition.x) < 0.001f)
-            {
-                localPosition.x = 0;
-                selected.localPosition = localPosition;
-                break;
-            }
-
+            var x = Mathf.Clamp01((Time.time - startTime) / transitionTime);
+            var t = 1 - Mathf.Pow(1 - x, 3); // cubic interpolation because linear looks bad
+            selected.localPosition = Vector3.Lerp(startLocalPosition, Vector3.zero, t);
             yield return new WaitForFixedUpdate();
         }
     }

--- a/Assets/__Scripts/MapEditor/UI/UIMode.cs
+++ b/Assets/__Scripts/MapEditor/UI/UIMode.cs
@@ -58,6 +58,7 @@ public class UIMode : MonoBehaviour, CMInput.IUIModeActions
         }
 
         atsc.PlayToggle += OnPlayToggle;
+        Shader.SetGlobalFloat("_EnableNoteSurfaceGridLine", 1f);
     }
 
     public void OnToggleUIMode(InputAction.CallbackContext context)
@@ -156,6 +157,7 @@ public class UIMode : MonoBehaviour, CMInput.IUIModeActions
 
         if (showPlacement)
         {
+            Shader.SetGlobalFloat("_EnableNoteSurfaceGridLine", 1f);
             foreach (var s in thingsThatRequireAMoveForPreview)
             {
                 var t = s.transform;
@@ -171,6 +173,7 @@ public class UIMode : MonoBehaviour, CMInput.IUIModeActions
         }
         else
         {
+            Shader.SetGlobalFloat("_EnableNoteSurfaceGridLine", 0f);
             foreach (var s in thingsThatRequireAMoveForPreview)
             {
                 var t = s.transform;

--- a/Assets/__Scripts/UI/MapEditorUI.cs
+++ b/Assets/__Scripts/UI/MapEditorUI.cs
@@ -44,7 +44,7 @@ public class MapEditorUI : MonoBehaviour
         group.blocksRaycasts = visible;
     }
 
-    private IEnumerator FadeCanvasGroup(CanvasGroup group, float start, float end, float time = 1f)
+    private IEnumerator FadeCanvasGroup(CanvasGroup group, float start, float end, float time = 0.2f)
     {
         Coroutine c = null;
         if (canvasFadeCoroutines.ContainsKey(group)) c = canvasFadeCoroutines[group];
@@ -56,7 +56,7 @@ public class MapEditorUI : MonoBehaviour
             if (t > 1) t = 1;
             group.alpha = Mathf.MoveTowards(start, end, t);
             yield return new WaitForEndOfFrame();
-            if (group.alpha == 1f || group.alpha == 0f) break;
+            if (group.alpha == end) break;
         }
     }
 }

--- a/Assets/__Scripts/UI/SongEditMenu/DifficultyInfo.cs
+++ b/Assets/__Scripts/UI/SongEditMenu/DifficultyInfo.cs
@@ -21,17 +21,12 @@ public class DifficultyInfo : MonoBehaviour
     private void UpdateValues()
     {
         float.TryParse(bpmField.text, out var bpm);
-        var num = 60f / bpm;
-        float halfJumpDuration = 4;
         float.TryParse(njsField.text, out var songNoteJumpSpeed);
         float.TryParse(songBeatOffsetField.text, out var songStartBeatOffset);
 
-        while (songNoteJumpSpeed * num * halfJumpDuration > 18)
-            halfJumpDuration /= 2;
+        var halfJumpDuration = SpawnParameterHelper.CalculateHalfJumpDuration(songNoteJumpSpeed, songStartBeatOffset, bpm);
 
-        halfJumpDuration += songStartBeatOffset;
-
-        if (halfJumpDuration < 0.25f) halfJumpDuration = 0.25f;
+        var num = 60 / bpm;
         var jumpDistance = songNoteJumpSpeed * num * halfJumpDuration * 2;
 
         halfJumpDurationField.text = halfJumpDuration.ToString();


### PR DESCRIPTION
- Fixes the crouch keybind in playing mode (defaults to S)
- Saves and restores the camera position when going in and out of playing mode
- Fixes the spawn offset calculation (and moved HJD calculation code to helper class)
- Shows the song timeline when paused (in playing and preview modes)
- UI fade transition times reduced to 0.2 seconds (from 1 second)
- Disables grid line on the surface of notes when the placement grid is not visible
- Obstacle fade distance during playback now follows the spawn offset for notes
- Camera z-position tweaked in playing mode (from -7 to -6)