### PR TITLE
remove known and parsed customData from base CustomData object

### DIFF
--- a/Assets/TestsEditMode/BeatmapV2Test.cs
+++ b/Assets/TestsEditMode/BeatmapV2Test.cs
@@ -173,7 +173,9 @@ namespace TestsEditMode
         {
             var difficulty = V2Difficulty.GetFromJson(JSONNode.Parse(fileJson), "");
             Assert.AreEqual("_bar", difficulty.CustomData["_foo"].Value);
-            Assert.AreEqual(123.456f, difficulty.CustomData["_time"].AsFloat, 0.001);
+            
+            Assert.IsFalse(difficulty.CustomData.HasKey("_time"));
+            Assert.AreEqual(123.456f, difficulty.Time, 0.001);
 
             var output = V2Difficulty.GetOutputJson(difficulty);
             Assert.AreEqual("_bar", output["_customData"]["_foo"].Value);

--- a/Assets/TestsEditMode/BeatmapV3Test.cs
+++ b/Assets/TestsEditMode/BeatmapV3Test.cs
@@ -358,7 +358,10 @@ namespace TestsEditMode
         {
             var difficulty = V3Difficulty.GetFromJson(JSONNode.Parse(fileJson), "");
             Assert.AreEqual("bar", difficulty.CustomData["foo"].Value);
-            Assert.AreEqual(123.456f, difficulty.CustomData["time"].AsFloat, 0.001);
+            
+            // Key be gone
+            Assert.IsFalse(difficulty.CustomData.HasKey("time"));
+            Assert.AreEqual(123.456f, difficulty.Time, 0.001);
 
             var output = V3Difficulty.GetOutputJson(difficulty);
             Assert.AreEqual("bar", output["customData"]["foo"].Value);

--- a/Assets/TestsEditMode/BeatmapVersionSwitchingTest.cs
+++ b/Assets/TestsEditMode/BeatmapVersionSwitchingTest.cs
@@ -88,7 +88,8 @@ namespace TestsEditMode
             Assert.AreEqual(6, difficulty.Notes[0].CustomCoordinate[1].AsInt);
             
             Assert.AreEqual("bar", difficulty.CustomData["foo"].Value);
-            Assert.AreEqual(123.456f, difficulty.CustomData["time"].AsFloat, 0.001);
+            Assert.AreEqual(123.456f, difficulty.Time, 0.001);
+            Assert.IsFalse(difficulty.CustomData.HasKey("time"));
             
             difficulty.ConvertCustomDataVersion(fromVersion: 3, toVersion: 2);
             
@@ -103,8 +104,9 @@ namespace TestsEditMode
             Assert.AreEqual(6, difficulty.Notes[0].CustomCoordinate[1].AsInt);
             
             Assert.AreEqual("bar", difficulty.CustomData["foo"].Value);
-            Assert.AreEqual(123.456f, difficulty.CustomData["_time"].AsFloat, 0.001);
+            Assert.AreEqual(123.456f, difficulty.Time, 0.001);
             Assert.IsFalse(difficulty.CustomData.HasKey("time"));
+            Assert.IsFalse(difficulty.CustomData.HasKey("_time"));
             
             difficulty.ConvertCustomDataVersion(fromVersion: 2, toVersion: 3);
             
@@ -119,7 +121,8 @@ namespace TestsEditMode
             Assert.AreEqual(6, difficulty.Notes[0].CustomCoordinate[1].AsInt);
             
             Assert.AreEqual("bar", difficulty.CustomData["foo"].Value);
-            Assert.AreEqual(123.456f, difficulty.CustomData["time"].AsFloat, 0.001);
+            Assert.AreEqual(123.456f, difficulty.Time, 0.001);
+            Assert.IsFalse(difficulty.CustomData.HasKey("time"));
             Assert.IsFalse(difficulty.CustomData.HasKey("_time"));
         }
     }

--- a/Assets/TestsEditMode/InfoTest.cs
+++ b/Assets/TestsEditMode/InfoTest.cs
@@ -80,7 +80,8 @@ namespace TestsEditMode
         {
             ""_customData"": {
                 ""_characteristicLabel"" : ""A Custom Characteristic"",
-                ""_characteristicIconImageFilename"" : ""customCharacteristic.png""
+                ""_characteristicIconImageFilename"" : ""customCharacteristic.png"",
+                ""foo"" : ""bar"",
             }
             ""_beatmapCharacteristicName"": ""Standard"",
             ""_difficultyBeatmaps"": [
@@ -93,6 +94,7 @@ namespace TestsEditMode
                     ""_beatmapColorSchemeIdx"": 0,
                     ""_environmentNameIdx"": 0,
                     ""_customData"": {
+                        ""foo"": ""bar"",
                         ""_oneSaber"" : true,
                         ""_showRotationNoteSpawnLines"" : true,
 						""_difficultyLabel"": ""ACustomLabel"",
@@ -203,7 +205,8 @@ namespace TestsEditMode
                 ""_iconPath"": ""Bullet.png""
             }
         ],
-        ""_customEnvironment"": ""Big Mirror V2""
+        ""_customEnvironment"": ""Big Mirror V2"",
+        ""foo"": ""bar""
     }
 }
 ";
@@ -258,6 +261,7 @@ namespace TestsEditMode
             ""beatmapDataFilename"": ""Easy.dat"",
             ""lightshowDataFilename"": ""Lightshow.dat"",
             ""customData"": {
+                ""foo"" : ""bar"",
                 ""oneSaber"" : true,
                 ""showRotationNoteSpawnLines"" : true,
 				""difficultyLabel"": ""ACustomLabel"",
@@ -393,7 +397,8 @@ namespace TestsEditMode
                 ""iconPath"" : ""customCharacteristic.png""
             },
         ],
-        ""customEnvironment"": ""Big Mirror V2""
+        ""customEnvironment"": ""Big Mirror V2"",
+        ""foo"" : ""bar"",
     }
 }
 ";
