### PR TITLE
Basic V3 rotation event support 

### DIFF
--- a/Assets/__Scripts/Map/BeatSaberMapV3.cs
+++ b/Assets/__Scripts/Map/BeatSaberMapV3.cs
@@ -328,7 +328,6 @@ public class BeatSaberMapV3 : BeatSaberMap
         Events = BasicBeatmapEvents.OfType<MapEvent>().ToList();
         Events.AddRange(ColorBoostBeatmapEvents.OfType<MapEvent>().ToList());
         Events.AddRange(RotationEvents.OfType<MapEvent>().ToList());
-        foreach(var e in Events) {if (e is RotationEvent ee) Debug.Log($"Rotation {ee.RotationAmount} has event value is {ee.Value}");}
         Events.Sort((lhs, rhs) => { return lhs.Time.CompareTo(rhs.Time); });
     }
 }

--- a/Assets/__Scripts/Map/BeatSaberMapV3.cs
+++ b/Assets/__Scripts/Map/BeatSaberMapV3.cs
@@ -15,7 +15,7 @@ public class BeatSaberMapV3 : BeatSaberMap
     /// All Lists of type JSONNode are unsupported
     /// </summary>
     public List<JSONNode> BpmEvents = new List<JSONNode>(); // disable supprot for bpm change
-    public List<JSONNode> RotationEvents = new List<JSONNode>();
+    public List<RotationEvent> RotationEvents = new List<RotationEvent>();
     public List<BeatmapColorNote> ColorNotes = new List<BeatmapColorNote>();
     public List<BeatmapBombNote> BombNotes = new List<BeatmapBombNote>();
     public List<BeatmapObstacleV3> ObstaclesV3 = new List<BeatmapObstacleV3>();
@@ -73,7 +73,7 @@ public class BeatSaberMapV3 : BeatSaberMap
             foreach (var b in BpmEvents) bpmEvents.Add(b);
 
             var rotationEvents = new JSONArray();
-            foreach (var b in RotationEvents) RotationEvents.Add(b);
+            foreach (var r in RotationEvents) rotationEvents.Add(r.ConvertToJson());
 
             var colorNotes = new JSONArray();
             foreach (var n in ColorNotes) colorNotes.Add(n.ConvertToJson());
@@ -159,7 +159,7 @@ public class BeatSaberMapV3 : BeatSaberMap
 
             var eventsList = new List<MapEvent>();
             var bpmEventsList = new List<JSONNode>();
-            var rotationEventsList = new List<JSONNode>();
+            var rotationEventsList = new List<RotationEvent>();
             var colorNotesList = new List<BeatmapColorNote>();
             var bombNotesList = new List<BeatmapBombNote>();
             var arcsList = new List<BeatmapArc>();
@@ -188,7 +188,7 @@ public class BeatSaberMapV3 : BeatSaberMap
                         foreach (JSONNode n in node) bpmEventsList.Add(n);
                         break;
                     case "rotationEvents":
-                        foreach (JSONNode n in node) rotationEventsList.Add(n);
+                        foreach (JSONNode n in node) rotationEventsList.Add(new RotationEvent(n));
                         break;
                     case "colorNotes":
                         foreach (JSONNode n in node) colorNotesList.Add(new BeatmapColorNote(n));
@@ -295,12 +295,17 @@ public class BeatSaberMapV3 : BeatSaberMap
 
         BasicBeatmapEvents.Clear();
         ColorBoostBeatmapEvents.Clear();
+        RotationEvents.Clear();
         foreach (var e in Events)
         {
             switch (e.Type)
             {
                 case MapEvent.EventTypeBoostLights:
                     ColorBoostBeatmapEvents.Add(new ColorBoostEvent(e));
+                    break;
+                case MapEvent.EventTypeEarlyRotation:
+                case MapEvent.EventTypeLateRotation:
+                    RotationEvents.Add(new RotationEvent(e));
                     break;
                 default:
                     BasicBeatmapEvents.Add(new MapEventV3(e));
@@ -322,6 +327,8 @@ public class BeatSaberMapV3 : BeatSaberMap
         Obstacles = ObstaclesV3.OfType<BeatmapObstacle>().ToList();
         Events = BasicBeatmapEvents.OfType<MapEvent>().ToList();
         Events.AddRange(ColorBoostBeatmapEvents.OfType<MapEvent>().ToList());
+        Events.AddRange(RotationEvents.OfType<MapEvent>().ToList());
+        foreach(var e in Events) {if (e is RotationEvent ee) Debug.Log($"Rotation {ee.RotationAmount} has event value is {ee.Value}");}
         Events.Sort((lhs, rhs) => { return lhs.Time.CompareTo(rhs.Time); });
     }
 }

