### PR TITLE
Fix ghost/stacked objects caused by group modified actions 

### DIFF
--- a/Assets/Tests/NotesContainerTest.cs
+++ b/Assets/Tests/NotesContainerTest.cs
@@ -300,7 +300,13 @@ namespace Tests
             var selectionController = root.GetComponentInChildren<SelectionController>();
             selectionController.MoveSelection(-2);
 
-            notesContainer.DeleteObject(baseNoteB);
+            var baseNoteBAfterMove = new BaseNote
+            {
+                JsonTime = 1,
+                Type = (int)NoteType.Red
+            };
+
+            notesContainer.DeleteObject(baseNoteBAfterMove);
 
             Assert.AreEqual(1, notesContainer.LoadedContainers.Count);
             Assert.AreEqual(1, notesContainer.MapObjects.Count);

--- a/Assets/Tests/SimpleMirrorTest.cs
+++ b/Assets/Tests/SimpleMirrorTest.cs
@@ -48,7 +48,47 @@ namespace Tests
         }
 
         [Test]
-        public void MirrorME()
+        public void MirrorNoteDouble()
+        {
+            
+            var notesContainer = BeatmapObjectContainerCollection.GetCollectionForType<NoteGridContainer>(ObjectType.Note);
+            var root = notesContainer.transform.root;
+            var notePlacement = root.GetComponentInChildren<NotePlacement>();
+
+            var baseNoteA = new BaseNote{ JsonTime = 2, PosX = (int)GridX.MiddleLeft, PosY = (int)GridY.Base, Type = (int)NoteType.Red, CutDirection = (int)NoteCutDirection.Down };
+            var baseNoteB = new BaseNote{ JsonTime = 2, PosX = (int)GridX.MiddleRight, PosY = (int)GridY.Base, Type = (int)NoteType.Blue, CutDirection = (int)NoteCutDirection.Down };
+            
+            PlaceUtils.PlaceNote(notePlacement, baseNoteA);
+            PlaceUtils.PlaceNote(notePlacement, baseNoteB);
+
+            SelectionController.Select(baseNoteA);
+            SelectionController.Select(baseNoteB, addsToSelection: true);
+
+            _mirror.Mirror();
+            AssertNoteDoubleState(notesContainer);
+            
+            _mirror.Mirror();
+            AssertNoteDoubleState(notesContainer);
+            
+            _actionContainer.Undo();
+            AssertNoteDoubleState(notesContainer);
+            
+            _actionContainer.Undo();
+            AssertNoteDoubleState(notesContainer);
+        }
+
+        private void AssertNoteDoubleState(NoteGridContainer notesContainer)
+        {
+            Assert.AreEqual(2, notesContainer.MapObjects.Count, "Notes should not be deleted");
+            Assert.AreEqual(2, SelectionController.SelectedObjects.Count, "Mirrored notes should be selected");
+            CheckUtils.CheckNote("Left note after mirror", notesContainer, 0, 2, (int)GridX.MiddleLeft, (int)GridY.Base,
+                (int)NoteType.Red, (int)NoteCutDirection.Down, 0);
+            CheckUtils.CheckNote("Right note after mirror", notesContainer, 1, 2, (int)GridX.MiddleRight, (int)GridY.Base,
+                (int)NoteType.Blue, (int)NoteCutDirection.Down, 0);
+        }
+
+        [Test]
+        public void MirrorNoteME()
         {
             var notesContainer = BeatmapObjectContainerCollection.GetCollectionForType<NoteGridContainer>(ObjectType.Note);
             var root = notesContainer.transform.root;
@@ -306,7 +346,7 @@ namespace Tests
 
         // TODO: update rotation event test for more representative
         [Test]
-        public void MirrorRotation()
+        public void MirrorRotationEvent()
         {
             var rotationCb = Object.FindObjectOfType<RotationCallbackController>();
             rotationCb.Start();

--- a/Assets/__Scripts/BeatmapActions/Beatmap Actions/ActionCollectionAction.cs
+++ b/Assets/__Scripts/BeatmapActions/Beatmap Actions/ActionCollectionAction.cs
@@ -10,14 +10,16 @@ using Beatmap.Containers;
  * 
  * In a nutshell, this is an Action that groups together multiple other Actions, which are mass undone/redone.
  * This is useful for storing many separate Actions that need to be grouped together, and not clog up the queue.
+ *
+ * Note that the undos and redos are performed in order. If these undos can result in overlapping objects such that the
+ * next undo will affect the wrong object this can cause seemingly random unselected, ghost, or stacked object.
+ * For this case, use BeatmapObjectModifiedCollectionAction
  */
 public class ActionCollectionAction : BeatmapAction
 {
     private IEnumerable<BeatmapAction> actions;
     private bool clearSelection;
     private bool forceRefreshesPool;
-
-    public ActionCollectionAction() : base() { }
 
     public ActionCollectionAction(IEnumerable<BeatmapAction> beatmapActions, bool forceRefreshPool = false,
         bool clearsSelection = true, string comment = "No comment.")
@@ -71,7 +73,7 @@ public class ActionCollectionAction : BeatmapAction
 
     protected override void RefreshEventAppearance()
     {
-        var events = actions.SelectMany(x => x.Data).OfType<BaseEvent>();
+        var events = actions.SelectMany(x => x.Data).OfType<BaseEvent>().ToList();
         if (!events.Any())
             return;
 

--- a/Assets/__Scripts/BeatmapActions/Beatmap Actions/BeatmapObjectModifiedCollectionAction.cs
+++ b/Assets/__Scripts/BeatmapActions/Beatmap Actions/BeatmapObjectModifiedCollectionAction.cs
@@ -1,0 +1,100 @@
+using System.Collections.Generic;
+using System.Linq;
+using LiteNetLib.Utils;
+using Beatmap.Base;
+using NetDataReader = LiteNetLib.Utils.NetDataReader;
+
+/*
+ * Alternative to ActionCollectionAction that removes all objects and then re adds them on undo/redo.
+ * No modifying in-place should ensure map objects don't run into weird stacked/ghost issues. 
+ */
+public class BeatmapObjectModifiedCollectionAction : BeatmapAction
+{
+    private List<BaseObject> editedObjects;
+    private List<BaseObject> originalObjects;
+    
+    private readonly float firstBpmEventJsonTime;
+
+    public BeatmapObjectModifiedCollectionAction(List<BaseObject> editedObjects, List<BaseObject> originalObjects,
+        string comment = "No comment.") : base(editedObjects.Concat(originalObjects), comment)
+    {
+        this.editedObjects = editedObjects;
+        this.originalObjects = originalObjects;
+
+        firstBpmEventJsonTime = Data.OfType<BaseBpmEvent>().DefaultIfEmpty().Min(x => x?.JsonTime ?? -1f);
+    }
+
+    public override BaseObject DoesInvolveObject(BaseObject obj)
+    {
+        var involvedObject = editedObjects.Find(x => x == obj);
+        involvedObject ??= originalObjects.Find(x => x == obj);
+        
+        return involvedObject;
+    }
+
+    public override void Undo(BeatmapActionContainer.BeatmapActionParams param)
+    {
+        foreach (var obj in editedObjects)
+        {
+            DeleteObject(obj, false);
+            SelectionController.Deselect(obj, false);
+        }
+
+        foreach (var obj in originalObjects)
+        {
+            SpawnObject(obj, false, false);
+            
+            if (!Networked)
+            {
+                SelectionController.Select(obj, true, true, false);
+            }
+        }
+
+        if (firstBpmEventJsonTime >= 0)
+        {
+            BeatmapObjectContainerCollection.RefreshFutureObjectsPosition(firstBpmEventJsonTime);
+        }
+        
+        RefreshPools(Data);
+        RefreshEventAppearance();
+    }
+
+    public override void Redo(BeatmapActionContainer.BeatmapActionParams param)
+    {
+        foreach (var obj in originalObjects)
+        {
+            DeleteObject(obj, false);
+            SelectionController.Deselect(obj, false);
+        }
+
+        foreach (var obj in editedObjects)
+        {
+            SpawnObject(obj, false, false);
+            
+            if (!Networked)
+            {
+                SelectionController.Select(obj, true, true, false);
+            }
+        }
+
+        if (firstBpmEventJsonTime >= 0)
+        {
+            BeatmapObjectContainerCollection.RefreshFutureObjectsPosition(firstBpmEventJsonTime);
+        }
+        
+        RefreshPools(Data);
+        RefreshEventAppearance();
+    }
+
+    public override void Serialize(NetDataWriter writer)
+    {
+        SerializeBeatmapObjectList(writer, editedObjects);
+        SerializeBeatmapObjectList(writer, originalObjects);
+    }
+
+    public override void Deserialize(NetDataReader reader)
+    {
+        editedObjects = DeserializeBeatmapObjectList(reader).ToList();
+        originalObjects = DeserializeBeatmapObjectList(reader).ToList();
+    }
+}

--- a/Assets/__Scripts/BeatmapActions/Beatmap Actions/BeatmapObjectModifiedCollectionAction.cs.meta
+++ b/Assets/__Scripts/BeatmapActions/Beatmap Actions/BeatmapObjectModifiedCollectionAction.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 18e19a0ecedc425e9e8621db2ec2a99c
+timeCreated: 1734004007

--- a/Assets/__Scripts/BeatmapActions/BeatmapAction.cs
+++ b/Assets/__Scripts/BeatmapActions/BeatmapAction.cs
@@ -108,13 +108,19 @@ public abstract class BeatmapAction : INetSerializable
 
     protected virtual void RefreshEventAppearance()
     {
-        var events = Data.OfType<BaseEvent>();
+        var events = Data.OfType<BaseEvent>().ToList();
         if (!events.Any())
             return;
 
         var eventContainer = BeatmapObjectContainerCollection.GetCollectionForType<EventGridContainer>(ObjectType.Event);
         eventContainer.MarkEventsToBeRelinked(events);
         eventContainer.LinkAllLightEvents();
-        eventContainer.RefreshEventsAppearance(events);
+        foreach (var evt in events)
+        {
+            if (evt.Prev != null && eventContainer.LoadedContainers.TryGetValue(evt.Prev, out var evtPrevContainer))
+                (evtPrevContainer as EventContainer).RefreshAppearance();
+            if (eventContainer.LoadedContainers.TryGetValue(evt, out var evtContainer))
+                (evtContainer as EventContainer).RefreshAppearance();
+        }
     }
 }

--- a/Assets/__Scripts/MapEditor/Mapping/Selection/SelectionController.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/Selection/SelectionController.cs
@@ -470,38 +470,35 @@ public class SelectionController : MonoBehaviour, CMInput.ISelectingActions, CMI
 
     public void MoveSelection(float beats, bool snapObjects = false)
     {
-        var allActions = new List<BeatmapAction>();
-        foreach (var data in SelectedObjects)
+        var originalObjects = new List<BaseObject>();
+        var editedObjects = new List<BaseObject>();
+        
+        foreach (var original in SelectedObjects)
         {
-            var collection = BeatmapObjectContainerCollection.GetCollectionForType(data.ObjectType);
-            var original = BeatmapFactory.Clone(data);
-
-            collection.DeleteObject(data, false, false, default, true, false);
-
-            data.JsonTime += beats;
+            var edited = BeatmapFactory.Clone(original);
+            
+            edited.JsonTime += beats;
             if (snapObjects)
-                data.JsonTime = Mathf.Round(beats / (1f / atsc.GridMeasureSnapping)) * (1f / atsc.GridMeasureSnapping);
+                edited.JsonTime = Mathf.Round(beats / (1f / atsc.GridMeasureSnapping)) * (1f / atsc.GridMeasureSnapping);
 
-            if (data is BaseSlider slider)
+            if (edited is BaseSlider slider)
             {
                 slider.TailJsonTime += beats;
                 if (snapObjects)
                     slider.TailJsonTime = Mathf.Round(beats / (1f / atsc.GridMeasureSnapping)) * (1f / atsc.GridMeasureSnapping);
             }
 
-            collection.SpawnObject(data, false, true);
-
-            allActions.Add(new BeatmapObjectModifiedAction(data, data, original, "", true));
+            editedObjects.Add(edited);
+            originalObjects.Add(original);
         }
 
         RefreshMovedEventsAppearance(SelectedObjects.OfType<BaseEvent>());
-        BeatmapActionContainer.AddAction(new ActionCollectionAction(allActions, true, true, "Shifted a selection of objects."));
-        BeatmapObjectContainerCollection.RefreshAllPools();
+        BeatmapActionContainer.AddAction(new BeatmapObjectModifiedCollectionAction(editedObjects, originalObjects, "Shifted a selection of objects."), perform: true);
     }
 
     public void ShiftSelection(int leftRight, int upDown)
     {
-        var allActions = SelectedObjects.AsParallel().Select(original =>
+        var editedObjects = SelectedObjects.AsParallel().Select(original =>
         {
             var edited = BeatmapFactory.Clone(original);
             if (edited is BaseNote note)
@@ -703,14 +700,14 @@ public class SelectionController : MonoBehaviour, CMInput.ISelectingActions, CMI
             }
 
             edited.SaveCustom();
-            
-            return new BeatmapObjectModifiedAction(edited, original, original, "", true);
+
+            return edited;
         }).ToList();
 
-        RefreshMovedEventsAppearance(SelectedObjects.OfType<BaseEvent>());
-
+        var originalObjects = SelectedObjects.ToList();
+        
         BeatmapActionContainer.AddAction(
-            new ActionCollectionAction(allActions, true, true, "Shifted a selection of objects."), true);
+            new BeatmapObjectModifiedCollectionAction(editedObjects, originalObjects, "Shifted a selection of objects."), true);
         tracksManager.RefreshTracks();
     }
 

--- a/Assets/__Scripts/MapEditor/UI/MirrorSelection.cs
+++ b/Assets/__Scripts/MapEditor/UI/MirrorSelection.cs
@@ -70,7 +70,8 @@ public class MirrorSelection : MonoBehaviour
         }
 
         var events = BeatmapObjectContainerCollection.GetCollectionForType<EventGridContainer>(ObjectType.Event);
-        var allActions = new List<BeatmapAction>();
+        var originalObjects = new List<BaseObject>();
+        var editedObjects = new List<BaseObject>();
         foreach (var original in SelectionController.SelectedObjects)
         {
             var edited = BeatmapFactory.Clone(original);
@@ -379,12 +380,10 @@ public class MirrorSelection : MonoBehaviour
 
             edited.SaveCustom();
 
-            allActions.Add(new BeatmapObjectModifiedAction(edited, original, original, "e", true));
+            editedObjects.Add(edited);
+            originalObjects.Add(original);
         }
 
-        foreach (var unique in SelectionController.SelectedObjects.DistinctBy(x => x.ObjectType))
-            BeatmapObjectContainerCollection.GetCollectionForType(unique.ObjectType).RefreshPool(true);
-        BeatmapActionContainer.AddAction(new ActionCollectionAction(allActions, true, true,
-            "Mirrored a selection of objects."), true);
+        BeatmapActionContainer.AddAction(new BeatmapObjectModifiedCollectionAction(editedObjects, originalObjects, "Mirrored a selection of objects."), true);
     }
 }


### PR DESCRIPTION
Add `BeatmapObjectModifiedCollectionAction` which deletes all objects *and then* adds all objects on undo/redo instead of performing sequential undo/redo (which does delete -> add -> delete -> add) in `ActionCollectionAction`.

This fixes some ghost/stacked objects issues that have been appeared.