### PR TITLE
Local Bug Reports

### DIFF
--- a/Assets/__Scripts/UI/DevConsole.cs
+++ b/Assets/__Scripts/UI/DevConsole.cs
@@ -144,11 +144,20 @@ public class DevConsole : MonoBehaviour, ILogHandler, CMInput.IDebugActions
         StartCoroutine(nameof(ScrollToBottom));
     }
 
-    public void OpenFolder()
+    // grumble grumble grumble im not feeling like doing this right
+    public static void OpenFolder(string subfolder = null)
     {
         try
         {
             var path = Application.persistentDataPath;
+
+            if (!string.IsNullOrWhiteSpace(subfolder))
+            {
+                path = Path.Combine(path, subfolder);
+            }
+
+            Directory.CreateDirectory(subfolder);
+
             OSTools.OpenFileBrowser(path);
         }
         catch


### PR DESCRIPTION
Our current text hosting service [paste.ee](https://paste.ee) has been unreliable as of late, with a period of downtime preventing CM bug reports from being generated, to browsers flagging paste.ee as a phishing site and causing distrust in users (and, to some extent, myself).

This PR removes paste.ee as the host for bug reports. ChroMapper will generate all bug reports on the local file system, in a `Bug Reports` subfolder in persistent data. When generating a bug report, ChroMapper will now open OS's file explorer instead of the web browser.