@@ -444,6 +449,12 @@ namespace TestsEditMode
 
             Assert.AreEqual("WeaveEnvironment", info.EnvironmentName);
             Assert.AreEqual("GlassDesertEnvironment", info.AllDirectionsEnvironmentName);
+            
+            // All supported customData properties are removed on load
+            // Only v2 has a direct characteristic set customData
+            Assert.AreEqual(1, info.DifficultySets[0].CustomData.Count);
+            Assert.AreEqual(true, info.DifficultySets[0].CustomData.HasKey("foo"));
+            Assert.AreEqual("bar", info.DifficultySets[0].CustomData["foo"].Value);
         }
 
         private void AssertV4Info(BaseInfo info)
@@ -541,6 +552,11 @@ namespace TestsEditMode
             Assert.AreEqual(1, easyDifficulty.CustomRequirements.Count);
             Assert.AreEqual("Noodle Extensions", easyDifficulty.CustomRequirements[0]);
             
+            // All supported customData properties are removed on load
+            Assert.AreEqual(1, easyDifficulty.CustomData.Count);
+            Assert.AreEqual(true, easyDifficulty.CustomData.HasKey("foo"));
+            Assert.AreEqual("bar", easyDifficulty.CustomData["foo"].Value);
+            
             AssertColorsAreEqual(new Color(0.111f, 0.111f, 0.111f),easyDifficulty.CustomColorLeft!.Value);
             AssertColorsAreEqual(new Color(0.222f, 0.222f, 0.222f),easyDifficulty.CustomColorRight!.Value);
             AssertColorsAreEqual(new Color(0.333f, 0.333f, 0.333f),easyDifficulty.CustomColorObstacle!.Value);
@@ -616,6 +632,11 @@ namespace TestsEditMode
             Assert.AreEqual("Bullet.png", contributor.LocalImageLocation);
 
             Assert.AreEqual("Big Mirror V2", info.CustomEnvironmentMetadata.Name);
+            
+            // All supported customData properties are removed on load
+            Assert.AreEqual(1, easyDifficulty.CustomData.Count);
+            Assert.AreEqual(true, easyDifficulty.CustomData.HasKey("foo"));
+            Assert.AreEqual("bar", easyDifficulty.CustomData["foo"].Value);
         }
 
         private void AssertColorsAreEqual(Color expected, Color actual)

--- a/Assets/__Scripts/Beatmap/Info/Base/BaseInfo.cs
+++ b/Assets/__Scripts/Beatmap/Info/Base/BaseInfo.cs
@@ -301,43 +301,17 @@ namespace Beatmap.Info
             if (!Settings.Instance.AutomaticModRequirements) return;
 
             //Saving Map Requirement Info
-            var requiredArray = new JSONArray(); //Generate suggestions and requirements array
-            var suggestedArray = new JSONArray();
-
             foreach (var req in RequirementCheck.requirementsAndSuggestions)
             {
                 switch (req.IsRequiredOrSuggested(this, map))
                 {
                     case RequirementCheck.RequirementType.Requirement:
-                        requiredArray.Add(req.Name);
+                        CustomRequirements.Add(req.Name);
                         break;
                     case RequirementCheck.RequirementType.Suggestion:
-                        suggestedArray.Add(req.Name);
+                        CustomSuggestions.Add(req.Name);
                         break;
                 }
-            }
-                
-            CustomData ??= new JSONObject();
-
-            if (requiredArray.Count > 0)
-            {
-                CustomData[majorInfoVersion == 4 ? "requirements" : "_requirements"] = requiredArray;
-            }
-            else
-            {
-                CustomData.Remove("requirements");
-                CustomData.Remove("_requirements");
-            }
-
-            if (suggestedArray.Count > 0)
-            {
-                CustomData ??= new JSONObject();
-                CustomData[majorInfoVersion == 4 ? "suggestions" : "_suggestions"] = suggestedArray;
-            }
-            else
-            {
-                CustomData.Remove("suggestions");
-                CustomData.Remove("_suggestions");
             }
         }
     }

--- a/Assets/__Scripts/Beatmap/Info/Base/BaseInfo.cs
+++ b/Assets/__Scripts/Beatmap/Info/Base/BaseInfo.cs
@@ -296,7 +296,7 @@ namespace Beatmap.Info
 
         public void SetBeatmapFileNameToDefault() => BeatmapFileName = $"{Difficulty}{Characteristic}.dat";
         
