### PR TITLE
remove redundant time assignment when dragging objects

### DIFF
--- a/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/PlacementController.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/PlacementController.cs
@@ -160,7 +160,6 @@ public abstract class PlacementController<TBo, TBoc, TBocc> : MonoBehaviour, CMI
             if ((IsDraggingObject || IsDraggingObjectAtTime) && queuedData != null)
             {
                 TransferQueuedToDraggedObject(ref draggedObjectData, BeatmapObject.GenerateCopy(queuedData));
-                DraggedObjectContainer.ObjectData.Time = placementZ / EditorScaleController.EditorScale;
                 if (DraggedObjectContainer != null) DraggedObjectContainer.UpdateGridPosition();
             }
         }


### PR DESCRIPTION
As far as I can tell this time assignment was entirely redundant as time already got assigned in the line above, and as a bonus it introduced floating point errors due to needlessly multiplying and dividing by editor scale