### PR TITLE
Don't yeet lightId from env enhancements

### DIFF
--- a/Assets/__Scripts/UI/SongEditMenu/EnvEnhancement.cs
+++ b/Assets/__Scripts/UI/SongEditMenu/EnvEnhancement.cs
@@ -32,11 +32,7 @@ public class EnvEnhancement
         localPosition = ReadVector3OrNull(node, "_localPosition");
         rotation = ReadVector3OrNull(node, "_rotation");
         localRotation = ReadVector3OrNull(node, "_localRotation");
-        lightID = node.HasKey("_lightID") && !node["_lightID"].IsNull
-            ? node["_lightID"].AsInt
-            : node.HasKey("_lightId") && !node["_lightId"].IsNull 
-                ? node["_lightId"].AsInt 
-                : (int?)null;
+        lightID = !node.HasKey("_lightID") || node["_lightID"].IsNull ? (int?)null : node["_lightID"].AsInt;
         track = node["_track"].Value;
     }
 
@@ -71,7 +67,7 @@ public class EnvEnhancement
         WriteVector3(node, "_localPosition", localPosition);
         WriteVector3(node, "_rotation", rotation);
         WriteVector3(node, "_localRotation", localRotation);
-        if (lightID.HasValue) node["_lightId"] = lightID.Value;
+        if (lightID.HasValue) node["_lightID"] = lightID.Value;
         if (!string.IsNullOrEmpty(track)) node["_track"] = track;
 
         return node;

--- a/Assets/__Scripts/UI/SongEditMenu/EnvEnhancement.cs
+++ b/Assets/__Scripts/UI/SongEditMenu/EnvEnhancement.cs
@@ -12,6 +12,7 @@ public class EnvEnhancement
     private ELookupMethod lookupMethod;
     private Vector3? position;
     private Vector3? rotation;
+    private int? lightID;
 
     private Vector3? scale;
 
@@ -31,6 +32,11 @@ public class EnvEnhancement
         localPosition = ReadVector3OrNull(node, "_localPosition");
         rotation = ReadVector3OrNull(node, "_rotation");
         localRotation = ReadVector3OrNull(node, "_localRotation");
+        lightID = node.HasKey("_lightID") && !node["_lightID"].IsNull
+            ? node["_lightID"].AsInt
+            : node.HasKey("_lightId") && !node["_lightId"].IsNull 
+                ? node["_lightId"].AsInt 
+                : (int?)null;
         track = node["_track"].Value;
     }
 
@@ -65,6 +71,7 @@ public class EnvEnhancement
         WriteVector3(node, "_localPosition", localPosition);
         WriteVector3(node, "_rotation", rotation);
         WriteVector3(node, "_localRotation", localRotation);
+        if (lightID.HasValue) node["_lightId"] = lightID.Value;
         if (!string.IsNullOrEmpty(track)) node["_track"] = track;
 
         return node;
@@ -81,6 +88,7 @@ public class EnvEnhancement
             localPosition = localPosition,
             rotation = rotation,
             localRotation = localRotation,
+            lightID = lightID,
             track = track
         };
 
@@ -89,7 +97,8 @@ public class EnvEnhancement
         active == other.active && Nullable.Equals(scale, other.scale) &&
         Nullable.Equals(position, other.position) && Nullable.Equals(localPosition, other.localPosition) &&
         Nullable.Equals(rotation, other.rotation) &&
-        Nullable.Equals(localRotation, other.localRotation) && track == other.track;
+        Nullable.Equals(localRotation, other.localRotation) && 
+        Nullable.Equals(lightID, other.lightID) && track == other.track;
 
     public override bool Equals(object obj)
     {
@@ -112,6 +121,7 @@ public class EnvEnhancement
             hashCode = (hashCode * 397) ^ localPosition.GetHashCode();
             hashCode = (hashCode * 397) ^ rotation.GetHashCode();
             hashCode = (hashCode * 397) ^ localRotation.GetHashCode();
+            hashCode = (hashCode * 397) ^ lightID.GetHashCode();
             hashCode = (hashCode * 397) ^ (track != null ? track.GetHashCode() : 0);
             return hashCode;
         }


### PR DESCRIPTION
Apparently `_lightID` and `_lightId` both work, so using `_lightId` because that's what documentation says.