-        public void RefreshRequirementsAndWarnings(int majorInfoVersion, BaseDifficulty map)
+        public void RefreshRequirementsAndWarnings(BaseDifficulty map)
         {
             if (!Settings.Instance.AutomaticModRequirements) return;
 

--- a/Assets/__Scripts/Beatmap/Info/Base/BaseInfo.cs
+++ b/Assets/__Scripts/Beatmap/Info/Base/BaseInfo.cs
@@ -303,7 +303,13 @@ namespace Beatmap.Info
             //Saving Map Requirement Info
             foreach (var req in RequirementCheck.requirementsAndSuggestions)
             {
-                switch (req.IsRequiredOrSuggested(this, map))
+                // get this result before clearing from the lists to allow preserving Chroma as requirement
+                var requirementType = req.IsRequiredOrSuggested(this, map);
+
+                CustomRequirements.RemoveAll(x => x.Equals(req.Name));
+                CustomSuggestions.RemoveAll(x => x.Equals(req.Name));
+
+                switch (requirementType)
                 {
                     case RequirementCheck.RequirementType.Requirement:
                         CustomRequirements.Add(req.Name);

--- a/Assets/__Scripts/Beatmap/Info/V2/V2Info.cs
+++ b/Assets/__Scripts/Beatmap/Info/V2/V2Info.cs
@@ -111,17 +111,20 @@ namespace Beatmap.Info
                 if (customData["_contributors"].IsArray)
                 {
                     info.CustomContributors = customData["_contributors"].AsArray.Children.Select(V2Contributor.GetFromJson).ToList();
+                    customData.Remove("_contributors");
                 }
 
                 if (customData["_editors"].IsObject)
                 {
                     info.CustomEditorsData = new BaseInfo.CustomEditorsMetadata(customData["_editors"]);
+                    customData.Remove("_editors");
                 }
 
                 if (customData["_customEnvironment"].IsString)
                 {
                     info.CustomEnvironmentMetadata.Name = customData["_customEnvironment"].Value;
                     // Don't need save retrieve since it's calculated on save
+                    customData.Remove("_customEnvironment");
                 }
                 
                 info.CustomData = customData;
@@ -256,11 +259,13 @@ namespace Beatmap.Info
             if (customData["_characteristicLabel"].IsString)
             {
                 difficultySet.CustomCharacteristicLabel = customData["_characteristicLabel"].Value;
+                customData.Remove("_characteristicLabel");
             }
 
             if (customData["_characteristicIconImageFilename"].IsString)
             {
                 difficultySet.CustomCharacteristicIconImageFileName = customData["_characteristicIconImageFilename"].Value;
+                customData.Remove("_characteristicIconImageFilename");
             }
         }
 
@@ -269,85 +274,101 @@ namespace Beatmap.Info
             if (customData["_oneSaber"].IsBoolean)
             {
                 difficulty.CustomOneSaberFlag = customData["_oneSaber"].AsBool;
+                customData.Remove("_oneSaber");
             }
 
             if (customData["_showRotationNoteSpawnLines"].IsBoolean)
             {
                 difficulty.CustomShowRotationNoteSpawnLinesFlag = customData["_showRotationNoteSpawnLines"].AsBool;
+                customData.Remove("_showRotationNoteSpawnLines");
             }
 
             if (customData["_difficultyLabel"].IsString)
             {
                 difficulty.CustomLabel = customData["_difficultyLabel"].Value;
+                customData.Remove("_difficultyLabel");
             }
             
             if (customData["_information"].IsArray)
             {
                 difficulty.CustomInformation =
                     customData["_information"].AsArray.Children.Select(x => x.Value).ToList();
+                customData.Remove("_information");
             }
 
             if (customData["_warnings"].IsArray)
             {
                 difficulty.CustomWarnings =
                     customData["_warnings"].AsArray.Children.Select(x => x.Value).ToList();
+                customData.Remove("_warnings");
             }
 
             if (customData["_suggestions"].IsArray)
             {
                 difficulty.CustomSuggestions =
                     customData["_suggestions"].AsArray.Children.Select(x => x.Value).ToList();
+                customData.Remove("_suggestions");
             }
 
             if (customData["_requirements"].IsArray)
             {
                 difficulty.CustomRequirements =
                     customData["_requirements"].AsArray.Children.Select(x => x.Value).ToList();
+                customData.Remove("_requirements");
             }
 
             if (customData["_colorLeft"].IsObject)
             {
                 difficulty.CustomColorLeft = customData["_colorLeft"].ReadColor();
+                customData.Remove("_colorLeft");
             }
             
             if (customData["_colorRight"].IsObject)
             {
                 difficulty.CustomColorRight = customData["_colorRight"].ReadColor();
+                customData.Remove("_colorRight");
             }
             
             if (customData["_obstacleColor"].IsObject)
             {
                 difficulty.CustomColorObstacle = customData["_obstacleColor"].ReadColor();
+                customData.Remove("_obstacleColor");
             }
 
             if (customData["_envColorLeft"].IsObject)
             {
                 difficulty.CustomEnvColorLeft = customData["_envColorLeft"].ReadColor();
+                customData.Remove("_envColorLeft");
             }
             
             if (customData["_envColorRight"].IsObject)
             {
                 difficulty.CustomEnvColorRight = customData["_envColorRight"].ReadColor();
+                customData.Remove("_envColorRight");
             }
             
             if (customData["_envColorWhite"].IsObject)
             {
                 difficulty.CustomEnvColorWhite = customData["_envColorWhite"].ReadColor();
+                customData.Remove("_envColorWhite");
             }
             
             if (customData["_envColorLeftBoost"].IsObject)
             {
                 difficulty.CustomEnvColorBoostLeft = customData["_envColorLeftBoost"].ReadColor();
+                customData.Remove("_envColorLeftBoost");
             }
             
             if (customData["_envColorRightBoost"].IsObject)
             {
                 difficulty.CustomEnvColorBoostRight = customData["_envColorRightBoost"].ReadColor();
+                customData.Remove("_envColorRightBoost");
             }
             
             if (customData["_envColorWhiteBoost"].IsObject)
             {
                 difficulty.CustomEnvColorBoostWhite = customData["_envColorWhiteBoost"].ReadColor();
+                customData.Remove("_envColorWhiteBoost");
             }
         }
 

--- a/Assets/__Scripts/Beatmap/Info/V2/V2Info.cs
+++ b/Assets/__Scripts/Beatmap/Info/V2/V2Info.cs
@@ -207,10 +207,10 @@ namespace Beatmap.Info
                     node["_beatmapColorSchemeIdx"] = difficulty.ColorSchemeIndex;
                     node["_environmentNameIdx"] = difficulty.EnvironmentNameIndex;
 
-                    PopulateDifficultyCustomData(difficulty);
-                    if (difficulty.CustomData.Count > 0)
+                    var diffCustomData = GetOutputDifficultyCustomData(difficulty);
+                    if (diffCustomData.Count > 0)
                     {
-                        node["_customData"] = difficulty.CustomData;
+                        node["_customData"] = diffCustomData;
                     }
                     
                     difficultyBeatmapsArray.Add(node);
@@ -218,10 +218,10 @@ namespace Beatmap.Info
 
                 setNode["_difficultyBeatmaps"] = difficultyBeatmapsArray;
 
-                PopulateDifficultySetCustomData(beatmapSet);
-                if (beatmapSet.CustomData.Count > 0)
+                var diffSetCustomData = GetOutputDifficultySetCustomData(beatmapSet);
+                if (diffSetCustomData.Count > 0)
                 {
-                    setNode["_customData"] = beatmapSet.CustomData;
+                    setNode["_customData"] = diffSetCustomData;
                 }
                 
                 beatmapSetArray.Add(setNode);
@@ -230,6 +230,7 @@ namespace Beatmap.Info
             json["_difficultyBeatmapSets"] = beatmapSetArray;
 
             // CustomData writing
+            var customData = info.CustomData.Clone();
             if (info.CustomContributors.Any())
             {
                 var customContributors = new JSONArray();
@@ -238,18 +239,18 @@ namespace Beatmap.Info
                     customContributors.Add(V2Contributor.ToJson(customContributor));
                 }
                 
-                info.CustomData["_contributors"] = customContributors;
+                customData["_contributors"] = customContributors;
             }
             
             if (!string.IsNullOrEmpty(info.CustomEnvironmentMetadata.Name))
             {
-                info.CustomData["_customEnvironment"] = info.CustomEnvironmentMetadata.Name;
-                info.CustomData["_customEnvironmentHash"] = info.CustomEnvironmentMetadata.Hash;
+                customData["_customEnvironment"] = info.CustomEnvironmentMetadata.Name;
+                customData["_customEnvironmentHash"] = info.CustomEnvironmentMetadata.Hash;
             }
             
