### PR TITLE
account for playback speed when using audio latency compensation

### DIFF
--- a/Assets/__Scripts/MapEditor/AudioTimeSyncController.cs
+++ b/Assets/__Scripts/MapEditor/AudioTimeSyncController.cs
@@ -119,7 +119,7 @@ public class AudioTimeSyncController : MonoBehaviour, CMInput.IPlaybackActions, 
             if (!levelLoaded) return;
             if (IsPlaying)
             {
-                var time = currentSeconds + audioLatencyCompensationSeconds;
+                var time = currentSeconds + (audioLatencyCompensationSeconds * (songSpeed / 10f));
 
                 // Slightly more accurate than songAudioSource.time
                 var trackTime = CurrentSongSeconds;
@@ -145,7 +145,7 @@ public class AudioTimeSyncController : MonoBehaviour, CMInput.IPlaybackActions, 
 
                 // Add frame time to current time
                 CurrentSeconds = time + (correction * (Time.deltaTime * (songSpeed / 10f))) -
-                                 audioLatencyCompensationSeconds;
+                                 (audioLatencyCompensationSeconds * (songSpeed / 10f));
             }
         }
         catch (Exception e)
@@ -272,7 +272,7 @@ public class AudioTimeSyncController : MonoBehaviour, CMInput.IPlaybackActions, 
             SongAudioSource.Play();
 
             audioLatencyCompensationSeconds = Settings.Instance.AudioLatencyCompensation / 1000f;
-            CurrentSeconds -= audioLatencyCompensationSeconds;
+            CurrentSeconds -= audioLatencyCompensationSeconds * (songSpeed / 10f);
         }
         else
         {


### PR DESCRIPTION
I return once more to repent for my sins.

This still isn't ideal behavior since the grid visibly jumps around in time, but it doesn't seem to actually cause things to break.

Ideally you would apply playback speed changes only after some time has passed (equal to the amount of compensation) but that would be a lot more difficult to implement.