### PR TITLE
Graceful plugin failure

### DIFF
--- a/Assets/__Scripts/PluginLoader/PluginLoader.cs
+++ b/Assets/__Scripts/PluginLoader/PluginLoader.cs
@@ -46,8 +46,13 @@ internal class PluginLoader : MonoBehaviour
                 ;
 
                 if (pluginAttribute == null) continue;
-                plugins.Add(
-                    new Plugin(pluginAttribute.Name, assembly.GetName().Version, Activator.CreateInstance(type)));
+                try {
+                    var plugin = new Plugin(pluginAttribute.Name, assembly.GetName().Version, Activator.CreateInstance(type));
+                    plugins.Add(plugin);
+                }
+                catch (Exception) {
+                    Debug.LogError($"Incompatible plugin {pluginAttribute.Name}, please check for an update or remove it!");
+                }
             }
         }
 


### PR DESCRIPTION
Right now one incompatible plugin will cause all plugins to not run, even though they show up in the plugin list. This prevents that and puts a helpful message in the log.