-            info.CustomData["_editors"] = info.CustomEditorsData.ToJson();
+            customData["_editors"] = info.CustomEditorsData.ToJson();
             
-            json["_customData"] = info.CustomData;
+            json["_customData"] = customData;
             
             return json;
         }
@@ -372,57 +373,63 @@ namespace Beatmap.Info
             }
         }
 
-        private static void PopulateDifficultySetCustomData(InfoDifficultySet difficultySet)
+        private static JSONNode GetOutputDifficultySetCustomData(InfoDifficultySet difficultySet)
         {
+            var customData = difficultySet.CustomData.Clone();
+
             if (!string.IsNullOrWhiteSpace(difficultySet.CustomCharacteristicLabel))
             {
-                difficultySet.CustomData["_characteristicLabel"] = difficultySet.CustomCharacteristicLabel;
+                customData["_characteristicLabel"] = difficultySet.CustomCharacteristicLabel;
             }
             
             if (!string.IsNullOrWhiteSpace(difficultySet.CustomCharacteristicIconImageFileName))
             {
-                difficultySet.CustomData["_characteristicIconImageFilename"] = difficultySet.CustomCharacteristicIconImageFileName;
+                customData["_characteristicIconImageFilename"] = difficultySet.CustomCharacteristicIconImageFileName;
             }
+
+            return customData;
         }
 
-        private static void PopulateDifficultyCustomData(InfoDifficulty difficulty)
+        private static JSONNode GetOutputDifficultyCustomData(InfoDifficulty difficulty)
         {
+            var customData = difficulty.CustomData.Clone();
+
             if (difficulty.CustomOneSaberFlag != null)
             {
-                difficulty.CustomData["_oneSaber"] = difficulty.CustomOneSaberFlag.Value;
+                customData["_oneSaber"] = difficulty.CustomOneSaberFlag.Value;
             }
 
             if (difficulty.CustomShowRotationNoteSpawnLinesFlag != null)
             {
-                difficulty.CustomData["_showRotationNoteSpawnLines"] = difficulty.CustomShowRotationNoteSpawnLinesFlag.Value;
+                customData["_showRotationNoteSpawnLines"] = difficulty.CustomShowRotationNoteSpawnLinesFlag.Value;
             }
 
             if (!string.IsNullOrWhiteSpace(difficulty.CustomLabel))
             {
-                difficulty.CustomData["_difficultyLabel"] = difficulty.CustomLabel;
+                customData["_difficultyLabel"] = difficulty.CustomLabel;
             }
 
             if (difficulty.CustomInformation.Any())
             {
-                difficulty.CustomData["_information"] =
+                customData["_information"] =
                     SimpleJSONHelper.MapSequenceToJSONArray(difficulty.CustomInformation, s => s);
             }
             
             if (difficulty.CustomWarnings.Any())
             {
-                difficulty.CustomData["_warnings"] =
+                customData["_warnings"] =
                     SimpleJSONHelper.MapSequenceToJSONArray(difficulty.CustomWarnings, s => s);
             }
             
             if (difficulty.CustomSuggestions.Any())
             {
-                difficulty.CustomData["_suggestions"] =
+                customData["_suggestions"] =
                     SimpleJSONHelper.MapSequenceToJSONArray(difficulty.CustomSuggestions, s => s);
             }
             
             if (difficulty.CustomRequirements.Any())
             {
-                difficulty.CustomData["_requirements"] =
+                customData["_requirements"] =
                     SimpleJSONHelper.MapSequenceToJSONArray(difficulty.CustomRequirements, s => s);
             }
             
@@ -431,50 +438,52 @@ namespace Beatmap.Info
 
             if (difficulty.CustomColorLeft != null)
             {
-                difficulty.CustomData["_colorLeft"] = difficulty.CustomColorLeft.Value;
+                customData["_colorLeft"] = difficulty.CustomColorLeft.Value;
             }
 
             if (difficulty.CustomColorRight != null)
             {
-                difficulty.CustomData["_colorRight"] = difficulty.CustomColorRight.Value;
+                customData["_colorRight"] = difficulty.CustomColorRight.Value;
             }
 
             if (difficulty.CustomColorObstacle != null)
             {
-                difficulty.CustomData["_obstacleColor"] = difficulty.CustomColorObstacle.Value;
+                customData["_obstacleColor"] = difficulty.CustomColorObstacle.Value;
             }
 
             if (difficulty.CustomEnvColorLeft != null)
             {
-                difficulty.CustomData["_envColorLeft"] = difficulty.CustomEnvColorLeft.Value;
+                customData["_envColorLeft"] = difficulty.CustomEnvColorLeft.Value;
             }
 
             if (difficulty.CustomEnvColorRight != null)
             {
-                difficulty.CustomData["_envColorRight"] = difficulty.CustomEnvColorRight.Value;
+                customData["_envColorRight"] = difficulty.CustomEnvColorRight.Value;
             }
 
             if (difficulty.CustomEnvColorWhite != null)
             {
-                difficulty.CustomData["_envColorWhite"] = difficulty.CustomEnvColorWhite.Value;
+                customData["_envColorWhite"] = difficulty.CustomEnvColorWhite.Value;
             }
 
             if (difficulty.CustomEnvColorBoostLeft != null)
             {
-                difficulty.CustomData["_envColorLeftBoost"] = difficulty.CustomEnvColorBoostLeft.Value;
+                customData["_envColorLeftBoost"] = difficulty.CustomEnvColorBoostLeft.Value;
             }
 
             if (difficulty.CustomEnvColorBoostRight != null)
             {
-                difficulty.CustomData["_envColorRightBoost"] = difficulty.CustomEnvColorBoostRight.Value;
+                customData["_envColorRightBoost"] = difficulty.CustomEnvColorBoostRight.Value;
             }
 
             if (difficulty.CustomEnvColorBoostWhite != null)
             {
-                difficulty.CustomData["_envColorWhiteBoost"] = difficulty.CustomEnvColorBoostWhite.Value;
+                customData["_envColorWhiteBoost"] = difficulty.CustomEnvColorBoostWhite.Value;
             }
             
             JSONNode.ColorContainerType = JSONContainerType.Array;
+
+            return customData;
         }
     }
 }

