### PR TITLE
Clear CustomSize when removed from CustomData

### DIFF
--- a/Assets/__Scripts/Beatmap/Base/BaseObstacle.cs
+++ b/Assets/__Scripts/Beatmap/Base/BaseObstacle.cs
@@ -199,6 +199,10 @@ namespace Beatmap.Base
                 while (temp.Count < 3) temp.Add(null);
                 CustomSize = new Vector2Or3(temp[0], temp[1], temp[2].IsNull ? null : (float?)temp[2].AsFloat);
             }
+            else
+            {
+                CustomSize = null;
+            }
         }
 
         protected internal override JSONNode SaveCustom()


### PR DESCRIPTION
I looked through the rest of the `ParseCustom`s, this is the only one missed