### PR TITLE
trackpad scrolling improvements

### DIFF
--- a/Assets/__Scripts/MapEditor/AudioTimeSyncController.cs
+++ b/Assets/__Scripts/MapEditor/AudioTimeSyncController.cs
@@ -220,14 +220,17 @@ public class AudioTimeSyncController : MonoBehaviour, CMInput.IPlaybackActions, 
 
                 var scrollSize = value / scrollSizeDivisor;
                 internalScrollStepCounter += scrollSize;
-                if (Mathf.Abs(internalScrollStepCounter) >= 0.5f)
+
+                // +1 beat if we're going forward, -1 beat if we're going backwards
+                var direction = Mathf.Sign(internalScrollStepCounter);
+                var beatShiftRaw = 0f;
+                while (Mathf.Abs(internalScrollStepCounter) >= 0.5f)
                 {
-                    // +1 beat if we're going forward, -1 beat if we're going backwards
-                    var direction = value > 0 ? 1f : -1f;
-                    var beatShiftRaw = 1f / GridMeasureSnapping * direction;
-                    MoveToTimeInBeats(CurrentBeat + bpmChangesContainer.LocalBeatsToSongBeats(beatShiftRaw, CurrentBeat));
+                    beatShiftRaw += 1f / GridMeasureSnapping * direction;
                     internalScrollStepCounter -= direction;
                 }
+
+                MoveToTimeInBeats(CurrentBeat + bpmChangesContainer.LocalBeatsToSongBeats(beatShiftRaw, CurrentBeat));
 
                 if (resetScrollCounterCoroutine != null) StopCoroutine(resetScrollCounterCoroutine);
                 resetScrollCounterCoroutine = StartCoroutine(ResetInternalScrollStepCounter());


### PR DESCRIPTION
Submitting this as a draft for now. This is an initial implementation of improved trackpad scrolling. It does this by accounting for the size of the scroll value and keeping track with an internal counter. This changes trackpad scrolling from uncontrollably fast to natural and adaptive.

To do:
- [ ] Verify the correct `scrollSizeDivisor` on macOS (will need outside help for this)
- [ ] Verify that scrolling with regular mouse wheels is not impacted in any way
- [ ] Add similar logic to scrolling the cursor precision (Ctrl+Scroll)
- [ ] (Potentially) add a settings toggle
- [ ] (Potentially) add a scroll speed scalar setting
- [ ] (Potentially) add some visualization for the internal scroll step counter