### PR TITLE
Add more keybinds for changing UIMode

### DIFF
--- a/Assets/Input/Master.cs
+++ b/Assets/Input/Master.cs
@@ -3599,6 +3599,60 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""processors"": """",
                     ""interactions"": ""Press"",
                     ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""Toggle UI Mode (Reverse)"",
+                    ""type"": ""Button"",
+                    ""id"": ""20bb8021-4bb8-4be2-94c1-9600fd1a8208"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": ""Press"",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""Toggle UI Mode (Normal)"",
+                    ""type"": ""Button"",
+                    ""id"": ""841b053b-6c5e-43d5-8fbd-844a62f7efa5"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": ""Press"",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""Toggle UI Mode (Hide UI)"",
+                    ""type"": ""Button"",
+                    ""id"": ""e528aa35-53e4-40b4-b036-215fe4563f87"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": ""Press"",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""Toggle UI Mode (Hide Grids)"",
+                    ""type"": ""Button"",
+                    ""id"": ""215e2238-53f3-47d8-8e76-41526ab518cd"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": ""Press"",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""Toggle UI Mode (Preview)"",
+                    ""type"": ""Button"",
+                    ""id"": ""26ce21ba-1236-4447-ac87-1c720bb83468"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": ""Press"",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""Toggle UI Mode (Playing)"",
+                    ""type"": ""Button"",
+                    ""id"": ""7f2f742b-9cdb-43fc-9283-5750cbbb117b"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": ""Press"",
+                    ""initialStateCheck"": false
                 }
             ],
             ""bindings"": [
@@ -3627,11 +3681,209 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                 {
                     ""name"": ""button"",
                     ""id"": ""aa694fd9-9a8b-47b8-a9ac-682e08347b75"",
-                    ""path"": ""<Keyboard>/h"",
+                    ""path"": ""<Keyboard>/e"",
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": ""ChroMapper Default"",
                     ""action"": ""Toggle UI Mode"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": true
+                },
+                {
+                    ""name"": ""Keyboard"",
+                    ""id"": ""c3c30551-3541-4ac6-8ea3-08d7d68eb4d3"",
+                    ""path"": ""ButtonWithOneModifier"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""Toggle UI Mode (Reverse)"",
+                    ""isComposite"": true,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": ""modifier"",
+                    ""id"": ""26fcd8d4-b726-4baf-9a17-e7e252f55b78"",
+                    ""path"": ""<Keyboard>/ctrl"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""ChroMapper Default"",
+                    ""action"": ""Toggle UI Mode (Reverse)"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": true
+                },
+                {
+                    ""name"": ""button"",
+                    ""id"": ""ecf14d89-2c4a-4cd9-b155-8a320aa874d2"",
+                    ""path"": ""<Keyboard>/q"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""ChroMapper Default"",
+                    ""action"": ""Toggle UI Mode (Reverse)"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": true
+                },
+                {
+                    ""name"": ""Keyboard"",
+                    ""id"": ""fd46ba2c-b4fc-4d0a-85a2-f52e94f1056a"",
+                    ""path"": ""ButtonWithOneModifier"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""Toggle UI Mode (Normal)"",
+                    ""isComposite"": true,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": ""modifier"",
+                    ""id"": ""6eafc3d8-5fd7-4d10-9af1-c866d9e8720f"",
+                    ""path"": ""<Keyboard>/ctrl"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""ChroMapper Default"",
+                    ""action"": ""Toggle UI Mode (Normal)"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": true
+                },
+                {
+                    ""name"": ""button"",
+                    ""id"": ""0e4da0ef-b8ff-4490-b12d-744fc9acf8bd"",
+                    ""path"": ""<Keyboard>/1"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""ChroMapper Default"",
+                    ""action"": ""Toggle UI Mode (Normal)"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": true
+                },
+                {
+                    ""name"": ""Keyboard"",
+                    ""id"": ""52e63839-c79f-44a5-8d43-bb17531baa6d"",
+                    ""path"": ""ButtonWithOneModifier"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""Toggle UI Mode (Hide UI)"",
+                    ""isComposite"": true,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": ""modifier"",
+                    ""id"": ""62ef11c8-b1fc-4dcf-aa1d-86dc76d1a99a"",
+                    ""path"": ""<Keyboard>/ctrl"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""ChroMapper Default"",
+                    ""action"": ""Toggle UI Mode (Hide UI)"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": true
+                },
+                {
+                    ""name"": ""button"",
+                    ""id"": ""f6fcc22e-aa0e-4dd2-ac19-e0b2355f4440"",
+                    ""path"": ""<Keyboard>/2"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""ChroMapper Default"",
+                    ""action"": ""Toggle UI Mode (Hide UI)"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": true
+                },
+                {
+                    ""name"": ""Keyboard"",
+                    ""id"": ""4db8ca57-cf15-4f6a-9dca-549213894727"",
+                    ""path"": ""ButtonWithOneModifier"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""Toggle UI Mode (Hide Grids)"",
+                    ""isComposite"": true,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": ""modifier"",
+                    ""id"": ""ac76acc1-8c16-4c50-9076-91fc00a23a60"",
+                    ""path"": ""<Keyboard>/ctrl"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""ChroMapper Default"",
+                    ""action"": ""Toggle UI Mode (Hide Grids)"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": true
+                },
+                {
+                    ""name"": ""button"",
+                    ""id"": ""9e0ee0f1-9f8a-409c-863b-b9e3b963a85f"",
+                    ""path"": ""<Keyboard>/3"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""ChroMapper Default"",
+                    ""action"": ""Toggle UI Mode (Hide Grids)"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": true
+                },
+                {
+                    ""name"": ""Keyboard"",
+                    ""id"": ""f9536119-57b0-4edd-97ca-7a35cfc63f89"",
+                    ""path"": ""ButtonWithOneModifier"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""Toggle UI Mode (Preview)"",
+                    ""isComposite"": true,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": ""modifier"",
+                    ""id"": ""09a48e38-63db-4009-a79c-4d1694c487f8"",
+                    ""path"": ""<Keyboard>/ctrl"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""ChroMapper Default"",
+                    ""action"": ""Toggle UI Mode (Preview)"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": true
+                },
+                {
+                    ""name"": ""button"",
+                    ""id"": ""9c319980-2c8a-4fb5-9f85-f13ef906bde8"",
+                    ""path"": ""<Keyboard>/4"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""ChroMapper Default"",
+                    ""action"": ""Toggle UI Mode (Preview)"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": true
+                },
+                {
+                    ""name"": ""Keyboard"",
+                    ""id"": ""135d8a00-5a10-4669-9110-d451639d5fcb"",
+                    ""path"": ""ButtonWithOneModifier"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""Toggle UI Mode (Playing)"",
+                    ""isComposite"": true,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": ""modifier"",
+                    ""id"": ""6b748aa3-67ab-4f21-9465-69ac4b166280"",
+                    ""path"": ""<Keyboard>/ctrl"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""ChroMapper Default"",
+                    ""action"": ""Toggle UI Mode (Playing)"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": true
+                },
+                {
+                    ""name"": ""button"",
+                    ""id"": ""fd4396f5-7bfb-4a18-846c-3b0813ab0e25"",
+                    ""path"": ""<Keyboard>/5"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""ChroMapper Default"",
+                    ""action"": ""Toggle UI Mode (Playing)"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": true
                 }
@@ -4987,6 +5239,12 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
         // UI Mode
         m_UIMode = asset.FindActionMap("UI Mode", throwIfNotFound: true);
         m_UIMode_ToggleUIMode = m_UIMode.FindAction("Toggle UI Mode", throwIfNotFound: true);
+        m_UIMode_ToggleUIModeReverse = m_UIMode.FindAction("Toggle UI Mode (Reverse)", throwIfNotFound: true);
+        m_UIMode_ToggleUIModeNormal = m_UIMode.FindAction("Toggle UI Mode (Normal)", throwIfNotFound: true);
+        m_UIMode_ToggleUIModeHideUI = m_UIMode.FindAction("Toggle UI Mode (Hide UI)", throwIfNotFound: true);
+        m_UIMode_ToggleUIModeHideGrids = m_UIMode.FindAction("Toggle UI Mode (Hide Grids)", throwIfNotFound: true);
+        m_UIMode_ToggleUIModePreview = m_UIMode.FindAction("Toggle UI Mode (Preview)", throwIfNotFound: true);
+        m_UIMode_ToggleUIModePlaying = m_UIMode.FindAction("Toggle UI Mode (Playing)", throwIfNotFound: true);
         // Song Speed
         m_SongSpeed = asset.FindActionMap("Song Speed", throwIfNotFound: true);
         m_SongSpeed_DecreaseSongSpeed = m_SongSpeed.FindAction("Decrease Song Speed", throwIfNotFound: true);
@@ -7097,11 +7355,23 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
     private readonly InputActionMap m_UIMode;
     private List<IUIModeActions> m_UIModeActionsCallbackInterfaces = new List<IUIModeActions>();
     private readonly InputAction m_UIMode_ToggleUIMode;
+    private readonly InputAction m_UIMode_ToggleUIModeReverse;
+    private readonly InputAction m_UIMode_ToggleUIModeNormal;
+    private readonly InputAction m_UIMode_ToggleUIModeHideUI;
+    private readonly InputAction m_UIMode_ToggleUIModeHideGrids;
+    private readonly InputAction m_UIMode_ToggleUIModePreview;
+    private readonly InputAction m_UIMode_ToggleUIModePlaying;
     public struct UIModeActions
     {
         private @CMInput m_Wrapper;
         public UIModeActions(@CMInput wrapper) { m_Wrapper = wrapper; }
         public InputAction @ToggleUIMode => m_Wrapper.m_UIMode_ToggleUIMode;
+        public InputAction @ToggleUIModeReverse => m_Wrapper.m_UIMode_ToggleUIModeReverse;
+        public InputAction @ToggleUIModeNormal => m_Wrapper.m_UIMode_ToggleUIModeNormal;
+        public InputAction @ToggleUIModeHideUI => m_Wrapper.m_UIMode_ToggleUIModeHideUI;
+        public InputAction @ToggleUIModeHideGrids => m_Wrapper.m_UIMode_ToggleUIModeHideGrids;
+        public InputAction @ToggleUIModePreview => m_Wrapper.m_UIMode_ToggleUIModePreview;
+        public InputAction @ToggleUIModePlaying => m_Wrapper.m_UIMode_ToggleUIModePlaying;
         public InputActionMap Get() { return m_Wrapper.m_UIMode; }
         public void Enable() { Get().Enable(); }
         public void Disable() { Get().Disable(); }
@@ -7114,6 +7384,24 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
             @ToggleUIMode.started += instance.OnToggleUIMode;
             @ToggleUIMode.performed += instance.OnToggleUIMode;
             @ToggleUIMode.canceled += instance.OnToggleUIMode;
+            @ToggleUIModeReverse.started += instance.OnToggleUIModeReverse;
+            @ToggleUIModeReverse.performed += instance.OnToggleUIModeReverse;
+            @ToggleUIModeReverse.canceled += instance.OnToggleUIModeReverse;
+            @ToggleUIModeNormal.started += instance.OnToggleUIModeNormal;
+            @ToggleUIModeNormal.performed += instance.OnToggleUIModeNormal;
+            @ToggleUIModeNormal.canceled += instance.OnToggleUIModeNormal;
+            @ToggleUIModeHideUI.started += instance.OnToggleUIModeHideUI;
+            @ToggleUIModeHideUI.performed += instance.OnToggleUIModeHideUI;
+            @ToggleUIModeHideUI.canceled += instance.OnToggleUIModeHideUI;
+            @ToggleUIModeHideGrids.started += instance.OnToggleUIModeHideGrids;
+            @ToggleUIModeHideGrids.performed += instance.OnToggleUIModeHideGrids;
+            @ToggleUIModeHideGrids.canceled += instance.OnToggleUIModeHideGrids;
+            @ToggleUIModePreview.started += instance.OnToggleUIModePreview;
+            @ToggleUIModePreview.performed += instance.OnToggleUIModePreview;
+            @ToggleUIModePreview.canceled += instance.OnToggleUIModePreview;
+            @ToggleUIModePlaying.started += instance.OnToggleUIModePlaying;
+            @ToggleUIModePlaying.performed += instance.OnToggleUIModePlaying;
+            @ToggleUIModePlaying.canceled += instance.OnToggleUIModePlaying;
         }
 
         private void UnregisterCallbacks(IUIModeActions instance)
@@ -7121,6 +7409,24 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
             @ToggleUIMode.started -= instance.OnToggleUIMode;
             @ToggleUIMode.performed -= instance.OnToggleUIMode;
             @ToggleUIMode.canceled -= instance.OnToggleUIMode;
+            @ToggleUIModeReverse.started -= instance.OnToggleUIModeReverse;
+            @ToggleUIModeReverse.performed -= instance.OnToggleUIModeReverse;
+            @ToggleUIModeReverse.canceled -= instance.OnToggleUIModeReverse;
+            @ToggleUIModeNormal.started -= instance.OnToggleUIModeNormal;
+            @ToggleUIModeNormal.performed -= instance.OnToggleUIModeNormal;
+            @ToggleUIModeNormal.canceled -= instance.OnToggleUIModeNormal;
+            @ToggleUIModeHideUI.started -= instance.OnToggleUIModeHideUI;
+            @ToggleUIModeHideUI.performed -= instance.OnToggleUIModeHideUI;
+            @ToggleUIModeHideUI.canceled -= instance.OnToggleUIModeHideUI;
+            @ToggleUIModeHideGrids.started -= instance.OnToggleUIModeHideGrids;
+            @ToggleUIModeHideGrids.performed -= instance.OnToggleUIModeHideGrids;
+            @ToggleUIModeHideGrids.canceled -= instance.OnToggleUIModeHideGrids;
+            @ToggleUIModePreview.started -= instance.OnToggleUIModePreview;
+            @ToggleUIModePreview.performed -= instance.OnToggleUIModePreview;
+            @ToggleUIModePreview.canceled -= instance.OnToggleUIModePreview;
+            @ToggleUIModePlaying.started -= instance.OnToggleUIModePlaying;
+            @ToggleUIModePlaying.performed -= instance.OnToggleUIModePlaying;
+            @ToggleUIModePlaying.canceled -= instance.OnToggleUIModePlaying;
         }
 
         public void RemoveCallbacks(IUIModeActions instance)
@@ -8306,6 +8612,12 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
     public interface IUIModeActions
     {
         void OnToggleUIMode(InputAction.CallbackContext context);
+        void OnToggleUIModeReverse(InputAction.CallbackContext context);
+        void OnToggleUIModeNormal(InputAction.CallbackContext context);
+        void OnToggleUIModeHideUI(InputAction.CallbackContext context);
+        void OnToggleUIModeHideGrids(InputAction.CallbackContext context);
+        void OnToggleUIModePreview(InputAction.CallbackContext context);
+        void OnToggleUIModePlaying(InputAction.CallbackContext context);
     }
     public interface ISongSpeedActions
     {

--- a/Assets/Input/Master.cs
+++ b/Assets/Input/Master.cs
@@ -3601,7 +3601,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""initialStateCheck"": false
                 },
                 {
-                    ""name"": ""Toggle UI Mode (Reverse)"",
+                    ""name"": ""Toggle UI Mode Reverse"",
                     ""type"": ""Button"",
                     ""id"": ""20bb8021-4bb8-4be2-94c1-9600fd1a8208"",
                     ""expectedControlType"": ""Button"",
@@ -3696,7 +3696,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""Toggle UI Mode (Reverse)"",
+                    ""action"": ""Toggle UI Mode Reverse"",
                     ""isComposite"": true,
                     ""isPartOfComposite"": false
                 },
@@ -3707,7 +3707,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": ""ChroMapper Default"",
-                    ""action"": ""Toggle UI Mode (Reverse)"",
+                    ""action"": ""Toggle UI Mode Reverse"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": true
                 },
@@ -3718,7 +3718,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": ""ChroMapper Default"",
-                    ""action"": ""Toggle UI Mode (Reverse)"",
+                    ""action"": ""Toggle UI Mode Reverse"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": true
                 },
@@ -5239,7 +5239,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
         // UI Mode
         m_UIMode = asset.FindActionMap("UI Mode", throwIfNotFound: true);
         m_UIMode_ToggleUIMode = m_UIMode.FindAction("Toggle UI Mode", throwIfNotFound: true);
-        m_UIMode_ToggleUIModeReverse = m_UIMode.FindAction("Toggle UI Mode (Reverse)", throwIfNotFound: true);
+        m_UIMode_ToggleUIModeReverse = m_UIMode.FindAction("Toggle UI Mode Reverse", throwIfNotFound: true);
         m_UIMode_ToggleUIModeNormal = m_UIMode.FindAction("Toggle UI Mode (Normal)", throwIfNotFound: true);
         m_UIMode_ToggleUIModeHideUI = m_UIMode.FindAction("Toggle UI Mode (Hide UI)", throwIfNotFound: true);
         m_UIMode_ToggleUIModeHideGrids = m_UIMode.FindAction("Toggle UI Mode (Hide Grids)", throwIfNotFound: true);

--- a/Assets/Input/Master.inputactions
+++ b/Assets/Input/Master.inputactions
@@ -3577,6 +3577,60 @@
                     "processors": "",
                     "interactions": "Press",
                     "initialStateCheck": false
+                },
+                {
+                    "name": "Toggle UI Mode (Reverse)",
+                    "type": "Button",
+                    "id": "20bb8021-4bb8-4be2-94c1-9600fd1a8208",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "Press",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Toggle UI Mode (Normal)",
+                    "type": "Button",
+                    "id": "841b053b-6c5e-43d5-8fbd-844a62f7efa5",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "Press",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Toggle UI Mode (Hide UI)",
+                    "type": "Button",
+                    "id": "e528aa35-53e4-40b4-b036-215fe4563f87",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "Press",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Toggle UI Mode (Hide Grids)",
+                    "type": "Button",
+                    "id": "215e2238-53f3-47d8-8e76-41526ab518cd",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "Press",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Toggle UI Mode (Preview)",
+                    "type": "Button",
+                    "id": "26ce21ba-1236-4447-ac87-1c720bb83468",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "Press",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Toggle UI Mode (Playing)",
+                    "type": "Button",
+                    "id": "7f2f742b-9cdb-43fc-9283-5750cbbb117b",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "Press",
+                    "initialStateCheck": false
                 }
             ],
             "bindings": [
@@ -3605,11 +3659,209 @@
                 {
                     "name": "button",
                     "id": "aa694fd9-9a8b-47b8-a9ac-682e08347b75",
-                    "path": "<Keyboard>/h",
+                    "path": "<Keyboard>/e",
                     "interactions": "",
                     "processors": "",
                     "groups": "ChroMapper Default",
                     "action": "Toggle UI Mode",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "Keyboard",
+                    "id": "c3c30551-3541-4ac6-8ea3-08d7d68eb4d3",
+                    "path": "ButtonWithOneModifier",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Toggle UI Mode (Reverse)",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "modifier",
+                    "id": "26fcd8d4-b726-4baf-9a17-e7e252f55b78",
+                    "path": "<Keyboard>/ctrl",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "ChroMapper Default",
+                    "action": "Toggle UI Mode (Reverse)",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "button",
+                    "id": "ecf14d89-2c4a-4cd9-b155-8a320aa874d2",
+                    "path": "<Keyboard>/q",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "ChroMapper Default",
+                    "action": "Toggle UI Mode (Reverse)",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "Keyboard",
+                    "id": "fd46ba2c-b4fc-4d0a-85a2-f52e94f1056a",
+                    "path": "ButtonWithOneModifier",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Toggle UI Mode (Normal)",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "modifier",
+                    "id": "6eafc3d8-5fd7-4d10-9af1-c866d9e8720f",
+                    "path": "<Keyboard>/ctrl",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "ChroMapper Default",
+                    "action": "Toggle UI Mode (Normal)",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "button",
+                    "id": "0e4da0ef-b8ff-4490-b12d-744fc9acf8bd",
+                    "path": "<Keyboard>/1",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "ChroMapper Default",
+                    "action": "Toggle UI Mode (Normal)",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "Keyboard",
+                    "id": "52e63839-c79f-44a5-8d43-bb17531baa6d",
+                    "path": "ButtonWithOneModifier",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Toggle UI Mode (Hide UI)",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "modifier",
+                    "id": "62ef11c8-b1fc-4dcf-aa1d-86dc76d1a99a",
+                    "path": "<Keyboard>/ctrl",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "ChroMapper Default",
+                    "action": "Toggle UI Mode (Hide UI)",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "button",
+                    "id": "f6fcc22e-aa0e-4dd2-ac19-e0b2355f4440",
+                    "path": "<Keyboard>/2",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "ChroMapper Default",
+                    "action": "Toggle UI Mode (Hide UI)",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "Keyboard",
+                    "id": "4db8ca57-cf15-4f6a-9dca-549213894727",
+                    "path": "ButtonWithOneModifier",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Toggle UI Mode (Hide Grids)",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "modifier",
+                    "id": "ac76acc1-8c16-4c50-9076-91fc00a23a60",
+                    "path": "<Keyboard>/ctrl",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "ChroMapper Default",
+                    "action": "Toggle UI Mode (Hide Grids)",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "button",
+                    "id": "9e0ee0f1-9f8a-409c-863b-b9e3b963a85f",
+                    "path": "<Keyboard>/3",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "ChroMapper Default",
+                    "action": "Toggle UI Mode (Hide Grids)",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "Keyboard",
+                    "id": "f9536119-57b0-4edd-97ca-7a35cfc63f89",
+                    "path": "ButtonWithOneModifier",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Toggle UI Mode (Preview)",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "modifier",
+                    "id": "09a48e38-63db-4009-a79c-4d1694c487f8",
+                    "path": "<Keyboard>/ctrl",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "ChroMapper Default",
+                    "action": "Toggle UI Mode (Preview)",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "button",
+                    "id": "9c319980-2c8a-4fb5-9f85-f13ef906bde8",
+                    "path": "<Keyboard>/4",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "ChroMapper Default",
+                    "action": "Toggle UI Mode (Preview)",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "Keyboard",
+                    "id": "135d8a00-5a10-4669-9110-d451639d5fcb",
+                    "path": "ButtonWithOneModifier",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Toggle UI Mode (Playing)",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "modifier",
+                    "id": "6b748aa3-67ab-4f21-9465-69ac4b166280",
+                    "path": "<Keyboard>/ctrl",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "ChroMapper Default",
+                    "action": "Toggle UI Mode (Playing)",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "button",
+                    "id": "fd4396f5-7bfb-4a18-846c-3b0813ab0e25",
+                    "path": "<Keyboard>/5",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "ChroMapper Default",
+                    "action": "Toggle UI Mode (Playing)",
                     "isComposite": false,
                     "isPartOfComposite": true
                 }

--- a/Assets/Input/Master.inputactions
+++ b/Assets/Input/Master.inputactions
@@ -3579,7 +3579,7 @@
                     "initialStateCheck": false
                 },
                 {
-                    "name": "Toggle UI Mode (Reverse)",
+                    "name": "Toggle UI Mode Reverse",
                     "type": "Button",
                     "id": "20bb8021-4bb8-4be2-94c1-9600fd1a8208",
                     "expectedControlType": "Button",
@@ -3674,7 +3674,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "Toggle UI Mode (Reverse)",
+                    "action": "Toggle UI Mode Reverse",
                     "isComposite": true,
                     "isPartOfComposite": false
                 },
@@ -3685,7 +3685,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "ChroMapper Default",
-                    "action": "Toggle UI Mode (Reverse)",
+                    "action": "Toggle UI Mode Reverse",
                     "isComposite": false,
                     "isPartOfComposite": true
                 },
@@ -3696,7 +3696,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "ChroMapper Default",
-                    "action": "Toggle UI Mode (Reverse)",
+                    "action": "Toggle UI Mode Reverse",
                     "isComposite": false,
                     "isPartOfComposite": true
                 },

--- a/Assets/__Scripts/MapEditor/Grid/Collections/ChainGridContainer.cs
+++ b/Assets/__Scripts/MapEditor/Grid/Collections/ChainGridContainer.cs
@@ -1,5 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
 using Beatmap.Appearances;
 using Beatmap.Base;
 using Beatmap.Containers;
@@ -15,9 +13,9 @@ public class ChainGridContainer : BeatmapObjectContainerCollection<BaseChain>
     [SerializeField] private GameObject chainPrefab;
     [SerializeField] private TracksManager tracksManager;
     [SerializeField] private ChainAppearanceSO chainAppearanceSO;
-    
+
     [SerializeField] private CountersPlusController countersPlus;
-    
+
     public const float ViewEpsilon = 0.1f; // original view is too small ?? sometimes cause error.
     public override ObjectType ContainerType => ObjectType.Chain;
 
@@ -70,7 +68,7 @@ public class ChainGridContainer : BeatmapObjectContainerCollection<BaseChain>
         DespawnCallbackController.ChainPassedThreshold += DespawnCallback;
         AudioTimeSyncController.PlayToggle += OnPlayToggle;
         UIMode.UIModeSwitched += OnUIModeSwitch;
-        
+
         Settings.NotifyBySettingName(nameof(Settings.NoteColorMultiplier), AppearanceChanged);
         Settings.NotifyBySettingName(nameof(Settings.ArrowColorMultiplier), AppearanceChanged);
         Settings.NotifyBySettingName(nameof(Settings.ArrowColorWhiteBlend), AppearanceChanged);
@@ -86,7 +84,7 @@ public class ChainGridContainer : BeatmapObjectContainerCollection<BaseChain>
         DespawnCallbackController.ChainPassedThreshold -= DespawnCallback;
         AudioTimeSyncController.PlayToggle -= OnPlayToggle;
         UIMode.UIModeSwitched -= OnUIModeSwitch;
-        
+
         Settings.ClearSettingNotifications(nameof(Settings.NoteColorMultiplier));
         Settings.ClearSettingNotifications(nameof(Settings.ArrowColorMultiplier));
         Settings.ClearSettingNotifications(nameof(Settings.ArrowColorWhiteBlend));
@@ -105,15 +103,11 @@ public class ChainGridContainer : BeatmapObjectContainerCollection<BaseChain>
 
     private void OnUIModeSwitch(UIModeType newMode)
     {
-        // If preview mode changed
-        if (newMode == UIModeType.Normal || newMode == UIModeType.Preview)
-        {
-            RefreshPool(true);
-        }
+        RefreshPool(true);
     }
 
     private void RecursiveCheckFinished(bool natural, int lastPassedIndex) => RefreshPool();
-    
+
     private void AppearanceChanged(object _) => RefreshPool(true);
 
     protected override void OnContainerSpawn(ObjectContainer container, BaseObject obj)

--- a/Assets/__Scripts/MapEditor/Grid/Collections/ChainGridContainer.cs
+++ b/Assets/__Scripts/MapEditor/Grid/Collections/ChainGridContainer.cs
@@ -67,7 +67,7 @@ public class ChainGridContainer : BeatmapObjectContainerCollection<BaseChain>
         SpawnCallbackController.RecursiveChainCheckFinished += RecursiveCheckFinished;
         DespawnCallbackController.ChainPassedThreshold += DespawnCallback;
         AudioTimeSyncController.PlayToggle += OnPlayToggle;
-        UIMode.UIModeSwitched += OnUIModeSwitch;
+        UIMode.PreviewModeSwitched += OnUIPreviewModeSwitch;
 
         Settings.NotifyBySettingName(nameof(Settings.NoteColorMultiplier), AppearanceChanged);
         Settings.NotifyBySettingName(nameof(Settings.ArrowColorMultiplier), AppearanceChanged);
@@ -83,7 +83,7 @@ public class ChainGridContainer : BeatmapObjectContainerCollection<BaseChain>
         SpawnCallbackController.RecursiveChainCheckFinished -= RecursiveCheckFinished;
         DespawnCallbackController.ChainPassedThreshold -= DespawnCallback;
         AudioTimeSyncController.PlayToggle -= OnPlayToggle;
-        UIMode.UIModeSwitched -= OnUIModeSwitch;
+        UIMode.PreviewModeSwitched -= OnUIPreviewModeSwitch;
 
         Settings.ClearSettingNotifications(nameof(Settings.NoteColorMultiplier));
         Settings.ClearSettingNotifications(nameof(Settings.ArrowColorMultiplier));
@@ -101,10 +101,7 @@ public class ChainGridContainer : BeatmapObjectContainerCollection<BaseChain>
         }
     }
 
-    private void OnUIModeSwitch(UIModeType newMode)
-    {
-        RefreshPool(true);
-    }
+    private void OnUIPreviewModeSwitch() => RefreshPool(true);
 
     private void RecursiveCheckFinished(bool natural, int lastPassedIndex) => RefreshPool();
 

--- a/Assets/__Scripts/MapEditor/Grid/Collections/CustomEventGridContainer.cs
+++ b/Assets/__Scripts/MapEditor/Grid/Collections/CustomEventGridContainer.cs
@@ -53,45 +53,47 @@ public class CustomEventGridContainer : BeatmapObjectContainerCollection<BaseCus
         {
             var ev = span[i];
 
-            var tracks = ev.CustomTrack switch {
+            var tracks = ev.CustomTrack switch
+            {
                 JSONArray arr => arr,
                 JSONString s => JSONObject.Parse($"[{s}]").AsArray,
                 _ => null,
             };
             switch (ev.Type)
             {
-            case "AssignTrackParent":
-                if (ev.DataParentTrack == null) continue;
-                var parent = tracksManager.CreateAnimationTrack(ev.DataParentTrack);
-                tracks = ev.DataChildrenTracks switch {
-                    JSONArray arr => arr,
-                    JSONString s => JSONObject.Parse($"[{s}]").AsArray,
-                };
-                foreach (var tr in tracks)
-                {
-                    var at = tracksManager.CreateAnimationTrack(tr.Value);
-                    at.Track.transform.SetParent(parent.Track.ObjectParentTransform, ev.DataWorldPositionStays ?? false);
-                    if (at.Animator == null)
+                case "AssignTrackParent":
+                    if (ev.DataParentTrack == null) continue;
+                    var parent = tracksManager.CreateAnimationTrack(ev.DataParentTrack);
+                    tracks = ev.DataChildrenTracks switch
                     {
-                        at.Animator = at.gameObject.AddComponent<ObjectAnimator>();
-                        at.Animator.Atsc = AudioTimeSyncController;
-                        at.Animator.SetTrack(at.Track, tr.Value);
-                    }
+                        JSONArray arr => arr,
+                        JSONString s => JSONObject.Parse($"[{s}]").AsArray,
+                    };
+                    foreach (var tr in tracks)
+                    {
+                        var at = tracksManager.CreateAnimationTrack(tr.Value);
+                        at.Track.transform.SetParent(parent.Track.ObjectParentTransform, ev.DataWorldPositionStays ?? false);
+                        if (at.Animator == null)
+                        {
+                            at.Animator = at.gameObject.AddComponent<ObjectAnimator>();
+                            at.Animator.Atsc = AudioTimeSyncController;
+                            at.Animator.SetTrack(at.Track, tr.Value);
+                        }
 
-                    if (!parent.Children.Contains(at.Animator))
-                    {
-                        parent.Children.Add(at.Animator);
-                        at.Parents.Add(parent);
-                        at.OnChildrenChanged();
+                        if (!parent.Children.Contains(at.Animator))
+                        {
+                            parent.Children.Add(at.Animator);
+                            at.Parents.Add(parent);
+                            at.OnChildrenChanged();
+                        }
                     }
-                }
-                break;
-            case "AssignPlayerToTrack":
-                if (ev.CustomTrack == null) continue;
-                playerCamera.gameObject.SetActive(true);
-                var track = tracksManager.CreateAnimationTrack(ev.CustomTrack);
-                playerCamera.AddPlayerTrack(ev.JsonTime, track);
-                break;
+                    break;
+                case "AssignPlayerToTrack":
+                    if (ev.CustomTrack == null) continue;
+                    playerCamera.gameObject.SetActive(true);
+                    var track = tracksManager.CreateAnimationTrack(ev.CustomTrack);
+                    playerCamera.AddPlayerTrack(ev.JsonTime, track);
+                    break;
             }
         }
 
@@ -99,7 +101,8 @@ public class CustomEventGridContainer : BeatmapObjectContainerCollection<BaseCus
         geometries.ForEach((gc) => GameObject.Destroy(gc.gameObject));
         geometries.Clear();
 
-        BeatSaberSongContainer.Instance.Map.EnvironmentEnhancements.ForEach((eh) => {
+        BeatSaberSongContainer.Instance.Map.EnvironmentEnhancements.ForEach((eh) =>
+        {
             if (eh.Geometry is JSONNode)
             {
                 var container = GeometryContainer.SpawnGeometry(eh, ref geometryPrefab);
@@ -142,7 +145,8 @@ public class CustomEventGridContainer : BeatmapObjectContainerCollection<BaseCus
         {
             var customEvent = span[i];
 
-            var tracks = customEvent.CustomTrack switch {
+            var tracks = customEvent.CustomTrack switch
+            {
                 JSONString s => new List<string> { s },
                 JSONArray arr => new List<string>(arr.Children.Select(c => (string)c)),
                 _ => new List<string>()
@@ -181,11 +185,7 @@ public class CustomEventGridContainer : BeatmapObjectContainerCollection<BaseCus
 
     private void OnUIModeSwitch(UIModeType newMode)
     {
-        // When changing in/out of preview mode
-        if (newMode is UIModeType.Normal or UIModeType.Preview)
-        {
-            RefreshPool(true);
-        }
+        RefreshPool(true);
     }
 
     public override void RefreshPool(bool force)

--- a/Assets/__Scripts/MapEditor/Grid/Collections/CustomEventGridContainer.cs
+++ b/Assets/__Scripts/MapEditor/Grid/Collections/CustomEventGridContainer.cs
@@ -183,10 +183,7 @@ public class CustomEventGridContainer : BeatmapObjectContainerCollection<BaseCus
         LoadAnimationTracks();
     }
 
-    private void OnUIModeSwitch(UIModeType newMode)
-    {
-        RefreshPool(true);
-    }
+    private void OnUIPreviewModeSwitch() => RefreshPool(true);
 
     public override void RefreshPool(bool force)
     {
@@ -235,7 +232,7 @@ public class CustomEventGridContainer : BeatmapObjectContainerCollection<BaseCus
     internal override void SubscribeToCallbacks()
     {
         LoadInitialMap.LevelLoadedEvent += SetInitialTracks;
-        UIMode.UIModeSwitched += OnUIModeSwitch;
+        UIMode.PreviewModeSwitched += OnUIPreviewModeSwitch;
     }
 
     private void SetInitialTracks()
@@ -257,7 +254,7 @@ public class CustomEventGridContainer : BeatmapObjectContainerCollection<BaseCus
     internal override void UnsubscribeToCallbacks()
     {
         LoadInitialMap.LevelLoadedEvent -= SetInitialTracks;
-        UIMode.UIModeSwitched -= OnUIModeSwitch;
+        UIMode.PreviewModeSwitched -= OnUIPreviewModeSwitch;
     }
 
     private void CreateNewType()

--- a/Assets/__Scripts/MapEditor/Grid/Collections/NoteGridContainer.cs
+++ b/Assets/__Scripts/MapEditor/Grid/Collections/NoteGridContainer.cs
@@ -1,11 +1,8 @@
 using System.Collections.Generic;
-using System.Linq;
-using Beatmap.Animations;
 using Beatmap.Appearances;
 using Beatmap.Base;
 using Beatmap.Containers;
 using Beatmap.Enums;
-using Beatmap.V3;
 using UnityEngine;
 using UnityEngine.Serialization;
 
@@ -13,7 +10,7 @@ public class NoteGridContainer : BeatmapObjectContainerCollection<BaseNote>
 {
     [SerializeField] private GameObject notePrefab;
     [SerializeField] private GameObject bombPrefab;
-    [FormerlySerializedAs("noteAppearanceSO")][SerializeField] private NoteAppearanceSO noteAppearanceSo;
+    [FormerlySerializedAs("noteAppearanceSO")] [SerializeField] private NoteAppearanceSO noteAppearanceSo;
     [SerializeField] private TracksManager tracksManager;
 
     [SerializeField] private CountersPlusController countersPlus;
@@ -57,13 +54,9 @@ public class NoteGridContainer : BeatmapObjectContainerCollection<BaseNote>
 
     private void OnUIModeSwitch(UIModeType newMode)
     {
-        // If preview mode changed
-        if (newMode == UIModeType.Normal || newMode == UIModeType.Preview)
-        {
-            RefreshPool(true);
-        }
+        RefreshPool(true);
     }
-    
+
     private void AppearanceChanged(object _) => RefreshPool(true);
 
     //We don't need to check index as that's already done further up the chain
@@ -162,7 +155,7 @@ public class NoteGridContainer : BeatmapObjectContainerCollection<BaseNote>
         {
             var directionA = NoteContainer.Directionalize(a);
             var directionB = NoteContainer.Directionalize(b);
-            
+
             containerA.DirectionTarget.localEulerAngles = containerA.DirectionTargetEuler = directionA;
             containerB.DirectionTarget.localEulerAngles = containerB.DirectionTargetEuler = directionB;
             return;
@@ -216,15 +209,15 @@ public class NoteGridContainer : BeatmapObjectContainerCollection<BaseNote>
         containerA.DirectionTarget.localEulerAngles = containerA.DirectionTargetEuler;
         containerB.DirectionTarget.localEulerAngles = containerB.DirectionTargetEuler;
     }
-    
+
     public void ClearSpecialAngles(BaseObject obj)
     {
         var note = obj as BaseNote;
-        
+
         PopulateObjectsAtSameTime(note);
         ClearSpecialAnglesFromObjectsAtSameTime();
     }
-    
+
     // Grab all objects with the same type, and time (within epsilon)
     private void PopulateObjectsAtSameTime(BaseNote note)
     {

--- a/Assets/__Scripts/MapEditor/Grid/Collections/NoteGridContainer.cs
+++ b/Assets/__Scripts/MapEditor/Grid/Collections/NoteGridContainer.cs
@@ -27,7 +27,7 @@ public class NoteGridContainer : BeatmapObjectContainerCollection<BaseNote>
         SpawnCallbackController.RecursiveNoteCheckFinished += RecursiveCheckFinished;
         DespawnCallbackController.NotePassedThreshold += DespawnCallback;
         AudioTimeSyncController.PlayToggle += OnPlayToggle;
-        UIMode.UIModeSwitched += OnUIModeSwitch;
+        UIMode.PreviewModeSwitched += OnUIPreviewModeSwitch;
 
         Settings.NotifyBySettingName(nameof(Settings.NoteColorMultiplier), AppearanceChanged);
         Settings.NotifyBySettingName(nameof(Settings.ArrowColorMultiplier), AppearanceChanged);
@@ -40,7 +40,7 @@ public class NoteGridContainer : BeatmapObjectContainerCollection<BaseNote>
         SpawnCallbackController.RecursiveNoteCheckFinished -= RecursiveCheckFinished;
         DespawnCallbackController.NotePassedThreshold -= DespawnCallback;
         AudioTimeSyncController.PlayToggle -= OnPlayToggle;
-        UIMode.UIModeSwitched -= OnUIModeSwitch;
+        UIMode.PreviewModeSwitched -= OnUIPreviewModeSwitch;
 
         Settings.ClearSettingNotifications(nameof(Settings.NoteColorMultiplier));
         Settings.ClearSettingNotifications(nameof(Settings.ArrowColorMultiplier));
@@ -52,10 +52,7 @@ public class NoteGridContainer : BeatmapObjectContainerCollection<BaseNote>
         if (!isPlaying) RefreshPool();
     }
 
-    private void OnUIModeSwitch(UIModeType newMode)
-    {
-        RefreshPool(true);
-    }
+    private void OnUIPreviewModeSwitch() => RefreshPool(true);
 
     private void AppearanceChanged(object _) => RefreshPool(true);
 

--- a/Assets/__Scripts/MapEditor/Grid/Collections/ObstacleGridContainer.cs
+++ b/Assets/__Scripts/MapEditor/Grid/Collections/ObstacleGridContainer.cs
@@ -10,7 +10,7 @@ using UnityEngine.Serialization;
 public class ObstacleGridContainer : BeatmapObjectContainerCollection<BaseObstacle>
 {
     [SerializeField] private GameObject obstaclePrefab;
-    [FormerlySerializedAs("obstacleAppearanceSO")][SerializeField] private ObstacleAppearanceSO obstacleAppearanceSo;
+    [FormerlySerializedAs("obstacleAppearanceSO")] [SerializeField] private ObstacleAppearanceSO obstacleAppearanceSo;
     [SerializeField] private TracksManager tracksManager;
     [SerializeField] private CountersPlusController countersPlus;
 
@@ -21,7 +21,7 @@ public class ObstacleGridContainer : BeatmapObjectContainerCollection<BaseObstac
 
     public BaseObstacle[] DespawnSortedObjects;
     private int despawnIndex;
-    
+
     private static readonly int outsideAlpha = Shader.PropertyToID("_OutsideAlpha");
     private static readonly int mainAlpha = Shader.PropertyToID("_MainAlpha");
 
@@ -69,11 +69,7 @@ public class ObstacleGridContainer : BeatmapObjectContainerCollection<BaseObstac
 
     private void OnUIModeSwitch(UIModeType newMode)
     {
-        // When changing in/out of preview mode
-        if (newMode == UIModeType.Normal ||　newMode == UIModeType.Preview)
-        {
-            RefreshPool(true);
-        }
+        RefreshPool(true);
     }
 
     public void UpdateColor(Color obstacle) => obstacleAppearanceSo.DefaultObstacleColor = obstacle;

--- a/Assets/__Scripts/MapEditor/Grid/Collections/ObstacleGridContainer.cs
+++ b/Assets/__Scripts/MapEditor/Grid/Collections/ObstacleGridContainer.cs
@@ -30,7 +30,7 @@ public class ObstacleGridContainer : BeatmapObjectContainerCollection<BaseObstac
         Shader.SetGlobalFloat(outsideAlpha, 0.25f);
         AudioTimeSyncController.PlayToggle += OnPlayToggle;
         AudioTimeSyncController.TimeChanged += OnTimeChanged;
-        UIMode.UIModeSwitched += OnUIModeSwitch;
+        UIMode.PreviewModeSwitched += OnUIPreviewModeSwitch;
 
         Settings.NotifyBySettingName(nameof(Settings.ObstacleOpacity), ObstacleOpacityChanged);
         ObstacleOpacityChanged(Settings.Instance.ObstacleOpacity);
@@ -40,7 +40,7 @@ public class ObstacleGridContainer : BeatmapObjectContainerCollection<BaseObstac
     {
         AudioTimeSyncController.PlayToggle -= OnPlayToggle;
         AudioTimeSyncController.TimeChanged -= OnTimeChanged;
-        UIMode.UIModeSwitched -= OnUIModeSwitch;
+        UIMode.PreviewModeSwitched -= OnUIPreviewModeSwitch;
 
         Settings.ClearSettingNotifications(nameof(Settings.ObstacleOpacity));
     }
@@ -67,10 +67,7 @@ public class ObstacleGridContainer : BeatmapObjectContainerCollection<BaseObstac
         }
     }
 
-    private void OnUIModeSwitch(UIModeType newMode)
-    {
-        RefreshPool(true);
-    }
+    private void OnUIPreviewModeSwitch() => RefreshPool(true);
 
     public void UpdateColor(Color obstacle) => obstacleAppearanceSo.DefaultObstacleColor = obstacle;
 

--- a/Assets/__Scripts/MapEditor/UI/UIMode.cs
+++ b/Assets/__Scripts/MapEditor/UI/UIMode.cs
@@ -16,6 +16,7 @@ public class UIMode : MonoBehaviour, CMInput.IUIModeActions
     private Quaternion savedCamRotation = Quaternion.identity;
 
     public static Action<UIModeType> UIModeSwitched;
+    public static Action PreviewModeSwitched;
 
     [SerializeField] private GameObject modesGameObject;
     [SerializeField] private RectTransform selected;
@@ -47,6 +48,7 @@ public class UIMode : MonoBehaviour, CMInput.IUIModeActions
         modes.AddRange(modesGameObject.transform.GetComponentsInChildren<TextMeshProUGUI>());
         canvasGroup = GetComponent<CanvasGroup>();
         UIModeSwitched = null;
+        PreviewModeSwitched = null;
         SelectedMode = UIModeType.Normal;
         savedCamPosition = Settings.Instance.SavedPositions[0]?.Position ?? savedCamPosition;
         savedCamRotation = Settings.Instance.SavedPositions[0]?.Rotation ?? savedCamRotation;
@@ -180,10 +182,18 @@ public class UIMode : MonoBehaviour, CMInput.IUIModeActions
 
     public void SetUIMode(int modeID, bool showUIChange = true)
     {
+        var previousPreviewMode = PreviewMode;
+        
         SelectedMode = (UIModeType)modeID;
-        PreviewMode = (SelectedMode == UIModeType.Playing || SelectedMode == UIModeType.Preview);
+        PreviewMode = SelectedMode is UIModeType.Playing or UIModeType.Preview;
         AnimationMode = PreviewMode && Settings.Instance.Animations;
+
+        if (previousPreviewMode != PreviewMode)
+        {
+            PreviewModeSwitched?.Invoke();
+        }
         UIModeSwitched?.Invoke(SelectedMode);
+        
         selected.SetParent(modes[modeID].transform, true);
         slideSelectionCoroutine = StartCoroutine(SlideSelection());
         if (showUIChange) showUI = StartCoroutine(ShowUI());

--- a/Assets/__Scripts/MapEditor/UI/UIMode.cs
+++ b/Assets/__Scripts/MapEditor/UI/UIMode.cs
@@ -69,7 +69,7 @@ public class UIMode : MonoBehaviour, CMInput.IUIModeActions
 
     public void OnToggleUIMode(InputAction.CallbackContext context)
     {
-        if (context.performed && !BPMTapperController.IsActive)
+        if (context.performed)
         {
             ToggleUIMode(true);
         }

--- a/Assets/__Scripts/MapEditor/UI/UIMode.cs
+++ b/Assets/__Scripts/MapEditor/UI/UIMode.cs
@@ -38,7 +38,7 @@ public class UIMode : MonoBehaviour, CMInput.IUIModeActions
     private MapEditorUI mapEditorUi;
     private Coroutine showUI;
     private Coroutine slideSelectionCoroutine;
-    
+
     private static readonly int enableNoteSurfaceGridLine = Shader.PropertyToID("_EnableNoteSurfaceGridLine");
 
     private void Awake()
@@ -69,33 +69,94 @@ public class UIMode : MonoBehaviour, CMInput.IUIModeActions
     {
         if (context.performed && !BPMTapperController.IsActive)
         {
-            var currentOption = selected.parent.GetSiblingIndex();
-            var nextOption = currentOption + 1;
+            ToggleUIMode(true);
+        }
+    }
 
-            if (nextOption < 0)
-            {
-                nextOption = modes.Count - 1;
-            }
+    public void OnToggleUIModeReverse(InputAction.CallbackContext context)
+    {
+        if (context.performed)
+        {
+            ToggleUIMode(false);
+        }
+    }
 
-            if (nextOption >= modes.Count) nextOption = 0;
+    void CMInput.IUIModeActions.OnToggleUIModeNormal(InputAction.CallbackContext context)
+    {
+        if (context.performed && SelectedMode != UIModeType.Normal)
+        {
+            UpdateCameraOnUIModeToggle(UIModeType.Normal);
+            SetUIMode(UIModeType.Normal, true);
+        }
+    }
+    void CMInput.IUIModeActions.OnToggleUIModeHideUI(InputAction.CallbackContext context)
+    {
+        if (context.performed && SelectedMode != UIModeType.HideUI)
+        {
+            UpdateCameraOnUIModeToggle(UIModeType.HideUI);
+            SetUIMode(UIModeType.HideUI, true);
+        }
+    }
+    void CMInput.IUIModeActions.OnToggleUIModeHideGrids(InputAction.CallbackContext context)
+    {
+        if (context.performed && SelectedMode != UIModeType.HideGrids)
+        {
+            UpdateCameraOnUIModeToggle(UIModeType.HideGrids);
+            SetUIMode(UIModeType.HideGrids, true);
+        }
+    }
+    void CMInput.IUIModeActions.OnToggleUIModePreview(InputAction.CallbackContext context)
+    {
+        if (context.performed && SelectedMode != UIModeType.Preview)
+        {
+            UpdateCameraOnUIModeToggle(UIModeType.Preview);
+            SetUIMode(UIModeType.Preview, true);
+        }
+    }
+    void CMInput.IUIModeActions.OnToggleUIModePlaying(InputAction.CallbackContext context)
+    {
+        if (context.performed && SelectedMode != UIModeType.Playing)
+        {
+            UpdateCameraOnUIModeToggle(UIModeType.Playing);
+            SetUIMode(UIModeType.Playing, true);
+        }
+    }
 
-            if (currentOption == (int)UIModeType.Playing && nextOption != currentOption)
-            {
-                // restore cam position/rotation
-                cameraManager.SelectCamera(CameraType.Editing);
-                cameraManager.SelectedCameraController.transform.SetPositionAndRotation(savedCamPosition,
-                    savedCamRotation);
-            }
-            else if (nextOption == (int)UIModeType.Playing)
-            {
-                // save cam position/rotation
-                var cameraTransform = cameraManager.SelectedCameraController.transform;
-                savedCamPosition = cameraTransform.position;
-                savedCamRotation = cameraTransform.rotation;
-                cameraManager.SelectCamera(CameraType.Playing);
-            }
+    private void ToggleUIMode(bool forward)
+    {
+        var currentOption = selected.parent.GetSiblingIndex();
+        var nextOption = currentOption + (forward ? 1 : -1);
 
-            SetUIMode(nextOption);
+        if (nextOption < 0)
+        {
+            nextOption = modes.Count - 1;
+        }
+
+        if (nextOption >= modes.Count) nextOption = 0;
+
+        UpdateCameraOnUIModeToggle((UIModeType)nextOption);
+
+        SetUIMode(nextOption);
+    }
+
+    private void UpdateCameraOnUIModeToggle(UIModeType mode)
+    {
+        var currentOption = selected.parent.GetSiblingIndex();
+
+        if (currentOption == (int)UIModeType.Playing && ((int)mode) != currentOption)
+        {
+            // restore cam position/rotation
+            cameraManager.SelectCamera(CameraType.Editing);
+            cameraManager.SelectedCameraController.transform.SetPositionAndRotation(savedCamPosition,
+                savedCamRotation);
+        }
+        else if (mode == UIModeType.Playing)
+        {
+            // save cam position/rotation
+            var cameraTransform = cameraManager.SelectedCameraController.transform;
+            savedCamPosition = cameraTransform.position;
+            savedCamRotation = cameraTransform.rotation;
+            cameraManager.SelectCamera(CameraType.Playing);
         }
     }
 
@@ -156,7 +217,7 @@ public class UIMode : MonoBehaviour, CMInput.IUIModeActions
         foreach (var c in canvases) c.enabled = showCanvases;
 
         // If this is not used, then there is a chance the moved items may break.
-        var fixTheCam = cameraManager.SelectedCameraController.LockedOntoNoteGrid; 
+        var fixTheCam = cameraManager.SelectedCameraController.LockedOntoNoteGrid;
         if (fixTheCam) cameraManager.SelectedCameraController.LockedOntoNoteGrid = false;
 
         if (showPlacement)
@@ -262,6 +323,7 @@ public class UIMode : MonoBehaviour, CMInput.IUIModeActions
     /// Clear all <see cref="Action"/>s associated with a UI mode change
     /// </summary>
     public static void ClearUIModeNotifications() => actions.Clear();
+
 }
 
 


### PR DESCRIPTION
This adds multiple new keybindings for changing the current UIMode of the editor as well as changes the current `Ctrl + H` keybinding.

Keybindings Changes:
- Toggle UI Mode: `Ctrl + E`
- Toggle UI Mode (Reverse): `Ctrl + Q`
- Toggle UI Mode (Normal): `Ctrl + 1`
- Toggle UI Mode (Hide UI): `Ctrl + 2`
- Toggle UI Mode (Hide Grids): `Ctrl + 3`
- Toggle UI Mode (Preview): `Ctrl + 4`
- Toggle UI Mode (Playing): `Ctrl + 5`

Video showing the changes:

https://github.com/Caeden117/ChroMapper/assets/40338395/a2f76592-5302-4ba8-8bc9-cbffe223430a

