### PR TITLE
Prevent saving objects outside of map

### DIFF
--- a/Assets/Locales/Mapper Shared Data.asset
+++ b/Assets/Locales/Mapper Shared Data.asset
@@ -643,6 +643,10 @@ MonoBehaviour:
     m_Key: bookmark.dialog.color
     m_Metadata:
       m_Items: []
+  - m_Id: 118373130107551744
+    m_Key: save.objects.outside
+    m_Metadata:
+      m_Items: []
   m_Metadata:
     m_Items: []
   m_KeyGenerator:

--- a/Assets/Locales/Mapper_en.asset
+++ b/Assets/Locales/Mapper_en.asset
@@ -754,6 +754,10 @@ MonoBehaviour:
     m_Localized: Bookmark Color
     m_Metadata:
       m_Items: []
+  - m_Id: 118373130107551744
+    m_Localized: Objects found outside map. Do you want to remove them?
+    m_Metadata:
+      m_Items: []
   references:
     version: 1
     00000000:

--- a/Assets/__Scenes/03_Mapper.unity
+++ b/Assets/__Scenes/03_Mapper.unity
@@ -33755,9 +33755,9 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 1524038332}
-        m_TargetAssemblyTypeName: 
-        m_MethodName: Save
-        m_Mode: 6
+        m_TargetAssemblyTypeName: AutoSaveController, Main
+        m_MethodName: CheckAndSave
+        m_Mode: 3
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -45334,6 +45334,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   autoSaveToggle: {fileID: 1207263925}
+  pauseManager: {fileID: 614713889}
 --- !u!114 &1524038333
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/__Scripts/MapEditor/AutoSaveController.cs
+++ b/Assets/__Scripts/MapEditor/AutoSaveController.cs
@@ -13,6 +13,7 @@ public class AutoSaveController : MonoBehaviour, CMInput.ISavingActions
 {
     private const int maximumAutosaveCount = 15;
     [SerializeField] private Toggle autoSaveToggle;
+    [SerializeField] private PauseManager pauseManager;
 
     private List<DirectoryInfo> currentAutoSaves = new List<DirectoryInfo>();
 
@@ -21,6 +22,19 @@ public class AutoSaveController : MonoBehaviour, CMInput.ISavingActions
     private float t;
 
     private float maxBeatTime; // Does not account for official bpm changes. V3 sounds like fun
+    private const int FALSE = 0; // Because Interlocked.Exchange(bool) doesn't exist
+    private const int TRUE = 1;
+    private Thread objectCheckingThread;
+    private int objectsOutsideMap = FALSE;
+    private int objectsCheckIsComplete = FALSE;
+    private int saveFlag = (int)SaveType.None;
+
+    public enum SaveType
+    {
+        None,
+        Menu,
+        Quit
+    }
 
     // Use this for initialization
     private void Start()
@@ -43,6 +57,22 @@ public class AutoSaveController : MonoBehaviour, CMInput.ISavingActions
     // Update is called once per frame
     private void Update()
     {
+        if (Interlocked.Exchange(ref objectsCheckIsComplete, FALSE) == TRUE)
+        {
+            if (Interlocked.Exchange(ref objectsOutsideMap, FALSE) == TRUE)
+            {
+                if (saveFlag == (int)SaveType.None) PersistentUI.Instance.ShowDialogBox("Mapper", "save.objects.outside", CleanAndSave, PersistentUI.DialogBoxPresetType.YesNo);
+                if (saveFlag == (int)SaveType.Menu) PersistentUI.Instance.ShowDialogBox("Mapper", "save.objects.outside", CleanAndMenu, PersistentUI.DialogBoxPresetType.YesNo);
+                if (saveFlag == (int)SaveType.Quit) PersistentUI.Instance.ShowDialogBox("Mapper", "save.objects.outside", CleanAndQuit, PersistentUI.DialogBoxPresetType.YesNo);
+            }
+            else
+            {
+                if (saveFlag == (int)SaveType.None) Save();
+                if (saveFlag == (int)SaveType.Menu) pauseManager.SaveAndExitToMenu();
+                if (saveFlag == (int)SaveType.Quit) pauseManager.SaveAndQuitCM();
+            }
+        }
+
         if (!Settings.Instance.AutoSave || !Application.isFocused) return;
         t += Time.deltaTime;
         if (t > Settings.Instance.AutoSaveInterval * 60)
@@ -54,7 +84,96 @@ public class AutoSaveController : MonoBehaviour, CMInput.ISavingActions
 
     public void OnSave(InputAction.CallbackContext context)
     {
-        if (context.performed) Save();
+        if (context.performed) CheckAndSave();
+    }
+
+    public void CheckAndSave(int _) => CheckAndSave(); // So it shows up in Unity
+    public void CheckAndSave(SaveType saveType = SaveType.None)
+    {
+        if (objectCheckingThread != null && objectCheckingThread.IsAlive)
+        {
+            Debug.LogError(":hyperPepega: :mega: PLEASE BE PATIENT THANKS");
+            return;
+        }
+
+        SelectionController.RefreshMap();
+        objectCheckingThread = new Thread(() =>
+        {
+            if (ObjectIsOutsideMap())
+            {
+                Debug.Log("Found object outside of the map.");
+                Interlocked.Exchange(ref saveFlag, (int)saveType);
+                Interlocked.Exchange(ref objectsOutsideMap, TRUE);
+            }
+            Interlocked.Exchange(ref objectsCheckIsComplete, TRUE);
+        });
+        objectCheckingThread.Start();
+    }
+
+    private void CleanAndSave(int res)
+    {
+        if (res == 0) CleanObjectsOutsideMap();
+        Save();
+    }
+
+    private void CleanAndMenu(int res)
+    {
+        if (res == 0) CleanObjectsOutsideMap();
+        pauseManager.SaveAndExitToMenu();
+    }
+
+    private void CleanAndQuit(int res)
+    {
+        if (res == 0) CleanObjectsOutsideMap();
+        pauseManager.SaveAndQuitCM();
+    }
+
+    private void CleanObjectsOutsideMap()
+    {
+        if (Settings.Instance.RemoveNotesOutsideMap)
+        {
+            var noteCollection = BeatmapObjectContainerCollection.GetCollectionForType(BeatmapObject.ObjectType.Note);
+            foreach (var note in BeatSaberSongContainer.Instance.Map.Notes.Where(note => note.Time >= maxBeatTime))
+            {
+                noteCollection.DeleteObject(note);
+            }
+        }
+        if (Settings.Instance.RemoveEventsOutsideMap)
+        {
+            var eventCollection = BeatmapObjectContainerCollection.GetCollectionForType(BeatmapObject.ObjectType.Event);
+            foreach (var evt in BeatSaberSongContainer.Instance.Map.Events.Where(evt => evt.Time >= maxBeatTime))
+            {
+                eventCollection.DeleteObject(evt);
+            }
+        }
+        if (Settings.Instance.RemoveObstaclesOutsideMap)
+        {
+            var obstacleCollection = BeatmapObjectContainerCollection.GetCollectionForType(BeatmapObject.ObjectType.Obstacle);
+            foreach (var obst in BeatSaberSongContainer.Instance.Map.Obstacles.Where(obst => obst.Time >= maxBeatTime))
+            {
+                obstacleCollection.DeleteObject(obst);
+            }
+        }
+    }
+
+    private bool ObjectIsOutsideMap()
+    {
+        if (Settings.Instance.RemoveNotesOutsideMap)
+        {
+            if (BeatSaberSongContainer.Instance.Map.Notes.Any(note => note.Time >= maxBeatTime))
+                return true;
+        }
+        if (Settings.Instance.RemoveEventsOutsideMap)
+        {
+            if (BeatSaberSongContainer.Instance.Map.Events.Any(evt => evt.Time >= maxBeatTime))
+                return true;
+        }
+        if (Settings.Instance.RemoveObstaclesOutsideMap)
+        {
+            if (BeatSaberSongContainer.Instance.Map.Obstacles.Any(obst => obst.Time >= maxBeatTime))
+                return true;
+        }
+        return false;
     }
 
     public void ToggleAutoSave(bool enabled) => Settings.Instance.AutoSave = enabled;

--- a/Assets/__Scripts/MapEditor/AutoSaveController.cs
+++ b/Assets/__Scripts/MapEditor/AutoSaveController.cs
@@ -20,6 +20,8 @@ public class AutoSaveController : MonoBehaviour, CMInput.ISavingActions
 
     private float t;
 
+    private float maxBeatTime; // Does not account for official bpm changes. V3 sounds like fun
+
     // Use this for initialization
     private void Start()
     {
@@ -32,6 +34,8 @@ public class AutoSaveController : MonoBehaviour, CMInput.ISavingActions
             foreach (var dir in Directory.EnumerateDirectories(autoSavesDir))
                 currentAutoSaves.Add(new DirectoryInfo(dir));
         }
+
+        maxBeatTime = BeatSaberSongContainer.Instance.LoadedSong.length * BeatSaberSongContainer.Instance.Song.BeatsPerMinute / 60;
 
         CleanAutosaves();
     }
@@ -96,6 +100,12 @@ public class AutoSaveController : MonoBehaviour, CMInput.ISavingActions
                         var newDirectoryInfo = new DirectoryInfo(autoSaveDir);
                         currentAutoSaves.Add(newDirectoryInfo);
                         CleanAutosaves();
+                    }
+                    else // Only check on manual save
+                    {
+                        if (Settings.Instance.RemoveNotesOutsideMap) BeatSaberSongContainer.Instance.Map.Notes.RemoveAll(note => note.Time >= maxBeatTime);
+                        if (Settings.Instance.RemoveEventsOutsideMap) BeatSaberSongContainer.Instance.Map.Events.RemoveAll(evt => evt.Time >= maxBeatTime);
+                        if (Settings.Instance.RemoveObstaclesOutsideMap) BeatSaberSongContainer.Instance.Map.Obstacles.RemoveAll(obst => obst.Time >= maxBeatTime);
                     }
 
                     BeatSaberSongContainer.Instance.Map.Save();

