### PR TITLE
Disable Harmony patches on macOS

### DIFF
--- a/Assets/__Scripts/Input/InputSystemPatch.cs
+++ b/Assets/__Scripts/Input/InputSystemPatch.cs
@@ -21,6 +21,7 @@ using UnityEngine.InputSystem.Controls;
  */
 public class InputSystemPatch : MonoBehaviour
 {
+#if !UNITY_STANDALONE_OSX
     private const string inputPatchID = "com.caeden117.chromapper.inputpatch";
 
     private static readonly MethodInfo returnFromFunctionInfo =
@@ -144,4 +145,5 @@ public class InputSystemPatch : MonoBehaviour
 
         return moreBindings && sameBindings;
     }
+#endif
 }

--- a/Assets/__Scripts/MapEditor/Graphics/Better Bloom/BetterBloomController.cs
+++ b/Assets/__Scripts/MapEditor/Graphics/Better Bloom/BetterBloomController.cs
@@ -18,6 +18,7 @@ using UnityEngine.Rendering.Universal.Internal;
  */
 public class BetterBloomController : MonoBehaviour
 {
+#if !UNITY_STANDALONE_OSX
     private const string betterBloomID = "com.caeden117.chromapper.betterbloom";
 
     private Harmony betterBloomHarmony;
@@ -76,4 +77,5 @@ public class BetterBloomController : MonoBehaviour
 
         return resList;
     }
+#endif
 }


### PR DESCRIPTION
This PR aims to restore ChroMapper compatibility on Apple Silicon devices by disabling its Harmony patches on macOS.

On current `dev`, this may lead to problematic behavior relating to the Input System, which relies heavily on its Input System patch. However, on `2021.3`, this Harmony patch may be less necessary. If needed, this PR can be re-targeted to `2021.3` and merged there.

Unfortunately, Better Bloom will be completely disabled on macOS, since Universal Render Pipeline still has no option to enable a full resolution bloom effect.

Also to note, Unity does not seem to define specific preprocessor symbols for M1 specifically, so these changes will apply to Intel based Apple devices as well, even though Harmony works just fine on Intel devices.