### PR TITLE
Better Plugin Debuging

### DIFF
--- a/Assets/__Scripts/PluginLoader/Plugin.cs
+++ b/Assets/__Scripts/PluginLoader/Plugin.cs
@@ -39,21 +39,45 @@ public class Plugin
     public string Name { get; }
     public Version Version { get; }
 
-    public void CallMethod<T>()
+    public bool CallMethod<T>()
     {
         methods.TryGetValue(typeof(T), out var methodInfo);
-        methodInfo?.Invoke(pluginInstance, new object[0]);
+        try
+        {
+            methodInfo?.Invoke(pluginInstance, new object[0]);
+            return true;
+        }
+        catch (TargetInvocationException e)
+        {
+            Debug.LogException(e.InnerException);
+        }
+        return false;
     }
 
-    public void CallMethod<T, TS>(TS obj)
+    public bool CallMethod<T, TS>(TS obj)
     {
         methods.TryGetValue(typeof(T), out var methodInfo);
-        methodInfo?.Invoke(pluginInstance, new object[1] { obj });
+        try
+        {
+            methodInfo?.Invoke(pluginInstance, new object[1] { obj });
+            return true;
+        }
+        catch (TargetInvocationException e)
+        {
+            Debug.LogException(e.InnerException);
+        }
+        return false;
     }
 
     public void Init()
     {
-        CallMethod<InitAttribute>();
-        Debug.Log($"Loaded Plugin: {Name} - v{Version}");
+        if (CallMethod<InitAttribute>())
+        {
+            Debug.Log($"Loaded Plugin: {Name} - v{Version}");
+        }
+        else
+        {
+            Debug.LogError($"Error Loading Plugin: {Name} - v{Version}");
+        }
     }
 }

--- a/Assets/__Scripts/PluginLoader/PluginLoader.cs
+++ b/Assets/__Scripts/PluginLoader/PluginLoader.cs
@@ -50,8 +50,9 @@ internal class PluginLoader : MonoBehaviour
                     var plugin = new Plugin(pluginAttribute.Name, assembly.GetName().Version, Activator.CreateInstance(type));
                     plugins.Add(plugin);
                 }
-                catch (Exception) {
+                catch (Exception e) {
                     Debug.LogError($"Incompatible plugin {pluginAttribute.Name}, please check for an update or remove it!");
+                    Debug.LogException(e);
                 }
             }
         }


### PR DESCRIPTION
Does two things:

1. Keep loading plugins if one has an error.
2. Actually give useful exceptions for plugins instead of just a `TargetInvocationException`.