### PR TITLE
Fix the open config folder button on Linux

### DIFF
--- a/Assets/__Scripts/MapEditor/MapExporter.cs
+++ b/Assets/__Scripts/MapEditor/MapExporter.cs
@@ -162,28 +162,6 @@ public struct MapExporter
         }
 
         var path = song.Directory;
-#if UNITY_STANDALONE_WIN
-        path = path.Replace("/", "\\").Replace("\\\\", "\\");
-#else
-        path = path.Replace("\\", "/").Replace("//", "/");
-#endif
-        if (!path.StartsWith("\"")) path = "\"" + path;
-        if (!path.EndsWith("\"")) path += "\"";
-
-#if UNITY_STANDALONE_WIN
-        Debug.Log($"Opening song directory ({path}) with Windows...");
-        Process.Start("explorer.exe", path);
-#elif UNITY_STANDALONE_OSX
-        Debug.Log($"Opening song directory ({path}) with Mac...");
-        Process.Start("open", path);
-#elif UNITY_STANDALONE_LINUX
-        Debug.Log($"Opening song directory ({path}) with Linux...");
-        Process.Start("xdg-open", path);
-#else
-        Debug.Log("What is this, some UNIX bullshit?");
-        PersistentUI.Instance.ShowDialogBox(
-            "Unrecognized OS!\n\nIf you happen to know this OS and would like to contribute," +
-            " please contact me on Discord: Caeden117#0117", null, PersistentUI.DialogBoxPresetType.Ok);
-#endif
+        OSTools.OpenFileBrowser(path);
     }
 }

--- a/Assets/__Scripts/OSTools.cs
+++ b/Assets/__Scripts/OSTools.cs
@@ -1,0 +1,28 @@
+
+
+public class OSTools
+{
+    public static void OpenFileBrowser(string path)
+    {
+#if UNITY_STANDALONE_WIN
+        path = path.Replace("/", "\\").Replace("\\\\", "\\");
+#else
+        path = path.Replace("\\", "/").Replace("//", "/");
+#endif
+
+        if (!path.StartsWith("\"")) path = "\"" + path;
+        if (!path.EndsWith("\"")) path += "\"";
+
+#if UNITY_STANDALONE_WIN
+        System.Diagnostics.Process.Start("explorer.exe", $"{path}");
+#elif UNITY_STANDALONE_OSX
+        System.Diagnostics.Process.Start("open", path);
+#elif UNITY_STANDALONE_LINUX
+        System.Diagnostics.Process.Start("xdg-open", path);
+#else
+        Debug.LogError(
+            "Unrecognized OS! If you happen to know this OS and would like to contribute," +
+            " please contact me on Discord: Caeden117#0117");
+#endif
+    }
+}

--- a/Assets/__Scripts/OSTools.cs.meta
+++ b/Assets/__Scripts/OSTools.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e626bf4214b4c4c78b4d471b81d245ae
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/__Scripts/UI/DevConsole.cs
+++ b/Assets/__Scripts/UI/DevConsole.cs
@@ -149,14 +149,7 @@ public class DevConsole : MonoBehaviour, ILogHandler, CMInput.IDebugActions
         try
         {
             var path = Application.persistentDataPath;
-#if UNITY_STANDALONE_WIN
-            path = path.Replace("/", "\\").Replace("\\\\", "\\");
-            System.Diagnostics.Process.Start("explorer.exe", $"\"{path}\"");
-#elif UNITY_STANDALONE_OSX
-            System.Diagnostics.Process.Start("open", path);
-#elif UNITY_STANDALONE_LINUX
-            System.Diagnostics.Process.Start("xdg-open", path);
-#endif
+            OSTools.OpenFileBrowser(path);
         }
         catch
         {

--- a/Assets/__Scripts/UI/DevConsole.cs
+++ b/Assets/__Scripts/UI/DevConsole.cs
@@ -155,7 +155,7 @@ public class DevConsole : MonoBehaviour, ILogHandler, CMInput.IDebugActions
 #elif UNITY_STANDALONE_OSX
             System.Diagnostics.Process.Start("open", path);
 #elif UNITY_STANDALONE_LINUX
-            System.Diagnostics.Process.Start("open", path);
+            System.Diagnostics.Process.Start("xdg-open", path);
 #endif
         }
         catch

--- a/Assets/__Scripts/UI/Options/OptionsController.cs
+++ b/Assets/__Scripts/UI/Options/OptionsController.cs
@@ -48,21 +48,7 @@ public class OptionsController : MenuBase
         if (!Directory.Exists(pluginsDir))
             Directory.CreateDirectory(pluginsDir);
 
-#if UNITY_STANDALONE_WIN
-        Debug.Log($"Opening plugins directory ({pluginsDir}) with Windows...");
-        Process.Start("explorer.exe", pluginsDir);
-#elif UNITY_STANDALONE_OSX
-        Debug.Log($"Opening plugins directory ({pluginsDir}) with Mac...");
-        Process.Start("open", pluginsDir);
-#elif UNITY_STANDALONE_LINUX
-        Debug.Log($"Opening plugins directory ({pluginsDir}) with Linux...");
-        Process.Start("xdg-open", pluginsDir);
-#else
-        Debug.Log("What is this, some UNIX bullshit?");
-        PersistentUI.Instance.ShowDialogBox(
-            "Unrecognized OS!\n\nIf you happen to know this OS and would like to contribute," +
-            " please contact me on Discord: Caeden117#0117", null, PersistentUI.DialogBoxPresetType.Ok);
-#endif
+        OSTools.OpenFileBrowser(pluginsDir);
     }
 
     private IEnumerator CloseOptions()


### PR DESCRIPTION
Uses the same behavior as MapExporter and OptionsController.
*This should probably be made into a helper function somewhere if you have a good place to put it.*