--- a/Assets/__Scripts/Map/BeatmapObject.cs
+++ b/Assets/__Scripts/Map/BeatmapObject.cs
@@ -60,11 +60,16 @@ public abstract class BeatmapObject
         switch (originalData)
         {
             case MapEvent evt:
-                var ev = new MapEvent(evt.Time, evt.Type, evt.Value, originalData.CustomData?.Clone(), evt.FloatValue)
+                if (evt is RotationEvent)
+                    objectData = new RotationEvent(evt) as T;
+                else
                 {
-                    LightGradient = evt.LightGradient?.Clone()
-                };
-                objectData = ev as T;
+                    var ev = new MapEvent(evt.Time, evt.Type, evt.Value, originalData.CustomData?.Clone(), evt.FloatValue)
+                    {
+                        LightGradient = evt.LightGradient?.Clone()
+                    };
+                    objectData = ev as T;
+                }
                 break;
             case BeatmapNote note:
                 if (note is BeatmapColorNote colorNote)

--- a/Assets/__Scripts/Map/Events/ColorBoostEvent.cs
+++ b/Assets/__Scripts/Map/Events/ColorBoostEvent.cs
@@ -17,6 +17,7 @@ public class ColorBoostEvent : MapEvent
         Time = RetrieveRequiredNode(node, "b").AsFloat;
         Boost = RetrieveRequiredNode(node, "o").AsBool;
         Type = EventTypeBoostLights;
+        FloatValue = 1f;
         CustomData = node[BeatmapObjectV3CustomDataKey];
         if (node[BeatmapObjectV3CustomDataKey]["_lightGradient"] != null)
             LightGradient = new ChromaGradient(node[BeatmapObjectV3CustomDataKey]["_lightGradient"]);

--- a/Assets/__Scripts/Map/Events/MapEvent.cs
+++ b/Assets/__Scripts/Map/Events/MapEvent.cs
@@ -106,7 +106,7 @@ public class MapEvent : BeatmapObject
                                                            value == LightValueBlueFlash ||
                                                            value == LightValueBlueFade;
 
-    public int? GetRotationDegreeFromValue()
+    public virtual int? GetRotationDegreeFromValue()
     {
         //Mapping Extensions precision rotation from 1000 to 1720: 1000 = -360 degrees, 1360 = 0 degrees, 1720 = 360 degrees
         var val = CustomData != null && CustomData.HasKey("_queuedRotation")

--- a/Assets/__Scripts/Map/Events/RotationEvent.cs
+++ b/Assets/__Scripts/Map/Events/RotationEvent.cs
@@ -1,6 +1,7 @@
 using System;
 using SimpleJSON;
 using UnityEngine;
+using System.Linq;
 
 /// <summary>
 /// <see cref="RotationEvent"/> is seperated from basic <see cref="MapEvent"/> in map v3.
@@ -19,16 +20,10 @@ public class RotationEvent : MapEvent
         get => degrees;
         set {
             degrees = value;
-            // This sets it to the corresponding Value closest to the precise rotation
-            // (-60, -45, -30, -15, 15, 30, 45, 60)
-            if (value <= -53) Value = 0;
-            else if (value <= -38) Value = 1;
-            else if (value <= -23) Value = 2;
-            else if (value <= 0) Value = 3;
-            else if (value <= 22) Value = 4;
-            else if (value <= 37) Value = 5;
-            else if (value <= 52) Value = 6;
-            else Value = 7;
+            var index = Array.IndexOf(LightValueToRotationDegrees, value);
+            Value = (index != -1) 
+                ? index 
+                : value + 1360; // ME value
         }
     }
 
@@ -57,33 +52,15 @@ public class RotationEvent : MapEvent
         if (m is RotationEvent rotEvent)
             RotationAmount = rotEvent.RotationAmount;
         else
-            switch (m.Value)
-            {
-                case 0:
-                    RotationAmount = -60;
-                    break;
-                case 1:
-                    RotationAmount = -45;
-                    break;
-                case 2:
-                    RotationAmount = -30;
-                    break;
-                case 3:
-                    RotationAmount = -15;
-                    break;
-                case 4:
-                    RotationAmount = 15;
-                    break;
-                case 5:
-                    RotationAmount = 30;
-                    break;
-                case 6:
-                    RotationAmount = 45;
-                    break;
-                case 7:
-                    RotationAmount = 60;
-                    break;
-            }
+        {
+            var val = m.Value;
+            if (val >= 0 && val < LightValueToRotationDegrees.Length)
+                RotationAmount = LightValueToRotationDegrees[val];
+            else if (val >= 1000 && val <= 1720)
+                RotationAmount = val - 1360;
+            else
+                RotationAmount = 0;
+        }
     }
 
     public override JSONNode ConvertToJson()

