### PR TITLE
fix floating point errors introduced to atsc.CurrentBeat when changing editor scale

### DIFF
--- a/Assets/__Scripts/MapEditor/EditorScaleController.cs
+++ b/Assets/__Scripts/MapEditor/EditorScaleController.cs
@@ -116,7 +116,7 @@ public class EditorScaleController : MonoBehaviour, CMInput.IEditorScaleActions
                 b.UpdateGridPosition();
         }
 
-        atsc.MoveToTimeInSeconds(atsc.CurrentSeconds);
+        atsc.MoveToTimeInBeats(atsc.CurrentBeat);
         EditorScaleChangedEvent?.Invoke(EditorScale);
         previousEditorScale = EditorScale;
         foreach (var offset in scalingOffsets)


### PR DESCRIPTION
This fixes an annoying bug I've been chasing for a while where for seemingly no reason I was placing notes slightly off-grid.
EditorScaleController calls `atsc.MoveToTimeInSeconds`, changing this to `MoveToTimeInBeats` avoids introducing floating point errors.