--- a/Assets/__Scripts/Beatmap/Info/V4/V4Info.cs
+++ b/Assets/__Scripts/Beatmap/Info/V4/V4Info.cs
@@ -113,6 +113,7 @@ namespace Beatmap.Info
                 if (customData["contributors"].IsArray)
                 {
                     info.CustomContributors = customData["contributors"].AsArray.Children.Select(V4Contributor.GetFromJson).ToList();
+                    customData.Remove("contributors");
                 }
                 
                 // v4 no longer has difficulty sets so the customData for custom characteristics is done here
@@ -127,17 +128,23 @@ namespace Beatmap.Info
                             ParseDifficultySetCustomData(characteristicNode, difficultySet);
                         }
                     }
+
+                    // recreated on save so we can just remove the entire array
+                    // downside is data for characteristics that don't have any corresponding diffs will be lost
+                    customData.Remove("characteristicData");
                 }
 
                 if (customData["editors"].IsObject)
                 {
                     info.CustomEditorsData = new BaseInfo.CustomEditorsMetadata(customData["editors"]);
+                    customData.Remove("editors");
                 }
 
                 if (customData["customEnvironment"].IsString)
                 {
                     info.CustomEnvironmentMetadata.Name = customData["customEnvironment"].Value;
                     // Don't need save retrieve since it's calculated on save
+                    customData.Remove("customEnvironment");
                 }
                 
                 info.CustomData = customData;
@@ -314,85 +321,101 @@ namespace Beatmap.Info
             if (customData["oneSaber"].IsBoolean)
             {
                 difficulty.CustomOneSaberFlag = customData["oneSaber"].AsBool;
+                customData.Remove("oneSaber");
             }
 
             if (customData["showRotationNoteSpawnLines"].IsBoolean)
             {
                 difficulty.CustomShowRotationNoteSpawnLinesFlag = customData["showRotationNoteSpawnLines"].AsBool;
+                customData.Remove("showRotationNoteSpawnLines");
             }
 
             if (customData["difficultyLabel"].IsString)
             {
                 difficulty.CustomLabel = customData["difficultyLabel"].Value;
+                customData.Remove("difficultyLabel");
             }
 
             if (customData["information"].IsArray)
             {
                 difficulty.CustomInformation =
                     customData["information"].AsArray.Children.Select(x => x.Value).ToList();
+                customData.Remove("information");
             }
 
             if (customData["warnings"].IsArray)
             {
                 difficulty.CustomWarnings =
                     customData["warnings"].AsArray.Children.Select(x => x.Value).ToList();
+                customData.Remove("warnings");
             }
 
             if (customData["suggestions"].IsArray)
             {
                 difficulty.CustomSuggestions =
                     customData["suggestions"].AsArray.Children.Select(x => x.Value).ToList();
+                customData.Remove("suggestions");
             }
 
             if (customData["requirements"].IsArray)
             {
                 difficulty.CustomRequirements =
                     customData["requirements"].AsArray.Children.Select(x => x.Value).ToList();
+                customData.Remove("requirements");
             }
 
             if (customData["colorLeft"].IsObject)
             {
                 difficulty.CustomColorLeft = customData["colorLeft"].ReadColor();
+                customData.Remove("colorLeft");
             }
             
             if (customData["colorRight"].IsObject)
             {
                 difficulty.CustomColorRight = customData["colorRight"].ReadColor();
+                customData.Remove("colorRight");
             }
             
             if (customData["obstacleColor"].IsObject)
             {
                 difficulty.CustomColorObstacle = customData["obstacleColor"].ReadColor();
+                customData.Remove("obstacleColor");
             }
 
             if (customData["envColorLeft"].IsObject)
             {
                 difficulty.CustomEnvColorLeft = customData["envColorLeft"].ReadColor();
+                customData.Remove("envColorLeft");
             }
             
             if (customData["envColorRight"].IsObject)
             {
                 difficulty.CustomEnvColorRight = customData["envColorRight"].ReadColor();
+                customData.Remove("envColorRight");
             }
             
             if (customData["envColorWhite"].IsObject)
             {
                 difficulty.CustomEnvColorWhite = customData["envColorWhite"].ReadColor();
+                customData.Remove("envColorWhite");
             }
             
             if (customData["envColorLeftBoost"].IsObject)
             {
                 difficulty.CustomEnvColorBoostLeft = customData["envColorLeftBoost"].ReadColor();
+                customData.Remove("envColorLeftBoost");
             }
             
             if (customData["envColorRightBoost"].IsObject)
             {
                 difficulty.CustomEnvColorBoostRight = customData["envColorRightBoost"].ReadColor();
+                customData.Remove("envColorRightBoost");
             }
             
             if (customData["envColorWhiteBoost"].IsObject)
             {
                 difficulty.CustomEnvColorBoostWhite = customData["envColorWhiteBoost"].ReadColor();
+                customData.Remove("envColorWhiteBoost");
             }
         }
 

