### PR TITLE
update note lane count setting on map load

### DIFF
--- a/Assets/__Scripts/MapEditor/UI/NoteLanesController.cs
+++ b/Assets/__Scripts/MapEditor/UI/NoteLanesController.cs
@@ -10,6 +10,7 @@ public class NoteLanesController : MonoBehaviour
     {
         Settings.NotifyBySettingName("NoteLanes", UpdateNoteLanes);
         UpdateNoteLanes(4);
+        if (Settings.NonPersistentSettings.ContainsKey("NoteLanes")) Settings.NonPersistentSettings["NoteLanes"] = 4;
     }
 
     private void OnDestroy() => Settings.ClearSettingNotifications("NoteLanes");


### PR DESCRIPTION
lane count is always set to 4 on load, but the setting wasn't updated so it kept the previous value