### PR TITLE
Exclude geometry lights from propid

### DIFF
--- a/Assets/__Scripts/Beatmap/Appearances/GeometryAppearanceSO.cs
+++ b/Assets/__Scripts/Beatmap/Appearances/GeometryAppearanceSO.cs
@@ -90,6 +90,7 @@ namespace Beatmap.Appearances
                 light.OverrideLightGroup = true;
                 light.OverrideLightGroupID = eh.LightType ?? 0;
                 light.LightID = eh.LightID ?? 0;
+                light.PropGroup = -1;
             }
         }
 

--- a/Assets/__Scripts/Platforms/LightsManager.cs
+++ b/Assets/__Scripts/Platforms/LightsManager.cs
@@ -59,6 +59,7 @@ public class LightsManager : MonoBehaviour
 
     public LightGroup[] GroupLightsBasedOnZ() => ControllingLights
         .Where(x => x.gameObject.activeInHierarchy)
+        .Where(x => x.PropGroup >= 0)
         .GroupBy(x => Mathf.RoundToInt(x.PropGroup))
         .OrderBy(x => x.Key)
         .Select(x => new LightGroup { Lights = x.ToList() })


### PR DESCRIPTION
Fixes an issue where all geometry-added light ids are grouped under propid 1

Example:
![Screenshot from 2024-07-15 13:15:44](https://github.com/user-attachments/assets/0b3aaf5a-26e9-4429-90e7-3f9b2c903317)
