### PR TITLE
[macOS] Change App Category to Prevent Game Mode

### DIFF
--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -91,7 +91,7 @@ PlayerSettings:
   useFlipModelSwapchain: 1
   resizableWindow: 1
   useMacAppStoreValidation: 0
-  macAppStoreCategory: public.app-category.games
+  macAppStoreCategory: public.app-category.developer-tools
   gpuSkinning: 0
   xboxPIXTextureCapture: 0
   xboxEnableAvatar: 0


### PR DESCRIPTION
The current (Unity default) app category causes macOS to enter game mode when the app is put in full screen, which is not ideal for energy purposes. I am doing a broader investigation of the program preventing sleep and if it's possible to avoid, but this change is still relevant for energy use reduction.

Game mode is controlled by having one of the `game`-related tags set in Mac App Store Options/Category field in Unity. (Maps to `LSApplicationCategoryType`) I've changed it to `developer-tools` but `utilities` could also fit.

Note: Game Mode will still activate when you run the built project on a Mac if Unity Hub is running. This doesn't appear to be the case when it is closed, or sent to a computer without Unity Hub installed.

https://developer.apple.com/forums/thread/739387
https://developer.apple.com/documentation/bundleresources/information-property-list/lsapplicationcategorytype
https://docs.unity3d.com/2020.1/Documentation/Manual/HOWTO-PortToAppleMacStore.html