### PR TITLE
update max jump duration in HJD calculation

### DIFF
--- a/Assets/__Scripts/Map/SpawnParameterHelper.cs
+++ b/Assets/__Scripts/Map/SpawnParameterHelper.cs
@@ -4,7 +4,7 @@
         var halfJumpDuration = 4f;
         var num = 60 / bpm;
 
-        while (noteJumpSpeed * num * halfJumpDuration > 18)
+        while (noteJumpSpeed * num * halfJumpDuration > 17.999f)
             halfJumpDuration /= 2;
 
         halfJumpDuration += startBeatOffset;


### PR DESCRIPTION
In a recent game update this was changed from 36 to 35.998, presumably to combat the 36 JD bug