### PR TITLE
Unset custom properties when CustomData nodes are removed

### DIFF
--- a/Assets/__Scripts/Beatmap/Base/BaseEvent.cs
+++ b/Assets/__Scripts/Beatmap/Base/BaseEvent.cs
@@ -286,24 +286,25 @@ namespace Beatmap.Base
         protected override void ParseCustom()
         {
             base.ParseCustom();
-            if (CustomData == null) return;
 
-            if (CustomData.HasKey(CustomKeyLightID))
+            if (CustomData?.HasKey(CustomKeyLightID) ?? false)
             {
                 var temp = CustomData[CustomKeyLightID];
                 CustomLightID = temp.IsNumber
                     ? new[] { temp.AsInt }
                     : temp.AsArray.Linq.Where(x => x.Value.IsNumber).Select(x => x.Value.AsInt).ToArray();
             }
+            else {
+                CustomLightID = null;
+            }
 
-            if (CustomData.HasKey(CustomKeyLerpType)) CustomLerpType = CustomData[CustomKeyLerpType].Value;
-            if (CustomData.HasKey(CustomKeyEasing)) CustomEasing = CustomData[CustomKeyEasing].Value;
-            if (CustomData.HasKey(CustomKeyStep)) CustomStep = CustomData[CustomKeyStep].AsFloat;
-            if (CustomData.HasKey(CustomKeyProp)) CustomProp = CustomData[CustomKeyProp].AsFloat;
-            if (CustomData.HasKey(CustomKeySpeed)) CustomSpeed = CustomData[CustomKeySpeed].AsFloat;
-            if (CustomData.HasKey(CustomKeyDirection)) CustomDirection = CustomData[CustomKeyDirection].AsInt;
-            if (CustomData.HasKey(CustomKeyLockRotation))
-                CustomLockRotation = CustomData[CustomKeyLockRotation].AsBool;
+            CustomLerpType = (CustomData?.HasKey(CustomKeyLerpType) ?? false) ? CustomData?[CustomKeyLerpType].Value : null;
+            CustomEasing = (CustomData?.HasKey(CustomKeyEasing) ?? false) ? CustomData?[CustomKeyEasing].Value : null;
+            CustomStep = (CustomData?.HasKey(CustomKeyStep) ?? false) ? CustomData?[CustomKeyStep].AsFloat : null;
+            CustomProp = (CustomData?.HasKey(CustomKeyProp) ?? false) ? CustomData?[CustomKeyProp].AsFloat : null;
+            CustomSpeed = (CustomData?.HasKey(CustomKeySpeed) ?? false) ? CustomData?[CustomKeySpeed].AsFloat : null;
+            CustomDirection = (CustomData?.HasKey(CustomKeyDirection) ?? false) ? CustomData?[CustomKeyDirection].AsInt : null;
+            CustomLockRotation = (CustomData?.HasKey(CustomKeyLockRotation) ?? false) ? CustomData?[CustomKeyLockRotation].AsBool : null;
         }
 
         protected internal override JSONNode SaveCustom()

--- a/Assets/__Scripts/Beatmap/Base/BaseGrid.cs
+++ b/Assets/__Scripts/Beatmap/Base/BaseGrid.cs
@@ -64,14 +64,10 @@ namespace Beatmap.Base
         protected override void ParseCustom()
         {
             base.ParseCustom();
-            if (CustomData == null) return;
 
-            if (CustomData.HasKey(CustomKeyCoordinate))
-                CustomCoordinate = CustomData[CustomKeyCoordinate].ReadVector2();
-            if (CustomData.HasKey(CustomKeyWorldRotation))
-                CustomWorldRotation = CustomData[CustomKeyWorldRotation].ReadVector3();
-            if (CustomData.HasKey(CustomKeyLocalRotation))
-                CustomLocalRotation = CustomData[CustomKeyLocalRotation].ReadVector3();
+            CustomCoordinate = (CustomData?.HasKey(CustomKeyCoordinate) ?? false) ? CustomData?[CustomKeyCoordinate].ReadVector2() : null;
+            CustomWorldRotation = (CustomData?.HasKey(CustomKeyWorldRotation) ?? false) ? CustomData?[CustomKeyWorldRotation].ReadVector3() : null;
+            CustomLocalRotation = (CustomData?.HasKey(CustomKeyLocalRotation) ?? false) ? CustomData?[CustomKeyLocalRotation].ReadVector3() : null;
         }
 
         protected internal override JSONNode SaveCustom()

--- a/Assets/__Scripts/Beatmap/Base/BaseObject.cs
+++ b/Assets/__Scripts/Beatmap/Base/BaseObject.cs
@@ -53,10 +53,8 @@ namespace Beatmap.Base
 
         protected virtual void ParseCustom()
         {
-            if (CustomData == null) return;
-
-            if (CustomData.HasKey(CustomKeyTrack)) CustomTrack = CustomData[CustomKeyTrack].Value;
-            if (CustomData.HasKey(CustomKeyColor)) CustomColor = CustomData[CustomKeyColor].ReadColor();
+            CustomTrack = (CustomData?.HasKey(CustomKeyTrack) ?? false) ? CustomData?[CustomKeyTrack].Value : null;
+            CustomColor = (CustomData?.HasKey(CustomKeyColor) ?? false) ? CustomData?[CustomKeyColor].ReadColor() : null;
         }
 
         public void RefreshCustom() => ParseCustom();