--- a/Assets/__Scripts/Beatmap/Info/V4/V4Info.cs
+++ b/Assets/__Scripts/Beatmap/Info/V4/V4Info.cs
@@ -242,10 +242,10 @@ namespace Beatmap.Info
                 node["beatmapDataFilename"] = difficulty.BeatmapFileName;
                 node["lightshowDataFilename"] = difficulty.LightshowFileName;
                 
-                PopulateDifficultyCustomData(difficulty);
-                if (difficulty.CustomData.Count > 0)
+                var diffCustomData = GetOutputDifficultyCustomData(difficulty);
+                if (diffCustomData.Count > 0)
                 {
-                    node["customData"] = difficulty.CustomData;
+                    node["customData"] = diffCustomData;
                 }
                 
                 difficultyBeatmaps.Add(node);
@@ -254,6 +254,7 @@ namespace Beatmap.Info
             json["difficultyBeatmaps"] = difficultyBeatmaps;
 
             // CustomData writing
+            var customData = info.CustomData.Clone();
             if (info.CustomContributors.Any())
             {
                 var customContributors = new JSONArray();
@@ -261,7 +262,7 @@ namespace Beatmap.Info
                 {
                     customContributors.Add(V4Contributor.ToJson(customContributor));
                 }
-                info.CustomData["contributors"] = customContributors;
+                customData["contributors"] = customContributors;
             }
 
             var customCharacteristics = new JSONArray();
@@ -286,19 +287,19 @@ namespace Beatmap.Info
 
             if (customCharacteristics.Count > 0)
             {
-                info.CustomData["characteristicData"] = customCharacteristics;
+                customData["characteristicData"] = customCharacteristics;
             }
             
             // I'm not sure if custom platforms exists for v4 yet. This seems like a safe guess.
             if (!string.IsNullOrEmpty(info.CustomEnvironmentMetadata.Name))
             {
-                info.CustomData["customEnvironment"] = info.CustomEnvironmentMetadata.Name;
-                info.CustomData["customEnvironmentHash"] = info.CustomEnvironmentMetadata.Hash;
+                customData["customEnvironment"] = info.CustomEnvironmentMetadata.Name;
+                customData["customEnvironmentHash"] = info.CustomEnvironmentMetadata.Hash;
             }
             
-            info.CustomData["editors"] = info.CustomEditorsData.ToJson();
+            customData["editors"] = info.CustomEditorsData.ToJson();
 
-            json["customData"] = info.CustomData;
+            json["customData"] = customData;
             
             return json;
         }
@@ -419,44 +420,46 @@ namespace Beatmap.Info
             }
         }
 
-        private static void PopulateDifficultyCustomData(InfoDifficulty difficulty)
+        private static JSONNode GetOutputDifficultyCustomData(InfoDifficulty difficulty)
         {
+            var customData = difficulty.CustomData.Clone();
+
             if (difficulty.CustomOneSaberFlag != null)
             {
-                difficulty.CustomData["oneSaber"] = difficulty.CustomOneSaberFlag.Value;
+                customData["oneSaber"] = difficulty.CustomOneSaberFlag.Value;
             }
 
             if (difficulty.CustomShowRotationNoteSpawnLinesFlag != null)
             {
-                difficulty.CustomData["showRotationNoteSpawnLines"] = difficulty.CustomShowRotationNoteSpawnLinesFlag.Value;
+                customData["showRotationNoteSpawnLines"] = difficulty.CustomShowRotationNoteSpawnLinesFlag.Value;
             }
 
             if (!string.IsNullOrWhiteSpace(difficulty.CustomLabel))
             {
-                difficulty.CustomData["difficultyLabel"] = difficulty.CustomLabel;
+                customData["difficultyLabel"] = difficulty.CustomLabel;
             }
 
             if (difficulty.CustomInformation.Any())
             {
-                difficulty.CustomData["information"] =
+                customData["information"] =
                     SimpleJSONHelper.MapSequenceToJSONArray(difficulty.CustomInformation, s => s);
             }
             
             if (difficulty.CustomWarnings.Any())
             {
-                difficulty.CustomData["warnings"] =
+                customData["warnings"] =
                     SimpleJSONHelper.MapSequenceToJSONArray(difficulty.CustomWarnings, s => s);
             }
             
             if (difficulty.CustomSuggestions.Any())
             {
-                difficulty.CustomData["suggestions"] =
+                customData["suggestions"] =
                     SimpleJSONHelper.MapSequenceToJSONArray(difficulty.CustomSuggestions, s => s);
             }
             
             if (difficulty.CustomRequirements.Any())
             {
-                difficulty.CustomData["requirements"] =
+                customData["requirements"] =
                     SimpleJSONHelper.MapSequenceToJSONArray(difficulty.CustomRequirements, s => s);
             }
             
@@ -465,50 +468,52 @@ namespace Beatmap.Info
 
             if (difficulty.CustomColorLeft != null)
             {
-                difficulty.CustomData["colorLeft"] = difficulty.CustomColorLeft.Value;
+                customData["colorLeft"] = difficulty.CustomColorLeft.Value;
             }
 
             if (difficulty.CustomColorRight != null)
             {
-                difficulty.CustomData["colorRight"] = difficulty.CustomColorRight.Value;
+                customData["colorRight"] = difficulty.CustomColorRight.Value;
             }
 
             if (difficulty.CustomColorObstacle != null)
             {
-                difficulty.CustomData["obstacleColor"] = difficulty.CustomColorObstacle.Value;
+                customData["obstacleColor"] = difficulty.CustomColorObstacle.Value;
             }
 
             if (difficulty.CustomEnvColorLeft != null)
             {
-                difficulty.CustomData["envColorLeft"] = difficulty.CustomEnvColorLeft.Value;
+                customData["envColorLeft"] = difficulty.CustomEnvColorLeft.Value;
             }
 
             if (difficulty.CustomEnvColorRight != null)
             {
-                difficulty.CustomData["envColorRight"] = difficulty.CustomEnvColorRight.Value;
+                customData["envColorRight"] = difficulty.CustomEnvColorRight.Value;
             }
 
             if (difficulty.CustomEnvColorWhite != null)
             {
-                difficulty.CustomData["envColorWhite"] = difficulty.CustomEnvColorWhite.Value;
+                customData["envColorWhite"] = difficulty.CustomEnvColorWhite.Value;
             }
 
             if (difficulty.CustomEnvColorBoostLeft != null)
             {
-                difficulty.CustomData["envColorLeftBoost"] = difficulty.CustomEnvColorBoostLeft.Value;
+                customData["envColorLeftBoost"] = difficulty.CustomEnvColorBoostLeft.Value;
             }
 
             if (difficulty.CustomEnvColorBoostRight != null)
             {
-                difficulty.CustomData["envColorRightBoost"] = difficulty.CustomEnvColorBoostRight.Value;
+                customData["envColorRightBoost"] = difficulty.CustomEnvColorBoostRight.Value;
             }
 
             if (difficulty.CustomEnvColorBoostWhite != null)
             {
-                difficulty.CustomData["envColorWhiteBoost"] = difficulty.CustomEnvColorBoostWhite.Value;
+                customData["envColorWhiteBoost"] = difficulty.CustomEnvColorBoostWhite.Value;
             }
 
             JSONNode.ColorContainerType = JSONContainerType.Array;
+
+            return customData;
         }
     }
 }

