### PR TITLE
fix input fields in dialog boxes sometimes not being selected properly

### DIFF
--- a/Assets/__Scripts/UI/CM_InputBox.cs
+++ b/Assets/__Scripts/UI/CM_InputBox.cs
@@ -59,8 +59,11 @@ public class CM_InputBox : MenuBase
         yield return new WaitForSeconds(0.25f);
         group.interactable = visible;
 
+        // Clear selection first to avoid issues with repeated selection of the same object
+        EventSystem.current.SetSelectedGameObject(null);
+
         // Set focus to input field
-        EventSystem.current.SetSelectedGameObject(inputField.gameObject, new BaseEventData(EventSystem.current));
+        EventSystem.current.SetSelectedGameObject(inputField.gameObject);
     }
 
     public override void OnTab(InputAction.CallbackContext context)


### PR DESCRIPTION
This issue occurs when repeatedly placing bookmarks. The input box doesn't get selected even though the method is called.
I'm assuming this happens because the same game object is selected twice in a row, resulting in the events not being sent properly.
A working solution seems to be to set the selected game object to null first.