--- a/Assets/__Scripts/Map/Events/RotationEvent.cs
+++ b/Assets/__Scripts/Map/Events/RotationEvent.cs
@@ -1,0 +1,92 @@
+using System;
+using SimpleJSON;
+using UnityEngine;
+
+/// <summary>
+/// <see cref="RotationEvent"/> is seperated from basic <see cref="MapEvent"/> in map v3.
+/// </summary>
+public class RotationEvent : MapEvent
+{
+    public int RotationType
+    {
+        get => (Type == EventTypeEarlyRotation) ? 0 : 1;
+        set => Type = (value == 0) ? EventTypeEarlyRotation : EventTypeLateRotation;
+    }
+
+    private int degrees;
+    public int RotationAmount
+    {
+        get => degrees;
+        set {
+            degrees = value;
+            // This sets it to the corresponding Value closest to the precise rotation
+            // (-60, -45, -30, -15, 15, 30, 45, 60)
+            if (value <= -53) Value = 0;
+            else if (value <= -38) Value = 1;
+            else if (value <= -23) Value = 2;
+            else if (value <= 0) Value = 3;
+            else if (value <= 22) Value = 4;
+            else if (value <= 37) Value = 5;
+            else if (value <= 52) Value = 6;
+            else Value = 7;
+        }
+    }
+
+    public RotationEvent(JSONNode node)
+    {
+        Time = RetrieveRequiredNode(node, "b").AsFloat;
+        RotationAmount = RetrieveRequiredNode(node, "r").AsInt;
+        RotationType = RetrieveRequiredNode(node, "e").AsInt;
+        CustomData = node[BeatmapObjectV3CustomDataKey];
+        if (node[BeatmapObjectV3CustomDataKey]["_lightGradient"] != null)
+            LightGradient = new ChromaGradient(node[BeatmapObjectV3CustomDataKey]["_lightGradient"]);
+    }
+
+    public RotationEvent(MapEvent m) :
+        base(m.Time, m.Type, m.Value, m.CustomData)
+    {
+        if (m is RotationEvent rotEvent)
+            RotationAmount = rotEvent.RotationAmount;
+        else
+            switch (m.Value)
+            {
+                case 0:
+                    RotationAmount = -60;
+                    break;
+                case 1:
+                    RotationAmount = -45;
+                    break;
+                case 2:
+                    RotationAmount = -30;
+                    break;
+                case 3:
+                    RotationAmount = -15;
+                    break;
+                case 4:
+                    RotationAmount = 15;
+                    break;
+                case 5:
+                    RotationAmount = 30;
+                    break;
+                case 6:
+                    RotationAmount = 45;
+                    break;
+                case 7:
+                    RotationAmount = 60;
+                    break;
+            }
+    }
+
+    public override JSONNode ConvertToJson()
+    {
+        if (!Settings.Instance.Load_MapV3) return base.ConvertToJson();
+        JSONNode node = new JSONObject();
+        node["b"] = Math.Round(Time, DecimalPrecision);
+        node["r"] = RotationAmount;
+        node["e"] = RotationType;
+        if (CustomData != null) node[BeatmapObjectV3CustomDataKey] = CustomData;
+
+        return node;
+    }
+
+}

--- a/Assets/__Scripts/Map/Events/RotationEvent.cs
+++ b/Assets/__Scripts/Map/Events/RotationEvent.cs
@@ -75,4 +75,13 @@ public class RotationEvent : MapEvent
         return node;
     }
 
+    public override void Apply(BeatmapObject originalData)
+    {
+        base.Apply(originalData);
+
+        if (originalData is RotationEvent rotEvt)
+        {
+            RotationAmount = rotEvt.RotationAmount;
+        }
+    }
 }

--- a/Assets/__Scripts/Map/Events/RotationEvent.cs
+++ b/Assets/__Scripts/Map/Events/RotationEvent.cs
@@ -32,6 +32,14 @@ public class RotationEvent : MapEvent
         }
     }
 