--- a/Assets/__Scripts/Beatmap/V2/V2Difficulty.cs
+++ b/Assets/__Scripts/Beatmap/V2/V2Difficulty.cs
@@ -210,7 +210,7 @@ namespace Beatmap.V2
                     case "_customData":
                         map.CustomData = mNode;
 
-                        var dataNodeEnum = mNode.GetEnumerator();
+                        var dataNodeEnum = mNode.Clone().GetEnumerator();
                         while (dataNodeEnum.MoveNext())
                         {
                             var cKey = dataNodeEnum.Current.Key;
@@ -219,15 +219,19 @@ namespace Beatmap.V2
                             {
                                 case "_BPMChanges":
                                     foreach (JSONNode n in cNode) bpmList.Add(V2BpmChange.GetFromJson(n));
+                                    map.CustomData.Remove(cKey);
                                     break;
                                 case "_bpmChanges":
                                     foreach (JSONNode n in cNode) bpmList.Add(V2BpmChange.GetFromJson(n));
+                                    map.CustomData.Remove(cKey);
                                     break;
                                 case "_bookmarks":
                                     foreach (JSONNode n in cNode) bookmarksList.Add(V2Bookmark.GetFromJson(n));
+                                    map.CustomData.Remove(cKey);
                                     break;
                                 case "_customEvents":
                                     foreach (JSONNode n in cNode) customEventsList.Add(V2CustomEvent.GetFromJson(n));
+                                    map.CustomData.Remove(cKey);
                                     break;
                                 case "_pointDefinitions":
                                     foreach (JSONNode n in cNode)
@@ -238,10 +242,12 @@ namespace Beatmap.V2
                                         else
                                             Debug.LogWarning($"Duplicate key {n["_name"]} found in point definitions");
                                     }
+                                    map.CustomData.Remove(cKey);
                                     break;
                                 case "_environment":
                                     foreach (JSONNode n in cNode)
                                         envEnhancementsList.Add(V2EnvironmentEnhancement.GetFromJson(n));
+                                    map.CustomData.Remove(cKey);
                                     break;
                                 case "_materials":
                                     if (cNode is JSONObject matObj)
@@ -254,9 +260,11 @@ namespace Beatmap.V2
                                         break;
                                     }
                                     Debug.LogWarning("Could not read materials");
+                                    map.CustomData.Remove(cKey);
                                     break;
                                 case "_time":
                                     map.Time = cNode.AsFloat;
+                                    map.CustomData.Remove(cKey);
                                     break;
                             }
                         }

--- a/Assets/__Scripts/Beatmap/V3/V3Difficulty.cs
+++ b/Assets/__Scripts/Beatmap/V3/V3Difficulty.cs
@@ -355,7 +355,7 @@ namespace Beatmap.V3
             var envEnhancementsList = new List<BaseEnvironmentEnhancement>();
             var materials = new Dictionary<string, BaseMaterial>();
 
-            var nodeEnum = mainNode["customData"].GetEnumerator();
+            var nodeEnum = mainNode["customData"].Clone().GetEnumerator();
             while (nodeEnum.MoveNext())
             {
                 var key = nodeEnum.Current.Key;
@@ -365,24 +365,31 @@ namespace Beatmap.V3
                 {
                     case "BPMChanges":
                         foreach (JSONNode n in node) bpmList.Add(V3BpmChange.GetFromJson(n));
+                        map.CustomData.Remove(key);
                         break;
                     case "bookmarks":
                         foreach (JSONNode n in node) bookmarksList.Add(V3Bookmark.GetFromJson(n));
+                        map.CustomData.Remove(key);
                         break;
                     case "customEvents":
                         foreach (JSONNode n in node) customEventsList.Add(V3CustomEvent.GetFromJson(n));
+                        map.CustomData.Remove(key);
                         break;
                     case "fakeColorNotes":
                         foreach (JSONNode n in node) map.Notes.Add(V3ColorNote.GetFromJson(n, true));
+                        map.CustomData.Remove(key);
                         break;
                     case "fakeBombNotes":
                         foreach (JSONNode n in node) map.Notes.Add(V3BombNote.GetFromJson(n, true));
+                        map.CustomData.Remove(key);
                         break;
                     case "fakeObstacles":
                         foreach (JSONNode n in node) map.Obstacles.Add(V3Obstacle.GetFromJson(n, true));
+                        map.CustomData.Remove(key);
                         break;
                     case "fakeBurstSliders":
                         foreach (JSONNode n in node) map.Chains.Add(V3Chain.GetFromJson(n, true));
+                        map.CustomData.Remove(key);
                         break;
                     case "pointDefinitions":
                         // TODO: array is incorrect, but some old v3 NE/Chroma map uses them, temporarily this needs to be here
@@ -415,9 +422,11 @@ namespace Beatmap.V3
                         }
 
                         Debug.LogWarning("Could not read point definitions");
+                        map.CustomData.Remove(key);
                         break;
                     case "environment":
                         foreach (JSONNode n in node) envEnhancementsList.Add(V3EnvironmentEnhancement.GetFromJson(n));
+                        map.CustomData.Remove(key);
                         break;
                     case "materials":
                         if (node is JSONObject matObj)
@@ -431,9 +440,11 @@ namespace Beatmap.V3
                         }
 
                         Debug.LogWarning("Could not read materials");
