### PR TITLE
fixes related to undo/redo with conflicting objects

### DIFF
--- a/Assets/__Scripts/BeatmapActions/Beatmap Actions/BeatmapObjectDeletionAction.cs
+++ b/Assets/__Scripts/BeatmapActions/Beatmap Actions/BeatmapObjectDeletionAction.cs
@@ -15,7 +15,7 @@ public class BeatmapObjectDeletionAction : BeatmapAction
     {
         foreach (var obj in Data)
         {
-            SpawnObject(obj, true);
+            SpawnObject(obj);
         }
 
         RefreshPools(Data);

--- a/Assets/__Scripts/BeatmapActions/Beatmap Actions/BeatmapObjectModifiedWithConflictingAction.cs
+++ b/Assets/__Scripts/BeatmapActions/Beatmap Actions/BeatmapObjectModifiedWithConflictingAction.cs
@@ -20,7 +20,7 @@ public class BeatmapObjectModifiedWithConflictingAction : BeatmapObjectModifiedA
         base.Undo(param);
         if (conflictingObject != null)
         {
-            SpawnObject(conflictingObject);
+            SpawnObject(conflictingObject, refreshesPool: true);
         }
     }
 

--- a/Assets/__Scripts/BeatmapActions/Beatmap Actions/BeatmapObjectPlacementAction.cs
+++ b/Assets/__Scripts/BeatmapActions/Beatmap Actions/BeatmapObjectPlacementAction.cs
@@ -28,7 +28,7 @@ public class BeatmapObjectPlacementAction : BeatmapAction
 
         foreach (var data in removedConflictObjects)
         {
-            SpawnObject(data, true);
+            SpawnObject(data);
         }
 
         RefreshPools(removedConflictObjects);
@@ -45,7 +45,7 @@ public class BeatmapObjectPlacementAction : BeatmapAction
 
         foreach (var obj in Data)
         {
-            SpawnObject(obj, true);
+            SpawnObject(obj);
         }
 
         RefreshPools(Data);

--- a/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/PlacementController.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/PlacementController.cs
@@ -465,7 +465,7 @@ public abstract class PlacementController<TBo, TBoc, TBocc> : MonoBehaviour, CMI
             if (conflicting.Any())
             {
                 actions.Add(new BeatmapObjectModifiedWithConflictingAction(draggedObjectData, draggedObjectData,
-                    originalDraggedObjectData, conflicting.First(), "Modified via alt-click and drag."));
+                    originalDraggedObjectData, conflicting, "Modified via alt-click and drag."));
             }
             else
             {
@@ -601,7 +601,7 @@ public abstract class PlacementController<TBo, TBoc, TBocc> : MonoBehaviour, CMI
             if (conflictingArcs.Any())
             {
                 actions.Add(new BeatmapObjectModifiedWithConflictingAction(draggedSlider, draggedSlider,
-                    originalSlider, conflictingArcs.First(), "Modified via alt-click and drag."));
+                    originalSlider, conflictingArcs, "Modified via alt-click and drag."));
             }
             else
             {


### PR DESCRIPTION
fixes the conflicting object not reappearing immediately upon undo, but only after the next action that refreshes the pool

(now also fixes ghost object issues with undo/redo)

(now also fixes undo of multiple conflicting objects on object modified with conflicting action)