+    public override int? GetRotationDegreeFromValue()
+    {
+        //Mapping Extensions should have no effect on V3 rotation event
+        return (CustomData != null && CustomData.HasKey("_queuedRotation"))
+            ? CustomData["_queuedRotation"].AsInt
+            : RotationAmount;
+    }
+
     public RotationEvent(JSONNode node)
     {
         Time = RetrieveRequiredNode(node, "b").AsFloat;

--- a/Assets/__Scripts/Map/Events/RotationEvent.cs
+++ b/Assets/__Scripts/Map/Events/RotationEvent.cs
@@ -37,6 +37,7 @@ public class RotationEvent : MapEvent
         Time = RetrieveRequiredNode(node, "b").AsFloat;
         RotationAmount = RetrieveRequiredNode(node, "r").AsInt;
         RotationType = RetrieveRequiredNode(node, "e").AsInt;
+        FloatValue = 1f;
         CustomData = node[BeatmapObjectV3CustomDataKey];
         if (node[BeatmapObjectV3CustomDataKey]["_lightGradient"] != null)
             LightGradient = new ChromaGradient(node[BeatmapObjectV3CustomDataKey]["_lightGradient"]);

--- a/Assets/__Scripts/Map/Events/RotationEvent.cs.meta
+++ b/Assets/__Scripts/Map/Events/RotationEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 48ddbd09c8181a34094a977dad0daa46
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/__Scripts/MapEditor/Input/BeatmapEventInputController.cs
+++ b/Assets/__Scripts/MapEditor/Input/BeatmapEventInputController.cs
@@ -98,7 +98,7 @@ public class BeatmapEventInputController : BeatmapInputController<BeatmapEventCo
         {
             (e.EventData as RotationEvent).RotationAmount += modifier;
         }
-        else 
+        else
         {
             e.EventData.Value += modifier;
 
@@ -123,7 +123,7 @@ public class BeatmapEventInputController : BeatmapInputController<BeatmapEventCo
     public void TweakFloatValue(BeatmapEventContainer e, int modifier)
     {
         var original = BeatmapObject.GenerateCopy(e.ObjectData);
-        
+
         if (!e.EventData.IsUtilityEvent)
         {
             e.EventData.FloatValue += 0.1f * modifier;

--- a/Assets/__Scripts/MapEditor/Input/BeatmapEventInputController.cs
+++ b/Assets/__Scripts/MapEditor/Input/BeatmapEventInputController.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using UnityEngine;
 using UnityEngine.InputSystem;
 using UnityEngine.Serialization;
@@ -49,14 +49,21 @@ public class BeatmapEventInputController : BeatmapInputController<BeatmapEventCo
             var rotation = e.EventData.GetRotationDegreeFromValue();
             if (rotation != null)
             {
-                if (e.EventData.Value >= 0 && e.EventData.Value < MapEvent.LightValueToRotationDegrees.Length)
+                if (e.EventData is RotationEvent)
                 {
-                    e.EventData.Value =
-                        MapEvent.LightValueToRotationDegrees.ToList().IndexOf((rotation ?? 0) * -1);
+                    (e.EventData as RotationEvent).RotationAmount *= -1;
                 }
-                else if (e.EventData.Value >= 1000 && e.EventData.Value <= 1720) //Invert Mapping Extensions rotation
+                else
                 {
-                    e.EventData.Value = 1720 - (e.EventData.Value - 1000);
+                    if (e.EventData.Value >= 0 && e.EventData.Value < MapEvent.LightValueToRotationDegrees.Length)
+                    {
+                        e.EventData.Value =
+                            MapEvent.LightValueToRotationDegrees.ToList().IndexOf((rotation ?? 0) * -1);
+                    }
+                    else if (e.EventData.Value >= 1000 && e.EventData.Value <= 1720) //Invert Mapping Extensions rotation
+                    {
+                        e.EventData.Value = 1720 - (e.EventData.Value - 1000);
+                    }
                 }
 
                 tracksManager.RefreshTracks();
@@ -86,17 +93,25 @@ public class BeatmapEventInputController : BeatmapInputController<BeatmapEventCo
     public void TweakValue(BeatmapEventContainer e, int modifier)
     {
         var original = BeatmapObject.GenerateCopy(e.ObjectData);
-        e.EventData.Value += modifier;
 
-        if (e.EventData.Value == 4 && !e.EventData.IsUtilityEvent)
+        if (e.EventData is RotationEvent)
+        {
+            (e.EventData as RotationEvent).RotationAmount += modifier;
+        }
+        else 
+        {
             e.EventData.Value += modifier;
 
-        if (e.EventData.Value < 0) e.EventData.Value = 0;
+            if (e.EventData.Value == 4 && !e.EventData.IsUtilityEvent)
+                e.EventData.Value += modifier;
 
-        if (!e.EventData.IsLaserSpeedEvent)
-        {
-            if (e.EventData.Value > 7)
-                e.EventData.Value = 7;
+            if (e.EventData.Value < 0) e.EventData.Value = 0;
+
+            if (!e.EventData.IsLaserSpeedEvent)
+            {
+                if (e.EventData.Value > 7)
+                    e.EventData.Value = 7;
+            }
         }
 
         if (e.EventData.IsRotationEvent)


### PR DESCRIPTION
* Previews rotation
* Adds saving and conversion to and from V3
  * Converting V3 rotation to V2 will use ME values if there is no vanilla value for the rotation amount
* Quick edit for V3 rotation increments in 1s
* Rotation events are not yet placed in V3 format
  * I feel that would be better for a future PR that supports Boost and Rotation event placement in V3