### PR TITLE
hide text on NJS extend events

### DIFF
--- a/Assets/__Scripts/Beatmap/Containers/NJSEventContainer.cs
+++ b/Assets/__Scripts/Beatmap/Containers/NJSEventContainer.cs
@@ -28,6 +28,7 @@ namespace Beatmap.Containers
         {
             var absoluteNJS = BeatSaberSongContainer.Instance.MapDifficultyInfo.NoteJumpSpeed + NJSData.RelativeNJS;
             njsText.text = absoluteNJS.ToString(CultureInfo.InvariantCulture);
+            njsText.enabled = NJSData.UsePrevious != 1;
         }
 
         public override void UpdateGridPosition()


### PR DESCRIPTION
the actual NJS value on these is irrelevant, and this makes them visually distinct