### PR TITLE
Fix lane labels when skipping LightIDs

### DIFF
--- a/Assets/__Scripts/MapEditor/Grid/CreateEventTypeLabels.cs
+++ b/Assets/__Scripts/MapEditor/Grid/CreateEventTypeLabels.cs
@@ -76,7 +76,7 @@ public class CreateEventTypeLabels : MonoBehaviour
                     }
                     else
                     {
-                        textMesh.text = $"{lightingManagers[eventType].name} ID {i}";
+                        textMesh.text = $"{lightingManagers[eventType].name} ID {EditorToLightID(eventType, i - 1)}";
                         if (i % 2 == 0)
                             textMesh.font = UtilityAsset;
                         else


### PR DESCRIPTION
Some people want this for ExtendedLightIDs

![image](https://github.com/Caeden117/ChroMapper/assets/74876786/97febc86-425c-4ecf-82ad-6d5df9370f32)