+                        map.CustomData.Remove(key);
                         break;
                     case "time":
                         map.Time = node.AsFloat;
+                        map.CustomData.Remove(key);
                         break;
                 }
             }

--- a/Assets/__Scripts/MapEditor/AutoSaveController.cs
+++ b/Assets/__Scripts/MapEditor/AutoSaveController.cs
@@ -455,8 +455,7 @@ public class AutoSaveController : MonoBehaviour, CMInput.ISavingActions
 
                     BeatSaberSongContainer.Instance.Map.Save();
 
-                    BeatSaberSongContainer.Instance.MapDifficultyInfo.RefreshRequirementsAndWarnings(
-                        BeatSaberSongContainer.Instance.Info.MajorVersion, BeatSaberSongContainer.Instance.Map);
+                    BeatSaberSongContainer.Instance.MapDifficultyInfo.RefreshRequirementsAndWarnings(BeatSaberSongContainer.Instance.Map);
                     
                     BeatSaberSongContainer.Instance.Info.Save(); //Save
                 }

--- a/Assets/__Scripts/Requirements/ChromaReq.cs
+++ b/Assets/__Scripts/Requirements/ChromaReq.cs
@@ -20,8 +20,7 @@ public class ChromaReq : HeckRequirementCheck
         map.IsChroma();
 
     private bool RequiresChroma(InfoDifficulty infoDifficulty, BaseDifficulty map) =>
-        infoDifficulty.CustomData != null && infoDifficulty.CustomData.HasKey("_requirements") &&
-        infoDifficulty.CustomData["_requirements"].Linq.Any(x => x.Value == "Chroma");
+        infoDifficulty.CustomRequirements.Any(x => x == "Chroma");
 
     private bool HasEnvironmentRemoval(InfoDifficulty infoDifficulty, BaseDifficulty map) =>
         (infoDifficulty.CustomData != null && infoDifficulty.CustomData.HasKey("_environmentRemoval") &&

--- a/Assets/__Scripts/UI/SongEditMenu/DifficultySelect.cs
+++ b/Assets/__Scripts/UI/SongEditMenu/DifficultySelect.cs
@@ -323,7 +323,7 @@ public class DifficultySelect : MonoBehaviour
             map.Save();
         }
 
-        diff.RefreshRequirementsAndWarnings(mapInfo.MajorVersion, map);
+        diff.RefreshRequirementsAndWarnings(map);
         
         // Handle environmentName indexes
         var environmentNames = new List<string>();

--- a/Assets/__Scripts/UI/SongEditMenu/DifficultySelect.cs
+++ b/Assets/__Scripts/UI/SongEditMenu/DifficultySelect.cs
@@ -512,6 +512,15 @@ public class DifficultySelect : MonoBehaviour
 
                     map.CustomData = fromDiff.InfoDifficulty.CustomData?.Clone().AsObject;
 
+                    map.CustomLabel = fromDiff.InfoDifficulty.CustomLabel;
+                    map.CustomOneSaberFlag = fromDiff.InfoDifficulty.CustomOneSaberFlag;
+                    map.CustomShowRotationNoteSpawnLinesFlag = fromDiff.InfoDifficulty.CustomShowRotationNoteSpawnLinesFlag;
+
+                    map.CustomInformation = fromDiff.InfoDifficulty.CustomInformation.ToList();
+                    map.CustomWarnings = fromDiff.InfoDifficulty.CustomWarnings.ToList();
+                    map.CustomSuggestions = fromDiff.InfoDifficulty.CustomSuggestions.ToList();
+                    map.CustomRequirements = fromDiff.InfoDifficulty.CustomRequirements.ToList();
+
                     // Yes this copies custom data, but color overrides dont copy since they're ripped from these fields instead.
                     map.CustomColorLeft = fromDiff.InfoDifficulty.CustomColorLeft;
                     map.CustomColorRight = fromDiff.InfoDifficulty.CustomColorRight;

--- a/Assets/__Scripts/UI/SongEditMenu/DifficultySettings.cs
+++ b/Assets/__Scripts/UI/SongEditMenu/DifficultySettings.cs
@@ -111,12 +111,6 @@ public class DifficultySettings
             V4Difficulty.LoadLightsFromLightshowFile(Map, BeatSaberSongContainer.Instance.Info, InfoDifficulty);
         }
 
-        if (string.IsNullOrEmpty(CustomName))
-        {
-            InfoDifficulty.CustomData?.Remove("_difficultyLabel");
-            InfoDifficulty.CustomData?.Remove("difficultyLabel");
-        }
-
         InfoDifficulty.CustomLabel = CustomName;
 
         InfoDifficulty.CustomData?.Remove("_environmentRemoval");


### PR DESCRIPTION
fixes converted custom bpm changes not being deleted, among other potential similar issues

(now also on Info.dat, fixing issues with removing contributors as one example)

(now also fixed diff label not being copied to new diff, among some other properties)