--- a/Assets/__Scripts/MapEditor/UI/PauseManager.cs
+++ b/Assets/__Scripts/MapEditor/UI/PauseManager.cs
@@ -66,19 +66,37 @@ public class PauseManager : MonoBehaviour, CMInput.IPauseMenuActions
         StartCoroutine(TransitionMenu());
     }
 
-    public void Quit(bool save)
+    public void Quit(bool save) 
     {
-        if (save)
+        if (save) // Save and Quit button
         {
-            saveController.Save();
-            SceneTransitionManager.Instance.LoadScene("02_SongEditMenu");
+            saveController.CheckAndSave(AutoSaveController.SaveType.Menu);
         }
-        else
+        else // Quit button
         {
             PersistentUI.Instance.ShowDialogBox("Mapper", "save", SaveAndExitResult,
                 PersistentUI.DialogBoxPresetType.YesNoCancel);
         }
     }
+
+    public void SaveAndExitToMenu() 
+    {
+        saveController.Save();
+        SceneTransitionManager.Instance.LoadScene("02_SongEditMenu");
+    }
+
+    public void SaveAndQuitCM()
+    {
+        saveController.Save();
+#if UNITY_EDITOR
+            EditorApplication.isPlaying = false;
+#else
+                Application.Quit();
+#endif
+    }
+
+    public void ExitToMenu() => PersistentUI.Instance.ShowDialogBox("Mapper", "save", 
+            SaveAndExitResult, PersistentUI.DialogBoxPresetType.YesNoCancel);
 
     public void CloseCM() =>
         PersistentUI.Instance.ShowDialogBox("Mapper", "quit.save",
@@ -88,8 +106,7 @@ public class PauseManager : MonoBehaviour, CMInput.IPauseMenuActions
     {
         if (result == 0) //Left button (ID 0) clicked; the user wants to Save before exiting.
         {
-            saveController.Save();
-            SceneTransitionManager.Instance.LoadScene("02_SongEditMenu");
+            saveController.CheckAndSave(AutoSaveController.SaveType.Menu);
         }
         else if (result == 1) //Middle button (ID 1) clicked; the user does not want to save before exiting.
         {
@@ -102,12 +119,7 @@ public class PauseManager : MonoBehaviour, CMInput.IPauseMenuActions
     {
         if (result == 0) //Left button (ID 0) clicked; the user wants to Save before exiting.
         {
-            saveController.Save();
-#if UNITY_EDITOR
-            EditorApplication.isPlaying = false;
-#else
-                Application.Quit();
-#endif
+            saveController.CheckAndSave(AutoSaveController.SaveType.Quit);
         }
         else if (result == 1) //Middle button (ID 1) clicked; the user does not want to save before exiting.
 #if UNITY_EDITOR

--- a/Assets/__Scripts/Settings/Settings.cs
+++ b/Assets/__Scripts/Settings/Settings.cs
@@ -61,6 +61,9 @@ public class Settings
     public bool Reminder_SettingsFailed = true;
     public bool AdvancedShit = false;
     public bool FormatJson = false;
+    public bool RemoveNotesOutsideMap = true; // Hidden setting
+    public bool RemoveEventsOutsideMap = true; // Hidden setting
+    public bool RemoveObstaclesOutsideMap = true; // Hidden setting
     public bool VanillaOnlyShift = true;
     public bool InstantEscapeMenuTransitions = false;
     public bool InstantLoadingTransitions = false;


### PR DESCRIPTION
Resolves (#398).
Adds dialogue prompt to remove objects outside the map on saving.
Setting is hidden because I don't know what use case you would have to disable it but someone is going to want to for whatever reason.