--- a/Assets/__Scripts/Beatmap/Base/BaseObstacle.cs
+++ b/Assets/__Scripts/Beatmap/Base/BaseObstacle.cs
@@ -179,14 +179,8 @@ namespace Beatmap.Base
         protected override void ParseCustom()
         {
             base.ParseCustom();
-            if (CustomData == null) return;
 
-            if (CustomData.HasKey(CustomKeySize) && CustomData[CustomKeySize].IsArray)
-            {
-                var temp = CustomData[CustomKeySize].AsArray;
-                if (temp.Count < 2) temp.Add(0);
-                CustomSize = temp;
-            }
+            CustomSize = (CustomData?.HasKey(CustomKeySize) ?? false) ? CustomData?[CustomKeySize].ReadVector3() : null;
         }
 
         protected internal override JSONNode SaveCustom()

--- a/Assets/__Scripts/Beatmap/Base/BaseSlider.cs
+++ b/Assets/__Scripts/Beatmap/Base/BaseSlider.cs
@@ -52,10 +52,8 @@ namespace Beatmap.Base
         protected override void ParseCustom()
         {
             base.ParseCustom();
-            if (CustomData == null) return;
 
-            if (CustomData.HasKey(CustomKeyTailCoordinate))
-                CustomTailCoordinate = CustomData[CustomKeyTailCoordinate].ReadVector2();
+            CustomTailCoordinate = (CustomData?.HasKey(CustomKeyTailCoordinate) ?? false) ? CustomData?[CustomKeyTailCoordinate].ReadVector2() : null;
         }
 
         protected internal override JSONNode SaveCustom()

--- a/Assets/__Scripts/Beatmap/V2/V2Event.cs
+++ b/Assets/__Scripts/Beatmap/V2/V2Event.cs
@@ -82,16 +82,14 @@ namespace Beatmap.V2
         {
             base.ParseCustom();
 
-            if (CustomData == null) return;
-            if (CustomData[CustomKeyLightGradient] != null)
-                CustomLightGradient = new ChromaLightGradient(CustomData[CustomKeyLightGradient]);
-            if (CustomData[CustomKeyPropMult] != null) CustomPropMult = CustomData[CustomKeyPropMult].AsFloat;
-            if (CustomData[CustomKeyStepMult] != null) CustomStepMult = CustomData[CustomKeyStepMult].AsFloat;
-            if (CustomData[CustomKeyPropMult] != null) CustomPropMult = CustomData[CustomKeyPropMult].AsFloat;
-            if (CustomData[CustomKeySpeedMult] != null) CustomSpeedMult = CustomData[CustomKeySpeedMult].AsFloat;
-            if (CustomData[CustomKeyPreciseSpeed] != null)
-                CustomPreciseSpeed = CustomData[CustomKeyPreciseSpeed].AsFloat;
-            if (CustomData[CustomKeyLaneRotation] != null) CustomLaneRotation = CustomData[CustomKeyLaneRotation].AsInt;
+            CustomLightGradient = (CustomData?.HasKey(CustomKeyLightGradient) ?? false)
+                ? new ChromaLightGradient(CustomData[CustomKeyLightGradient])
+                : null;
+            CustomPropMult = (CustomData?.HasKey(CustomKeyPropMult) ?? false) ? CustomData?[CustomKeyPropMult].AsFloat : null;
+            CustomStepMult = (CustomData?.HasKey(CustomKeyStepMult) ?? false) ? CustomData?[CustomKeyStepMult].AsFloat : null;
+            CustomSpeedMult = (CustomData?.HasKey(CustomKeySpeedMult) ?? false) ? CustomData?[CustomKeySpeedMult].AsFloat : null;
+            CustomPreciseSpeed = (CustomData?.HasKey(CustomKeyPreciseSpeed) ?? false) ? CustomData?[CustomKeyPreciseSpeed].AsFloat : null;
+            CustomLaneRotation = (CustomData?.HasKey(CustomKeyLaneRotation) ?? false) ? CustomData?[CustomKeyLaneRotation].AsInt : null;
         }
 
         protected internal sealed override JSONNode SaveCustom()

--- a/Assets/__Scripts/Beatmap/V2/V2Note.cs
+++ b/Assets/__Scripts/Beatmap/V2/V2Note.cs
@@ -48,9 +48,8 @@ namespace Beatmap.V2
         protected sealed override void ParseCustom()
         {
             base.ParseCustom();
-            if (CustomData == null) return;
 
-            if (CustomData[CustomKeyDirection] != null) CustomDirection = CustomData[CustomKeyDirection].AsInt;
+            CustomDirection = (CustomData?.HasKey(CustomKeyDirection) ?? false) ? CustomData?[CustomKeyDirection].AsInt : null;
         }
 
         protected internal sealed override JSONNode SaveCustom()


### PR DESCRIPTION
Right now, neither the CustomData nodes nor the Custom* event properties are particularly authoritative, and the only way to fully remove them is to unset both. This PR makes the CustomData node authoritative, and will overwrite and unset properties on ParseCustom(). Going the other way would be much harder, because JSONNodes would need to be `Remove`d and non-events don't yet have Custom* properties.

Implementation note: the ternary is necessary because of JSONLazyCreator, if there was a 
```cs
public JSONNode? TryGet(string key)
```
this could look like
```cs
CustomLerpType = CustomData?.TryGet(CustomKeyLerpType)?.Value
```
~~force push was for commit signing, don't worry about it~~