### PR TITLE
Export ChroMapper as a Universal macOS application

### DIFF
--- a/Assets/Editor/SimpleEditorUtils.cs
+++ b/Assets/Editor/SimpleEditorUtils.cs
@@ -46,6 +46,10 @@ public static class SimpleEditorUtils
         AddressableAssetSettings.BuildPlayerContent();
         SetBuildNumber();
 
+        // Needs to be wrapped in pre-processors since this code only compiles on macOS
+#if UNITY_EDITOR && UNITY_STANDALONE_OSX
+        UnityEditor.OSXStandalone.UserBuildSettings.architecture = UnityEditor.OSXStandalone.MacOSArchitecture.x64ARM64;
+#endif
         BuildPipeline.BuildPlayer(GetEnabledScenes(), "/root/project/checkout/build/MacOS/ChroMapper", BuildTarget.StandaloneOSX, buildOptions);
     }
 


### PR DESCRIPTION
As discussed in #433, Unity exposes settings in the macOS version of the Editor, which allows applications to be built as a universal x64 and ARM application. This should theoretically allow ChroMapper to run on both Intel-based Macs *and* M1 macs without the need of Rosetta.