### PR TITLE
fix issues with track length setting

### DIFF
--- a/Assets/__Scripts/MapEditor/AudioTimeSyncController.cs
+++ b/Assets/__Scripts/MapEditor/AudioTimeSyncController.cs
@@ -132,6 +132,7 @@ public class AudioTimeSyncController : MonoBehaviour, CMInput.IPlaybackActions, 
             LoadInitialMap.LevelLoadedEvent += OnLevelLoaded;
             Settings.NotifyBySettingName("SongSpeed", UpdateSongSpeed);
             Settings.NotifyBySettingName("SongVolume", UpdateSongVolume);
+            Settings.NotifyBySettingName(nameof(Settings.TrackLength), UpdateTrackLength);
 
             Initialized = true;
         }
@@ -334,6 +335,8 @@ public class AudioTimeSyncController : MonoBehaviour, CMInput.IPlaybackActions, 
 
     private void UpdateSongSpeed(object obj) => songSpeed = (float)obj;
 
+    private void UpdateTrackLength(object _) => UpdateMovables();
+
     private void OnLevelLoaded() => levelLoaded = true;
 
     private void UpdateMovables()
@@ -341,9 +344,9 @@ public class AudioTimeSyncController : MonoBehaviour, CMInput.IPlaybackActions, 
         Shader.SetGlobalFloat(songTime, currentSongBpmTime);
         Shader.SetGlobalFloat(songTimeSeconds, currentSeconds);
         
-        // CM's grid extends from [songTime - 2 beats, songTime + 8 beats]
-        Shader.SetGlobalFloat(viewStart, GetSecondsFromBeat(currentSongBpmTime - 2));
-        Shader.SetGlobalFloat(viewEnd, GetSecondsFromBeat(currentSongBpmTime + 8));
+        // set view range based on track length
+        Shader.SetGlobalFloat(viewStart, GetSecondsFromBeat(currentSongBpmTime - (Settings.Instance.TrackLength / 4)));
+        Shader.SetGlobalFloat(viewEnd, GetSecondsFromBeat(currentSongBpmTime + Settings.Instance.TrackLength));
         
         var position = currentSongBpmTime * EditorScaleController.EditorScale;
 

--- a/Assets/__Scripts/MapEditor/EditorScaleController.cs
+++ b/Assets/__Scripts/MapEditor/EditorScaleController.cs
@@ -120,6 +120,6 @@ public class EditorScaleController : MonoBehaviour, CMInput.IEditorScaleActions
         EditorScaleChangedEvent?.Invoke(EditorScale);
         previousEditorScale = EditorScale;
         foreach (var offset in scalingOffsets)
-            offset.localScale = new Vector3(offset.localScale.x, offset.localScale.y, 8 * EditorScale);
+            offset.localScale = new Vector3(offset.localScale.x, offset.localScale.y, Settings.Instance.TrackLength * EditorScale);
     }
 }

--- a/Assets/__Scripts/MapEditor/Grid/GridRenderingController.cs
+++ b/Assets/__Scripts/MapEditor/Grid/GridRenderingController.cs
@@ -118,7 +118,7 @@ public class GridRenderingController : MonoBehaviour
         foreach (var trans in gridFrontTransforms)
         {
             var scale = trans.localScale;
-            trans.localScale = new Vector3(scale.x, scale.y, Settings.Instance.TrackLength * 4);
+            trans.localScale = new Vector3(scale.x, scale.y, Settings.Instance.TrackLength * EditorScaleController.EditorScale);
         }
     }
 


### PR DESCRIPTION
* track length now actually applies on load
* editor scale change no longer overrides track length
* spectrogram view range properly accounts for track length