### PR TITLE
BPM event refactor

### DIFF
--- a/Assets/__Scripts/Beatmap/Animations/ObjectAnimator.cs
+++ b/Assets/__Scripts/Beatmap/Animations/ObjectAnimator.cs
@@ -178,7 +178,7 @@ namespace Beatmap.Animations
                     {
                         continue;
                     }
-                    var bpmChangeGridContainer = BeatmapObjectContainerCollection.GetCollectionForType<BPMChangeGridContainer>(ObjectType.BpmChange);
+                    var map = BeatSaberSongContainer.Instance.Map;
                     foreach (var ce in events.Where(ev => ev.Type == "AssignPathAnimation"))
                     {
                         foreach (var jprop in ce.Data)
@@ -196,7 +196,7 @@ namespace Beatmap.Animations
                                 TimeEnd = time_end,
                             };
                             if (p.Transition != 0) {
-                                p.Transition = bpmChangeGridContainer.JsonTimeToSongBpmTime(ce.JsonTime + p.Transition) - ce.SongBpmTime;
+                                p.Transition = (float)map.JsonTimeToSongBpmTime(ce.JsonTime + p.Transition) - ce.SongBpmTime;
                             }
                             AddPointDef(p, jprop.Key);
                         }

--- a/Assets/__Scripts/Beatmap/Base/BaseArc.cs
+++ b/Assets/__Scripts/Beatmap/Base/BaseArc.cs
@@ -35,13 +35,13 @@ namespace Beatmap.Base
 
         public BaseArc(BaseArc other)
         {
-            SetTimes(other.JsonTime, other.SongBpmTime);
+            SetTimes(other.JsonTime);
             Color = other.Color;
             PosX = other.PosX;
             PosY = other.PosY;
             CutDirection = other.CutDirection;
             HeadControlPointLengthMultiplier = other.HeadControlPointLengthMultiplier;
-            SetTailTimes(other.TailJsonTime, other.TailSongBpmTime);
+            SetTailTimes(other.TailJsonTime);
             TailPosX = other.TailPosX;
             TailPosY = other.TailPosY;
             TailCutDirection = other.TailCutDirection;
@@ -52,13 +52,13 @@ namespace Beatmap.Base
 
         public BaseArc(BaseNote start, BaseNote end)
         {
-            SetTimes(start.JsonTime, start.SongBpmTime);
+            SetTimes(start.JsonTime);
             Color = start.Color;
             PosX = start.PosX;
             PosY = start.PosY;
             CutDirection = start.CutDirection;
             HeadControlPointLengthMultiplier = 1f;
-            SetTailTimes(end.JsonTime, end.SongBpmTime);
+            SetTailTimes(end.JsonTime);
             TailPosX = end.PosX;
             TailPosY = end.PosY;
             TailCutDirection = end.CutDirection;

--- a/Assets/__Scripts/Beatmap/Base/BaseBpmEvent.cs
+++ b/Assets/__Scripts/Beatmap/Base/BaseBpmEvent.cs
@@ -26,7 +26,7 @@ namespace Beatmap.Base
 
         public BaseBpmEvent(BaseBpmEvent other)
         {
-            SetTimes(other.JsonTime, other.SongBpmTime);
+            SetTimes(other.JsonTime);
             Bpm = other.Bpm;
             CustomData = other.CustomData.Clone();
         }

--- a/Assets/__Scripts/Beatmap/Base/BaseChain.cs
+++ b/Assets/__Scripts/Beatmap/Base/BaseChain.cs
@@ -33,12 +33,12 @@ namespace Beatmap.Base
 
         public BaseChain(BaseChain other)
         {
-            SetTimes(other.JsonTime, other.SongBpmTime);
+            SetTimes(other.JsonTime);
             Color = other.Color;
             PosX = other.PosX;
             PosY = other.PosY;
             CutDirection = other.CutDirection;
-            SetTailTimes(other.TailJsonTime, other.TailSongBpmTime);
+            SetTailTimes(other.TailJsonTime);
             TailPosX = other.TailPosX;
             TailPosY = other.TailPosY;
             SliceCount = other.SliceCount;
@@ -48,12 +48,12 @@ namespace Beatmap.Base
 
         public BaseChain(BaseNote start, BaseNote end)
         {
-            SetTimes(start.JsonTime, start.SongBpmTime);
+            SetTimes(start.JsonTime);
             Color = start.Color;
             PosX = start.PosX;
             PosY = start.PosY;
             CutDirection = start.CutDirection;
-            SetTailTimes(end.JsonTime, end.SongBpmTime);
+            SetTailTimes(end.JsonTime);
             TailPosX = end.PosX;
             TailPosY = end.PosY;
             SliceCount = 5;

--- a/Assets/__Scripts/Beatmap/Base/BaseDifficulty.cs
+++ b/Assets/__Scripts/Beatmap/Base/BaseDifficulty.cs
@@ -135,7 +135,7 @@ namespace Beatmap.Base
         public float? JsonTimeToSongBpmTime(float jsonTime)
         {
             if (songBpm is null) return null;
-            var lastBpmEvent = FindLastBpmEventByJsonTime(jsonTime);
+            var lastBpmEvent = FindLastBpmEventByJsonTime(jsonTime, inclusive: false);
             if (lastBpmEvent is null)
             {
                 return jsonTime;
@@ -146,7 +146,7 @@ namespace Beatmap.Base
         public float? SongBpmTimeToJsonTime(float songBpmTime)
         {
             if (songBpm is null) return null;
-            var lastBpmEvent = FindLastBpmEventBySongBpmTime(songBpmTime);
+            var lastBpmEvent = FindLastBpmEventBySongBpmTime(songBpmTime, inclusive: false);
             if (lastBpmEvent is null)
             {
                 return songBpmTime;
@@ -154,25 +154,25 @@ namespace Beatmap.Base
             return lastBpmEvent.JsonTime + (songBpmTime - lastBpmEvent.SongBpmTime) * (lastBpmEvent.Bpm / songBpm);
         }
 
-        public BaseBpmEvent FindLastBpmEventByJsonTime(float jsonTime)
+        public BaseBpmEvent FindLastBpmEventByJsonTime(float jsonTime, bool inclusive = false)
         {
-            return BpmEvents.LastOrDefault(x => x.JsonTime < jsonTime);
+            return BpmEvents.LastOrDefault(x => inclusive ? x.JsonTime <= jsonTime : x.JsonTime < jsonTime);
         }
 
-        public BaseBpmEvent FindLastBpmEventBySongBpmTime(float songBpmTime)
+        public BaseBpmEvent FindLastBpmEventBySongBpmTime(float songBpmTime, bool inclusive = false)
         {
             if (songBpm is null) return null;
-            return BpmEvents.LastOrDefault(x => x.SongBpmTime < songBpmTime);
+            return BpmEvents.LastOrDefault(x => inclusive ? x.SongBpmTime <= songBpmTime : x.SongBpmTime < songBpmTime);
         }
 
         public float? BpmAtJsonTime(float jsonTime)
         {
-            return FindLastBpmEventByJsonTime(jsonTime)?.Bpm ?? songBpm;
+            return FindLastBpmEventByJsonTime(jsonTime, inclusive: true)?.Bpm ?? songBpm;
         }
 
         public float? BpmAtSongBpmTime(float songBpmTime)
         {
-            return FindLastBpmEventBySongBpmTime(songBpmTime)?.Bpm ?? songBpm;
+            return FindLastBpmEventBySongBpmTime(songBpmTime, inclusive: true)?.Bpm ?? songBpm;
         }
 
         public void RecomputeAllObjectSongBpmTimes()

--- a/Assets/__Scripts/Beatmap/Base/BaseDifficulty.cs
+++ b/Assets/__Scripts/Beatmap/Base/BaseDifficulty.cs
@@ -156,13 +156,13 @@ namespace Beatmap.Base
 
         public BaseBpmEvent FindLastBpmEventByJsonTime(float jsonTime)
         {
-            return BpmEvents.LastOrDefault(x => x.JsonTime <= jsonTime);
+            return BpmEvents.LastOrDefault(x => x.JsonTime < jsonTime);
         }
 
         public BaseBpmEvent FindLastBpmEventBySongBpmTime(float songBpmTime)
         {
             if (songBpm is null) return null;
-            return BpmEvents.LastOrDefault(x => x.SongBpmTime <= songBpmTime);
+            return BpmEvents.LastOrDefault(x => x.SongBpmTime < songBpmTime);
         }
 
         public float? BpmAtJsonTime(float jsonTime)

--- a/Assets/__Scripts/Beatmap/Base/BaseDifficulty.cs
+++ b/Assets/__Scripts/Beatmap/Base/BaseDifficulty.cs
@@ -99,6 +99,8 @@ namespace Beatmap.Base
 
         public void BootstrapBpmEvents(float songBpm)
         {
+            this.songBpm = songBpm;
+
             // remove invalid bpm events
             BpmEvents.RemoveAll(x => x.JsonTime < 0);
             BpmEvents.RemoveAll(x => x.Bpm < 0);
@@ -128,8 +130,6 @@ namespace Beatmap.Base
 
                 lastBpmEvent = bpmEvent;
             }
-
-            this.songBpm = songBpm;
         }
 
         public float? JsonTimeToSongBpmTime(float jsonTime)

--- a/Assets/__Scripts/Beatmap/Base/BaseDifficulty.cs
+++ b/Assets/__Scripts/Beatmap/Base/BaseDifficulty.cs
@@ -93,6 +93,102 @@ namespace Beatmap.Base
             new List<BaseObject>(CustomEvents),
         };
 
+        #region BPM Time Conversion Logic
+
+        private float? songBpm;
+
+        public void BootstrapBpmEvents(float songBpm)
+        {
+            // remove invalid bpm events
+            BpmEvents.RemoveAll(x => x.JsonTime < 0);
+            BpmEvents.RemoveAll(x => x.Bpm < 0);
+
+            if (!BpmEvents.Any()) return;
+
+            BpmEvents.Sort();
+
+            // insert beat 0 bpm event if needed
+            if (BpmEvents.First().JsonTime > 0)
+            {
+                var newBpmEvent = new BaseBpmEvent(0, songBpm);
+                BpmEvents.Insert(0, newBpmEvent);
+            }
+
+            BaseBpmEvent lastBpmEvent = null;
+            foreach (var bpmEvent in BpmEvents)
+            {
+                if (lastBpmEvent is null)
+                {
+                    bpmEvent.songBpmTime = bpmEvent.JsonTime;
+                }
+                else
+                {
+                    bpmEvent.songBpmTime = lastBpmEvent.songBpmTime + (bpmEvent.JsonTime - lastBpmEvent.JsonTime) * (songBpm / lastBpmEvent.Bpm);
+                }
+
+                lastBpmEvent = bpmEvent;
+            }
+
+            this.songBpm = songBpm;
+        }
+
+        public float? JsonTimeToSongBpmTime(float jsonTime)
+        {
+            if (songBpm is null) return null;
+            var lastBpmEvent = FindLastBpmEventByJsonTime(jsonTime);
+            if (lastBpmEvent is null)
+            {
+                return jsonTime;
+            }
+            return lastBpmEvent.SongBpmTime + (jsonTime - lastBpmEvent.JsonTime) * (songBpm / lastBpmEvent.Bpm);
+        }
+
+        public float? SongBpmTimeToJsonTime(float songBpmTime)
+        {
+            if (songBpm is null) return null;
+            var lastBpmEvent = FindLastBpmEventBySongBpmTime(songBpmTime);
+            if (lastBpmEvent is null)
+            {
+                return songBpmTime;
+            }
+            return lastBpmEvent.JsonTime + (songBpmTime - lastBpmEvent.SongBpmTime) * (lastBpmEvent.Bpm / songBpm);
+        }
+
+        public BaseBpmEvent FindLastBpmEventByJsonTime(float jsonTime)
+        {
+            return BpmEvents.LastOrDefault(x => x.JsonTime <= jsonTime);
+        }
+
+        public BaseBpmEvent FindLastBpmEventBySongBpmTime(float songBpmTime)
+        {
+            if (songBpm is null) return null;
+            return BpmEvents.LastOrDefault(x => x.SongBpmTime <= songBpmTime);
+        }
+
+        public float? BpmAtJsonTime(float jsonTime)
+        {
+            return FindLastBpmEventByJsonTime(jsonTime)?.Bpm ?? songBpm;
+        }
+
+        public float? BpmAtSongBpmTime(float songBpmTime)
+        {
+            return FindLastBpmEventBySongBpmTime(songBpmTime)?.Bpm ?? songBpm;
+        }
+
+        public void RecomputeAllObjectSongBpmTimes()
+        {
+            foreach (var objList in AllBaseObjectProperties())
+            {
+                if (objList is null) continue;
+                foreach (var obj in objList)
+                {
+                    obj.RecomputeSongBpmTime();
+                }
+            }
+        }
+
+        #endregion
+
         public void ConvertCustomBpmToOfficial()
         {
             var songBpm = BeatSaberSongContainer.Instance.Info.BeatsPerMinute;

--- a/Assets/__Scripts/Beatmap/Base/BaseEvent.cs
+++ b/Assets/__Scripts/Beatmap/Base/BaseEvent.cs
@@ -37,7 +37,7 @@ namespace Beatmap.Base
 
         public BaseEvent(BaseEvent other)
         {
-            SetTimes(other.JsonTime, other.SongBpmTime);
+            SetTimes(other.JsonTime);
             Type = other.Type;
             Value = other.Value;
             FloatValue = other.FloatValue;

--- a/Assets/__Scripts/Beatmap/Base/BaseGrid.cs
+++ b/Assets/__Scripts/Beatmap/Base/BaseGrid.cs
@@ -53,8 +53,8 @@ namespace Beatmap.Base
 
         public float EditorScale { get; private set; }
 
-        public virtual float SpawnSongBpmTime { get { return SongBpmTime - Hjd; } }
-        public virtual float DespawnSongBpmTime { get { return SongBpmTime + Hjd; } }
+        public virtual float SpawnSongBpmTime => SongBpmTime - Hjd;
+        public virtual float DespawnSongBpmTime => SongBpmTime + Hjd;
 
         public virtual JSONNode CustomAnimation { get; set; }
 

--- a/Assets/__Scripts/Beatmap/Base/BaseNJSEvent.cs
+++ b/Assets/__Scripts/Beatmap/Base/BaseNJSEvent.cs
@@ -29,7 +29,7 @@ namespace Beatmap.Base
 
         public BaseNJSEvent(BaseNJSEvent other)
         {
-            SetTimes(other.JsonTime, other.SongBpmTime);
+            SetTimes(other.JsonTime);
             UsePrevious = other.UsePrevious;
             Easing = other.Easing;
             RelativeNJS = other.RelativeNJS;

--- a/Assets/__Scripts/Beatmap/Base/BaseNote.cs
+++ b/Assets/__Scripts/Beatmap/Base/BaseNote.cs
@@ -36,7 +36,7 @@ namespace Beatmap.Base
 
         public BaseNote(BaseNote other)
         {
-            SetTimes(other.JsonTime, other.SongBpmTime);
+            SetTimes(other.JsonTime);
             PosX = other.PosX;
             PosY = other.PosY;
             Color = other.Color;

--- a/Assets/__Scripts/Beatmap/Base/BaseObject.cs
+++ b/Assets/__Scripts/Beatmap/Base/BaseObject.cs
@@ -12,7 +12,7 @@ namespace Beatmap.Base
         public virtual void Serialize(NetDataWriter writer)
         {
             writer.Put(jsonTime);
-            writer.Put(songBpmTime);
+            writer.Put((float)songBpmTime);
             writer.Put(CustomData?.ToString());
         }
 
@@ -49,28 +49,21 @@ namespace Beatmap.Base
             get => jsonTime;
             set
             {
-                var bpmChangeGridContainer = BeatmapObjectContainerCollection.GetCollectionForType<BPMChangeGridContainer>(ObjectType.BpmChange);
-                songBpmTime = bpmChangeGridContainer?.JsonTimeToSongBpmTime(value) ?? value;
+                var map = BeatSaberSongContainer.Instance.Map;
+                songBpmTime = map?.JsonTimeToSongBpmTime(value);
                 jsonTime = value;
             }
         }
 
-        private float songBpmTime;
-        public float SongBpmTime
-        {
-            get => songBpmTime;
-            set
-            {
-                var bpmChangeGridContainer = BeatmapObjectContainerCollection.GetCollectionForType<BPMChangeGridContainer>(ObjectType.BpmChange);
-                jsonTime = bpmChangeGridContainer?.SongBpmTimeToJsonTime(value) ?? value;
-                songBpmTime = value;
-            }
-        }
+        // should only be set directly when initializing
+        // read from SongBpmTime instead, and write to JsonTime to update this
+        // really should be private but we need to set this from BaseDifficulty on init
+        internal float? songBpmTime; 
+        public float SongBpmTime => (float)songBpmTime;
 
-        public void SetTimes(float jsonTime, float songBpmTime)
+        public void SetTimes(float jsonTime)
         {
             this.jsonTime = jsonTime;
-            this.songBpmTime = songBpmTime;
             RecomputeSongBpmTime();
         }
 

--- a/Assets/__Scripts/Beatmap/Base/BaseObject.cs
+++ b/Assets/__Scripts/Beatmap/Base/BaseObject.cs
@@ -49,7 +49,7 @@ namespace Beatmap.Base
             get => jsonTime;
             set
             {
-                var map = BeatSaberSongContainer.Instance.Map;
+                var map = BeatSaberSongContainer.Instance != null ? BeatSaberSongContainer.Instance.Map : null;
                 songBpmTime = map?.JsonTimeToSongBpmTime(value);
                 jsonTime = value;
             }

--- a/Assets/__Scripts/Beatmap/Base/BaseObject.cs
+++ b/Assets/__Scripts/Beatmap/Base/BaseObject.cs
@@ -25,6 +25,7 @@ namespace Beatmap.Base
 
         protected BaseObject()
         {
+            JsonTime = 0; // needed to set songBpmTime
         }
 
         protected BaseObject(float time, JSONNode customData = null)

--- a/Assets/__Scripts/Beatmap/Base/BaseObstacle.cs
+++ b/Assets/__Scripts/Beatmap/Base/BaseObstacle.cs
@@ -105,7 +105,7 @@ namespace Beatmap.Base
             get => duration; 
             set
             {
-                var map = BeatSaberSongContainer.Instance.Map;
+                var map = BeatSaberSongContainer.Instance != null ? BeatSaberSongContainer.Instance.Map : null;
                 durationSongBpm = map?.JsonTimeToSongBpmTime(value + JsonTime) - songBpmTime;
                 duration = value;
             }

--- a/Assets/__Scripts/Beatmap/Base/BaseObstacle.cs
+++ b/Assets/__Scripts/Beatmap/Base/BaseObstacle.cs
@@ -40,7 +40,7 @@ namespace Beatmap.Base
 
         private BaseObstacle(BaseObstacle other)
         {
-            SetTimes(other.JsonTime, other.SongBpmTime);
+            SetTimes(other.JsonTime);
             PosX = other.PosX;
             InternalPosY = other.PosY;
             InternalType = other.Type;
@@ -99,11 +99,22 @@ namespace Beatmap.Base
             set => InternalHeight = value;
         }
 
-        public float Duration { get; set; }
-        public float DurationSongBpm { get; set; }
+        private float duration;
+        public float Duration
+        { 
+            get => duration; 
+            set
+            {
+                var map = BeatSaberSongContainer.Instance.Map;
+                durationSongBpm = map?.JsonTimeToSongBpmTime(value + JsonTime) - songBpmTime;
+                duration = value;
+            }
+        }
+        private float? durationSongBpm;
+        public float DurationSongBpm => (float)durationSongBpm;
         public int Width { get; set; }
-        
-        public override float DespawnSongBpmTime { get { return SongBpmTime + DurationSongBpm + Hjd; } }
+
+        public override float DespawnSongBpmTime => SongBpmTime + DurationSongBpm + Hjd;
 
         public virtual JSONNode CustomSize { get; set; }
 
@@ -277,8 +288,7 @@ namespace Beatmap.Base
         public override void RecomputeSongBpmTime()
         {
             base.RecomputeSongBpmTime();
-            DurationSongBpm = (BeatmapObjectContainerCollection.GetCollectionForType<BPMChangeGridContainer>(ObjectType.BpmChange)
-                ?.JsonTimeToSongBpmTime(JsonTime + Duration) ?? (JsonTime + Duration)) - SongBpmTime;
+            Duration = Duration;
         }
 
         protected void InferType() =>

--- a/Assets/__Scripts/Beatmap/Base/BaseSlider.cs
+++ b/Assets/__Scripts/Beatmap/Base/BaseSlider.cs
@@ -71,27 +71,17 @@ namespace Beatmap.Base
             get => tailJsonTime;
             set
             {
-                var bpmChangeGridContainer = BeatmapObjectContainerCollection.GetCollectionForType<BPMChangeGridContainer>(ObjectType.BpmChange);
-                tailSongBpmTime = bpmChangeGridContainer?.JsonTimeToSongBpmTime(value) ?? value;
+                var map = BeatSaberSongContainer.Instance.Map;
+                tailSongBpmTime = map?.JsonTimeToSongBpmTime(value);
                 tailJsonTime = value;
             }
         }
-        private float tailSongBpmTime { get; set; }
-        public float TailSongBpmTime
-        {
-            get => tailSongBpmTime;
-            set
-            {
-                var bpmChangeGridContainer = BeatmapObjectContainerCollection.GetCollectionForType<BPMChangeGridContainer>(ObjectType.BpmChange);
-                tailJsonTime = bpmChangeGridContainer?.SongBpmTimeToJsonTime(value) ?? value;
-                tailSongBpmTime = value;
-            }
-        }
+        private float? tailSongBpmTime;
+        public float TailSongBpmTime => (float)tailSongBpmTime;
 
-        public void SetTailTimes(float jsonTime, float songBpmTime)
+        public void SetTailTimes(float jsonTime)
         {
-            this.tailJsonTime = jsonTime;
-            this.tailSongBpmTime = songBpmTime;
+            TailJsonTime = jsonTime;
         }
 
         public int TailPosX { get; set; }
@@ -140,9 +130,8 @@ namespace Beatmap.Base
         public virtual void SwapHeadAndTail()
         {
             var tempJsonTime = JsonTime;
-            var tempJsonSongBpmTime = SongBpmTime;
-            SetTimes(tailJsonTime, tailSongBpmTime);
-            SetTailTimes(tempJsonTime, tempJsonSongBpmTime);
+            SetTimes(tailJsonTime);
+            SetTailTimes(tempJsonTime);
             (PosX, TailPosX) = (TailPosX, PosX);
             (PosY, TailPosY) = (TailPosY, PosY);
         }

--- a/Assets/__Scripts/Beatmap/Base/BaseSlider.cs
+++ b/Assets/__Scripts/Beatmap/Base/BaseSlider.cs
@@ -34,6 +34,7 @@ namespace Beatmap.Base
 
         protected BaseSlider()
         {
+            TailJsonTime = 0; // needed to set tailSongBpmTime
         }
 
         protected BaseSlider(float time, int posX, int posY, int color, int cutDirection, int angleOffset,

--- a/Assets/__Scripts/Beatmap/Base/BaseSlider.cs
+++ b/Assets/__Scripts/Beatmap/Base/BaseSlider.cs
@@ -71,7 +71,7 @@ namespace Beatmap.Base
             get => tailJsonTime;
             set
             {
-                var map = BeatSaberSongContainer.Instance.Map;
+                var map = BeatSaberSongContainer.Instance != null ? BeatSaberSongContainer.Instance.Map : null;
                 tailSongBpmTime = map?.JsonTimeToSongBpmTime(value);
                 tailJsonTime = value;
             }

--- a/Assets/__Scripts/Beatmap/Base/BaseWaypoint.cs
+++ b/Assets/__Scripts/Beatmap/Base/BaseWaypoint.cs
@@ -14,7 +14,7 @@ namespace Beatmap.Base
 
         public BaseWaypoint(BaseWaypoint other)
         {
-            SetTimes(other.JsonTime, other.SongBpmTime);
+            SetTimes(other.JsonTime);
             PosX = other.PosX;
             PosY = other.PosY;
             OffsetDirection = other.OffsetDirection;

--- a/Assets/__Scripts/Beatmap/Base/Customs/BaseBookmark.cs
+++ b/Assets/__Scripts/Beatmap/Base/Customs/BaseBookmark.cs
@@ -41,7 +41,7 @@ namespace Beatmap.Base.Customs
 
         protected BaseBookmark(BaseBookmark other)
         {
-            SetTimes(other.JsonTime, other.SongBpmTime);
+            SetTimes(other.JsonTime);
             Name = other.Name;
             Color = other.Color;
         }

--- a/Assets/__Scripts/Beatmap/Base/Customs/BaseBpmChange.cs
+++ b/Assets/__Scripts/Beatmap/Base/Customs/BaseBpmChange.cs
@@ -13,7 +13,7 @@ namespace Beatmap.Base.Customs
 
         protected BaseBpmChange(BaseBpmChange other)
         {
-            SetTimes(other.JsonTime, other.SongBpmTime);
+            SetTimes(other.JsonTime);
             Bpm = other.Bpm;
             BeatsPerBar = other.BeatsPerBar;
             MetronomeOffset = other.MetronomeOffset;
@@ -21,7 +21,7 @@ namespace Beatmap.Base.Customs
 
         protected BaseBpmChange(BaseBpmEvent other)
         {
-            SetTimes(other.JsonTime, other.SongBpmTime);
+            SetTimes(other.JsonTime);
             Bpm = other.Bpm;
             BeatsPerBar = 4;
             MetronomeOffset = 4;

--- a/Assets/__Scripts/Beatmap/Containers/ObstacleContainer.cs
+++ b/Assets/__Scripts/Beatmap/Containers/ObstacleContainer.cs
@@ -58,9 +58,7 @@ namespace Beatmap.Containers
             if (ObstacleData.CustomSize != null && ObstacleData.CustomSize.IsArray && ObstacleData.CustomSize[2].IsNumber)
                 return ObstacleData.CustomSize[2];
 
-            var obstacleStart = ObstacleData.SongBpmTime;
-            var obstacleEnd = bpmChangeGridContainer?.JsonTimeToSongBpmTime(ObstacleData.JsonTime + ObstacleData.Duration) ?? 0;
-            var length = obstacleEnd - obstacleStart;
+            var length = ObstacleData.DurationSongBpm;
 
             //Take half jump duration into account if the setting is enabled.
             if (ObstacleData.Duration < 0 && Settings.Instance.ShowMoreAccurateFastWalls && !UIMode.AnimationMode)

--- a/Assets/__Scripts/Beatmap/Helper/BeatmapFactory.cs
+++ b/Assets/__Scripts/Beatmap/Helper/BeatmapFactory.cs
@@ -17,28 +17,36 @@ namespace Beatmap.Helper
     {
         public static BaseDifficulty GetDifficultyFromJson(JSONNode mainNode, string directoryAndFile)
         {
+            var info = BeatSaberSongContainer.Instance.Info;
+            var infoDifficulty = BeatSaberSongContainer.Instance.MapDifficultyInfo;
+            BaseDifficulty difficulty;
+
             var v = PeekMapVersionFromJson(mainNode);
 
             switch (v[0])
             {
                 case '4':
                     Settings.Instance.MapVersion = 4;
-                    var difficulty = V4Difficulty.GetFromJson(mainNode, directoryAndFile);
-                    var info = BeatSaberSongContainer.Instance.Info;
-                    var infoDifficulty = BeatSaberSongContainer.Instance.MapDifficultyInfo;
+                    difficulty = V4Difficulty.GetFromJson(mainNode, directoryAndFile);
                     V4Difficulty.LoadBpmFromAudioData(difficulty, info);
                     V4Difficulty.LoadLightsFromLightshowFile(difficulty, info, infoDifficulty);
                     V4Difficulty.LoadBookmarksFromOfficialEditor(difficulty, info, infoDifficulty);
-                    return difficulty;
+                    break;
                 case '3':
                     Settings.Instance.MapVersion = 3;
-                    return V3Difficulty.GetFromJson(mainNode, directoryAndFile);
+                    difficulty = V3Difficulty.GetFromJson(mainNode, directoryAndFile);
+                    break;
                 case '2':
                     Settings.Instance.MapVersion = 2;
-                    return V2Difficulty.GetFromJson(mainNode, directoryAndFile);
+                    difficulty = V2Difficulty.GetFromJson(mainNode, directoryAndFile);
+                    break;
                 default:
                     return null;
             }
+
+            difficulty.BootstrapBpmEvents(info.BeatsPerMinute);
+            difficulty.RecomputeAllObjectSongBpmTimes();
+            return difficulty;
         }
 
         private static string PeekMapVersionFromJson(JSONNode mainNode)

--- a/Assets/__Scripts/MapEditor/Audio/MetronomeHandler.cs
+++ b/Assets/__Scripts/MapEditor/Audio/MetronomeHandler.cs
@@ -49,13 +49,14 @@ public class MetronomeHandler : MonoBehaviour
             if (atsc.CurrentAudioBeats > queuedDingSongBpmTime)
             {
                 var nextJsonTime = Mathf.Ceil(atsc.CurrentJsonTime);
-                
-                if (Mathf.Abs(Mathf.Floor(bpmChangeGridContainer.SongBpmTimeToJsonTime(atsc.CurrentAudioBeats))
+
+                var map = BeatSaberSongContainer.Instance.Map;
+                if (Mathf.Abs(Mathf.Floor((float)map.SongBpmTimeToJsonTime(atsc.CurrentAudioBeats))
                               - Mathf.Floor(atsc.CurrentJsonTime)) > 0.01f)
                 {
                     nextJsonTime = Mathf.Ceil(nextJsonTime + 1f);
                 }
-                queuedDingSongBpmTime = bpmChangeGridContainer.JsonTimeToSongBpmTime(nextJsonTime);
+                queuedDingSongBpmTime = (float)map.JsonTimeToSongBpmTime(nextJsonTime);
 
                 var delay = atsc.GetSecondsFromBeat(queuedDingSongBpmTime - atsc.CurrentAudioBeats) / songSpeed;
                 audioUtil.PlayOneShotSound(CowBell ? cowbellSound : metronomeSound, Settings.Instance.MetronomeVolume,

--- a/Assets/__Scripts/MapEditor/AudioTimeSyncController.cs
+++ b/Assets/__Scripts/MapEditor/AudioTimeSyncController.cs
@@ -68,7 +68,7 @@ public class AudioTimeSyncController : MonoBehaviour, CMInput.IPlaybackActions, 
         private set
         {
             currentJsonTime = value;
-            currentSongBpmTime = bpmChangeGridContainer?.JsonTimeToSongBpmTime(value) ?? value;
+            currentSongBpmTime = (float)BeatSaberSongContainer.Instance.Map.JsonTimeToSongBpmTime(value);
             currentSeconds = GetSecondsFromBeat(currentSongBpmTime);
             ValidatePosition();
             UpdateMovables();
@@ -85,7 +85,7 @@ public class AudioTimeSyncController : MonoBehaviour, CMInput.IPlaybackActions, 
         private set
         {
             currentSongBpmTime = value;
-            currentJsonTime = bpmChangeGridContainer?.SongBpmTimeToJsonTime(value) ?? value;
+            currentJsonTime = (float)BeatSaberSongContainer.Instance.Map.SongBpmTimeToJsonTime(value);
             currentSeconds = GetSecondsFromBeat(value);
             ValidatePosition();
             UpdateMovables();
@@ -99,7 +99,7 @@ public class AudioTimeSyncController : MonoBehaviour, CMInput.IPlaybackActions, 
         {
             currentSeconds = value;
             currentSongBpmTime = GetBeatFromSeconds(value);
-            currentJsonTime = bpmChangeGridContainer.SongBpmTimeToJsonTime(currentSongBpmTime);
+            currentJsonTime = (float)BeatSaberSongContainer.Instance.Map.SongBpmTimeToJsonTime(currentSongBpmTime);
             ValidatePosition();
             UpdateMovables();
         }
@@ -412,24 +412,22 @@ public class AudioTimeSyncController : MonoBehaviour, CMInput.IPlaybackActions, 
     {
         if (IsPlaying) return;
         var songBpmTime = GetBeatFromSeconds(seconds);
-        UpdateCurrentTimes(songBpmTime);
+        currentJsonTime = (float)BeatSaberSongContainer.Instance.Map.SongBpmTimeToJsonTime(songBpmTime);
+
+        SnapToGrid();
         SongAudioSource.time = CurrentSeconds;
-        ValidatePosition();
-        UpdateMovables();
     }
 
     public void SnapToGrid(bool positionValidated = false)
     {
-        UpdateCurrentTimes(currentSongBpmTime);
+        var jsonTime = (float)Math.Round(CurrentJsonTime * GridMeasureSnapping, MidpointRounding.AwayFromZero) / GridMeasureSnapping;
+
+        currentJsonTime = jsonTime;
+        currentSongBpmTime = (float)BeatSaberSongContainer.Instance.Map.JsonTimeToSongBpmTime(jsonTime);
+        currentSeconds = GetSecondsFromBeat(currentSongBpmTime);
+
         if (!positionValidated) ValidatePosition();
         UpdateMovables();
-    }
-
-    private void UpdateCurrentTimes(float songBpmTime)
-    {
-        currentJsonTime = bpmChangeGridContainer.SongBpmTimeToRoundedJsonTime(songBpmTime);
-        currentSongBpmTime = bpmChangeGridContainer.JsonTimeToSongBpmTime(currentJsonTime);
-        currentSeconds = GetSecondsFromBeat(currentSongBpmTime);
     }
 
     public void RefreshGridSnapping() => GridMeasureSnappingChanged?.Invoke(GridMeasureSnapping);
@@ -456,8 +454,6 @@ public class AudioTimeSyncController : MonoBehaviour, CMInput.IPlaybackActions, 
         CurrentJsonTime = jsonTime;
         SongAudioSource.time = CurrentSeconds;
     }
-
-    public float FindRoundedBeatTime(float beat, float snap = -1) => bpmChangeGridContainer.FindRoundedBpmTime(beat, snap);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public float GetBeatFromSeconds(float seconds) => MapInfo.BeatsPerMinute / 60 * seconds;

--- a/Assets/__Scripts/MapEditor/Detection/DingOnNotePassingGrid.cs
+++ b/Assets/__Scripts/MapEditor/Detection/DingOnNotePassingGrid.cs
@@ -88,10 +88,10 @@ public class DingOnNotePassingGrid : MonoBehaviour
         if (!playing) return;
         
         // Since we schedule hit sounds ahead of time using the note callback, there will be a small period ahead of the
-        // playback cursor when start play is toggled where hit sounds are not scheduled play on play so we do that here 
-        var bpmCollection = BeatmapObjectContainerCollection.GetCollectionForType<BPMChangeGridContainer>(ObjectType.BpmChange);
-        var currentJsonTime = bpmCollection.SongBpmTimeToJsonTime(atsc.CurrentAudioBeats);
-        var endJsonTime = bpmCollection.SongBpmTimeToJsonTime(atsc.CurrentAudioBeats + beatSaberCutCallbackController.Offset);
+        // playback cursor when start play is toggled where hit sounds are not scheduled play on play so we do that here
+        var map = BeatSaberSongContainer.Instance.Map;
+        var currentJsonTime = (float)map.SongBpmTimeToJsonTime(atsc.CurrentAudioBeats);
+        var endJsonTime = (float)map.SongBpmTimeToJsonTime(atsc.CurrentAudioBeats + beatSaberCutCallbackController.Offset);
         var notes = container.GetBetween(currentJsonTime, endJsonTime);
         
         foreach (var n in notes) PlaySound(false, 0, n);

--- a/Assets/__Scripts/MapEditor/Grid/Collections/BPMChangeGridContainer.cs
+++ b/Assets/__Scripts/MapEditor/Grid/Collections/BPMChangeGridContainer.cs
@@ -108,14 +108,15 @@ public class BPMChangeGridContainer : BeatmapObjectContainerCollection<BaseBpmEv
 
     public void RefreshGridProperties()
     {
+        var songContainer = BeatSaberSongContainer.Instance;
         // Could probably save a tiny bit of performance since this should always be constant (0, Song BPM) but whatever
         var bpmChangeCount = 1;
         bpmShaderTimes[0] = 0;
         bpmShaderJsonTimes[0] = 0;
-        bpmShaderBpMs[0] = BeatSaberSongContainer.Instance.Info.BeatsPerMinute;
+        bpmShaderBpMs[0] = songContainer.Info.BeatsPerMinute;
 
         // Grab the last object before grid ends
-        var lastBpmChange = FindLastBpm(AudioTimeSyncController.CurrentSongBpmTime - firstVisibleBeatTime, false);
+        var lastBpmChange = songContainer.Map.FindLastBpmEventBySongBpmTime(AudioTimeSyncController.CurrentSongBpmTime - firstVisibleBeatTime);
 
         // Plug this last bpm change in
         // Believe it or not, I cannot actually skip this BPM change if it exists
@@ -162,114 +163,6 @@ public class BPMChangeGridContainer : BeatmapObjectContainerCollection<BaseBpmEv
 
     protected override void OnContainerDespawn(ObjectContainer container, BaseObject obj)
         => RefreshGridProperties();
-
-    public float FindRoundedBpmTime(float beatTimeInSongBpm, float snap = -1)
-    {
-        if (snap == -1) snap = 1f / AudioTimeSyncController.GridMeasureSnapping;
-        var lastBpm = FindLastBpm(beatTimeInSongBpm); //Find the last BPM Change before our beat time
-        if (lastBpm is null)
-        {
-            return (float)Math.Round(beatTimeInSongBpm / snap, MidpointRounding.AwayFromZero) *
-                   snap; //If its null, return rounded song bpm
-        }
-
-        var jsonTime = SongBpmTimeToJsonTime(beatTimeInSongBpm);
-        var roundedJsonTime = (float)Math.Round(jsonTime / snap, MidpointRounding.AwayFromZero) * snap;
-
-        return JsonTimeToSongBpmTime(roundedJsonTime);
-    }
-
-    public float SongBpmTimeToRoundedJsonTime(float songBpmTime, float snap = -1)
-    {
-        if (snap == -1) snap = 1f / AudioTimeSyncController.GridMeasureSnapping;
-
-        var jsonTime = SongBpmTimeToJsonTime(songBpmTime);
-        return (float)Math.Round(jsonTime / snap, MidpointRounding.AwayFromZero) * snap;
-    }
-
-    /// <summary>
-    ///     Find the last <see cref="BaseBpmEvent" /> before a given beat time.
-    /// </summary>
-    /// <param name="beatTimeInSongBpm">Time in raw beats (Unmodified by any BPM Changes)</param>
-    /// <param name="inclusive">Whether or not to include <see cref="BaseBpmEvent" />s with the same time value.</param>
-    /// <returns>The last <see cref="BaseBpmEvent" /> before the given beat (or <see cref="null" /> if there is none).</returns>
-    public BaseBpmEvent FindLastBpm(float beatTimeInSongBpm, bool inclusive = true)
-    {
-        return inclusive
-            ? MapObjects.FindLast(x => x.SongBpmTime <= beatTimeInSongBpm + 0.01f)
-            : MapObjects.FindLast(x => x.SongBpmTime + 0.01f < beatTimeInSongBpm);
-    }
-
-    /// <summary>
-    ///     Find the next <see cref="BaseBpmEvent" /> after a given beat time.
-    /// </summary>
-    /// <param name="beatTimeInSongBpm">Time in raw beats (Unmodified by any BPM Changes)</param>
-    /// <param name="inclusive">Whether or not to include <see cref="BaseBpmEvent" />s with the same time value.</param>
-    /// <returns>The next <see cref="BaseBpmEvent" /> after the given beat (or <see cref="null" /> if there is none).</returns>
-    public BaseBpmEvent FindNextBpm(float beatTimeInSongBpm, bool inclusive = false)
-    {
-        return inclusive
-            ? MapObjects.Find(x => x.SongBpmTime >= beatTimeInSongBpm - 0.01f)
-            : MapObjects.Find(x => x.SongBpmTime - 0.01f > beatTimeInSongBpm);
-    }
-
-    private BaseBpmEvent DefaultEvent()
-    {
-        var defaultEvent = new BaseBpmEvent { Bpm = BeatSaberSongContainer.Instance.Info.BeatsPerMinute };
-        return defaultEvent;
-    }
-
-    public float JsonTimeToSongBpmTime(float jsonTime)
-    {
-        var songBpm = BeatSaberSongContainer.Instance.Info.BeatsPerMinute;
-        var bpms = MapObjects.FindAll(x => x.JsonTime <= jsonTime);
-        bpms.Insert(0, DefaultEvent());
-
-        var currentSongBeats = 0f;
-        for (int i = 0; i < bpms.Count - 1; i++)
-        {
-            var bpmChange = bpms[i];
-            var nextBpmChange = bpms[i + 1];
-
-            var timeDiff = nextBpmChange.JsonTime - bpmChange.JsonTime;
-
-            currentSongBeats += timeDiff * (songBpm / bpmChange.Bpm);
-        }
-
-        currentSongBeats += (jsonTime - bpms.Last().JsonTime) * (songBpm / bpms.Last().Bpm);
-        return currentSongBeats;
-    }
-
-    public float SongBpmTimeToJsonTime(float songBpmTime)
-    {
-        var songBpm = BeatSaberSongContainer.Instance.Info.BeatsPerMinute;
-        var bpms = MapObjects.FindAll(x => x.SongBpmTime <= songBpmTime);
-        bpms.Insert(0, DefaultEvent());
-
-        var seconds = songBpmTime * (60f / songBpm);
-
-        var currentSeconds = 0f;
-        var nextSeconds = 0f;
-        for (int i = 0; i < bpms.Count - 1; i++)
-        {
-            var bpmChange = bpms[i];
-            var nextBpmChange = bpms[i + 1];
-
-            var timeDiff = nextBpmChange.JsonTime - bpmChange.JsonTime;
-            var scale = bpmChange.Bpm / 60;
-            nextSeconds += timeDiff / scale;
-
-            if (nextSeconds > seconds)
-            {
-                return bpmChange.JsonTime + scale * (seconds - currentSeconds);
-            }
-
-            currentSeconds = nextSeconds;
-        }
-
-        var lastBpm = bpms.Last();
-        return lastBpm.JsonTime + lastBpm.Bpm / 60 * (seconds - currentSeconds);
-    }
 
     public override ObjectContainer CreateContainer() =>
         BpmEventContainer.SpawnBpmChange(null, ref bpmPrefab);

--- a/Assets/__Scripts/MapEditor/Grid/Collections/BeatmapObjectContainerCollection.cs
+++ b/Assets/__Scripts/MapEditor/Grid/Collections/BeatmapObjectContainerCollection.cs
@@ -358,9 +358,14 @@ public abstract class BeatmapObjectContainerCollection : MonoBehaviour
 
     public static void RefreshFutureObjectsPosition(float jsonTime)
     {
-        foreach (var objectType in System.Enum.GetValues(typeof(Beatmap.Enums.ObjectType)))
+        // we have to refresh bpm events FIRST, and only then can we refresh other objects
+        // this is a janky way of accomplishing that
+        var objectTypes = new List<ObjectType> { ObjectType.BpmChange };
+        objectTypes.AddRange(((IEnumerable<ObjectType>)Enum.GetValues(typeof(ObjectType))).Where(x => x != ObjectType.BpmChange));
+
+        foreach (var objectType in objectTypes)
         {
-            var collection = BeatmapObjectContainerCollection.GetCollectionForType((Beatmap.Enums.ObjectType)objectType);
+            var collection = BeatmapObjectContainerCollection.GetCollectionForType(objectType);
             if (collection == null) continue;
             // REVIEW: not sure if allocation is avoidable
             foreach (var obj in collection.LoadedObjects)

--- a/Assets/__Scripts/MapEditor/Grid/Collections/BeatmapObjectContainerCollection.cs
+++ b/Assets/__Scripts/MapEditor/Grid/Collections/BeatmapObjectContainerCollection.cs
@@ -392,6 +392,13 @@ public abstract class BeatmapObjectContainerCollection : MonoBehaviour
                         obj.RecomputeSongBpmTime();
                     }
                 }
+                else if (collection is ObstacleGridContainer)
+                {
+                    if ((obj as BaseObstacle).Duration + obj.JsonTime > jsonTime)
+                    {
+                        obj.RecomputeSongBpmTime();
+                    }
+                }
             }
             foreach (var container in collection.LoadedContainers)
             {

--- a/Assets/__Scripts/MapEditor/Grid/Collections/BeatmapObjectContainerCollection.cs
+++ b/Assets/__Scripts/MapEditor/Grid/Collections/BeatmapObjectContainerCollection.cs
@@ -359,9 +359,20 @@ public abstract class BeatmapObjectContainerCollection : MonoBehaviour
     public static void RefreshFutureObjectsPosition(float jsonTime)
     {
         // we have to refresh bpm events FIRST, and only then can we refresh other objects
-        // this is a janky way of accomplishing that
-        var objectTypes = new List<ObjectType> { ObjectType.BpmChange };
-        objectTypes.AddRange(((IEnumerable<ObjectType>)Enum.GetValues(typeof(ObjectType))).Where(x => x != ObjectType.BpmChange));
+        var objectTypes = new List<ObjectType>
+        { 
+            ObjectType.BpmChange,
+            ObjectType.Note,
+            ObjectType.Event,
+            ObjectType.Obstacle,
+            ObjectType.CustomNote,
+            ObjectType.CustomEvent,
+            ObjectType.Arc,
+            ObjectType.Chain,
+            ObjectType.Bookmark,
+            ObjectType.Waypoint,
+            ObjectType.NJSEvent
+        };
 
         foreach (var objectType in objectTypes)
         {

--- a/Assets/__Scripts/MapEditor/Grid/MeasureLinesController.cs
+++ b/Assets/__Scripts/MapEditor/Grid/MeasureLinesController.cs
@@ -54,10 +54,12 @@ public class MeasureLinesController : MonoBehaviour
         var existing = new Queue<TextMeshProUGUI>(measureTextsByBeat.Select(x => x.Item2));
         measureTextsByBeat.Clear();
 
+        var songContainer = BeatSaberSongContainer.Instance;
+
         var rawBeatsInSong =
-            Mathf.FloorToInt(atsc.GetBeatFromSeconds(BeatSaberSongContainer.Instance.LoadedSong.length));
+            Mathf.FloorToInt(atsc.GetBeatFromSeconds(songContainer.LoadedSong.length));
         var modifiedBeatsInSong =
-            Mathf.FloorToInt(bpmChangeGridContainer.SongBpmTimeToJsonTime(rawBeatsInSong));
+            Mathf.FloorToInt((float)songContainer.Map.SongBpmTimeToJsonTime(rawBeatsInSong));
 
         // This stops CM freezing for a few seconds as a result of instantiating a bajillion lines from insanely
         // high bpm events. Should be reasonable to assume that you're not mapping at >10x the info bpm
@@ -68,7 +70,7 @@ public class MeasureLinesController : MonoBehaviour
         {
             var text = existing.Count > 0 ? existing.Dequeue() : Instantiate(measureLinePrefab, parent);
             text.text = $"{jsonBeat}";
-            var jsonBeatPosition = bpmChangeGridContainer.JsonTimeToSongBpmTime(jsonBeat);
+            var jsonBeatPosition = (float)songContainer.Map.JsonTimeToSongBpmTime(jsonBeat);
             text.transform.localPosition = new Vector3(0, jsonBeatPosition * EditorScaleController.EditorScale, 0);
             measureTextsByBeat.Add((jsonBeatPosition, text));
 

--- a/Assets/__Scripts/MapEditor/Input/BeatmapBPMChangeInputController.cs
+++ b/Assets/__Scripts/MapEditor/Input/BeatmapBPMChangeInputController.cs
@@ -42,15 +42,15 @@ public class BeatmapBPMChangeInputController : BeatmapInputController<BpmEventCo
                 BeatmapActionContainer.AddAction(new BeatmapObjectModifiedAction(containerToEdit.ObjectData,
                     containerToEdit.ObjectData, original, "Tweaked bpm"));
 
+                BeatmapObjectContainerCollection.RefreshFutureObjectsPosition(containerToEdit.BpmData.JsonTime);
+                bpmChanges.RefreshModifiedBeat();
+
                 // Update cursor position
                 var atsc = bpmChanges.AudioTimeSyncController;
                 if (containerToEdit.BpmData.JsonTime < atsc.CurrentJsonTime)
                 {
                     atsc.MoveToJsonTime(atsc.CurrentJsonTime);
                 }
-
-                BeatmapObjectContainerCollection.RefreshFutureObjectsPosition(containerToEdit.BpmData.JsonTime);
-                bpmChanges.RefreshModifiedBeat();
             }
         }
     }

--- a/Assets/__Scripts/MapEditor/Input/BeatmapBPMChangeInputController.cs
+++ b/Assets/__Scripts/MapEditor/Input/BeatmapBPMChangeInputController.cs
@@ -44,15 +44,9 @@ public class BeatmapBPMChangeInputController : BeatmapInputController<BpmEventCo
 
                 // Update cursor position
                 var atsc = bpmChanges.AudioTimeSyncController;
-                if (containerToEdit.BpmData.SongBpmTime < atsc.CurrentSongBpmTime)
+                if (containerToEdit.BpmData.JsonTime < atsc.CurrentJsonTime)
                 {
-                    var lastBpmChange = bpmChanges.FindLastBpm(atsc.CurrentSongBpmTime);
-                    if (lastBpmChange == containerToEdit.BpmData)
-                    {
-                        var newTime = lastBpmChange.SongBpmTime + ((atsc.CurrentSongBpmTime - lastBpmChange.SongBpmTime) *
-                            (lastBpmChange.Bpm - modifier) / lastBpmChange.Bpm);
-                        atsc.MoveToSongBpmTime(newTime);
-                    }
+                    atsc.MoveToJsonTime(atsc.CurrentJsonTime);
                 }
 
                 BeatmapObjectContainerCollection.RefreshFutureObjectsPosition(containerToEdit.BpmData.JsonTime);

--- a/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/ArcIndicatorPlacement.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/ArcIndicatorPlacement.cs
@@ -91,7 +91,7 @@ public class ArcIndicatorPlacement : PlacementController<BaseArc, ArcIndicatorCo
     {
         if (DraggedObjectContainer.IndicatorType == IndicatorType.Head)
         {
-            dragged.SetTimes(queued.JsonTime, queued.SongBpmTime);
+            dragged.SetTimes(queued.JsonTime);
             dragged.PosX = queued.PosX;
             dragged.PosY = queued.PosY;
             dragged.CutDirection = queued.CutDirection;
@@ -100,7 +100,7 @@ public class ArcIndicatorPlacement : PlacementController<BaseArc, ArcIndicatorCo
 
         if (DraggedObjectContainer.IndicatorType == IndicatorType.Tail)
         {
-            dragged.SetTailTimes(queued.JsonTime, queued.SongBpmTime);
+            dragged.SetTailTimes(queued.JsonTime);
             dragged.TailPosX = queued.PosX;
             dragged.TailPosY = queued.PosY;
             dragged.TailCutDirection = queued.TailCutDirection;

--- a/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/BPMChangePlacement.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/BPMChangePlacement.cs
@@ -20,7 +20,7 @@ public class BPMChangePlacement : PlacementController<BaseBpmEvent, BpmEventCont
 
     public override void TransferQueuedToDraggedObject(ref BaseBpmEvent dragged, BaseBpmEvent queued)
     {
-        dragged.SetTimes(queued.JsonTime, queued.SongBpmTime);
+        dragged.SetTimes(queued.JsonTime);
         objectContainerCollection.RefreshModifiedBeat();
     }
 
@@ -39,9 +39,8 @@ public class BPMChangePlacement : PlacementController<BaseBpmEvent, BpmEventCont
             if (willResetGrid && (Mathf.Abs(queuedData.JsonTime - Mathf.Round(queuedData.JsonTime)) > BeatmapObjectContainerCollection.Epsilon))
             {
                 // e.g. Placing a bpm event at beat 3.5 will create a bpm event at beat 3 and 4.
-                //      The bpm on beat 3 will be such that the bpm event on beat 4 lines with where the cursor is. 
-                var prevBpm = objectContainerCollection.FindLastBpm(SongBpmTime, false)?.Bpm ??
-                          BeatSaberSongContainer.Instance.Info.BeatsPerMinute;
+                //      The bpm on beat 3 will be such that the bpm event on beat 4 lines with where the cursor is.
+                var prevBpm = (float)BeatSaberSongContainer.Instance.Map.BpmAtSongBpmTime(SongBpmTime);
 
                 var prevBeat = Mathf.Floor(queuedData.JsonTime);
                 var nextBeat = Mathf.Ceil(queuedData.JsonTime);
@@ -89,8 +88,8 @@ public class BPMChangePlacement : PlacementController<BaseBpmEvent, BpmEventCont
                 .WithInitialValue("Mapper", "bpm.dialogue.invalidnumber");
         }
 
-        var lastBpm = objectContainerCollection.FindLastBpm(SongBpmTime, false)?.Bpm ??
-                      BeatSaberSongContainer.Instance.Info.BeatsPerMinute;
+        var lastBpm = (float)BeatSaberSongContainer.Instance.Map.BpmAtSongBpmTime(SongBpmTime);
+
         var bpmTextInput = createBpmEventDialogueBox
             .AddComponent<TextBoxComponent>()
             .WithLabel("Mapper", "bpm.dialogue.beatsperminute")

--- a/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/BombPlacement.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/BombPlacement.cs
@@ -88,7 +88,7 @@ public class BombPlacement : PlacementController<BaseNote, NoteContainer, NoteGr
 
     public override void TransferQueuedToDraggedObject(ref BaseNote dragged, BaseNote queued)
     {
-        dragged.SetTimes(queued.JsonTime, queued.SongBpmTime);
+        dragged.SetTimes(queued.JsonTime);
         dragged.PosX = queued.PosX;
         dragged.PosY = queued.PosY;
         dragged.CustomCoordinate = queued.CustomCoordinate;

--- a/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/ChainIndicatorPlacement.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/ChainIndicatorPlacement.cs
@@ -90,7 +90,7 @@ public class ChainIndicatorPlacement : PlacementController<BaseChain, ChainIndic
     {
         if (DraggedObjectContainer.IndicatorType == IndicatorType.Head)
         {
-            dragged.SetTimes(queued.JsonTime, queued.SongBpmTime);
+            dragged.SetTimes(queued.JsonTime);
             dragged.PosX = queued.PosX;
             dragged.PosY = queued.PosY;
             dragged.CutDirection = queued.CutDirection;
@@ -99,7 +99,7 @@ public class ChainIndicatorPlacement : PlacementController<BaseChain, ChainIndic
 
         if (DraggedObjectContainer.IndicatorType == IndicatorType.Tail)
         {
-            dragged.SetTailTimes(queued.JsonTime, queued.SongBpmTime);
+            dragged.SetTailTimes(queued.JsonTime);
             dragged.TailPosX = queued.PosX;
             dragged.TailPosY = queued.PosY;
             dragged.CustomTailCoordinate = queued.CustomTailCoordinate;

--- a/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/EventPlacement.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/EventPlacement.cs
@@ -263,7 +263,7 @@ public class EventPlacement : PlacementController<BaseEvent, EventContainer, Eve
 
     public override void TransferQueuedToDraggedObject(ref BaseEvent dragged, BaseEvent queued)
     {
-        dragged.SetTimes(queued.JsonTime, queued.SongBpmTime);
+        dragged.SetTimes(queued.JsonTime);
         dragged.Type = queued.Type;
         // Instead of copying the whole custom data, only copy prop ID
         if (dragged.CustomData != null && queued.CustomData != null)

--- a/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/NJSEventPlacement.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/NJSEventPlacement.cs
@@ -16,7 +16,7 @@ public class NJSEventPlacement : PlacementController<BaseNJSEvent, NJSEventConta
             new Vector3(0.5f, 0.5f, instantiatedContainer.transform.localPosition.z);
 
     public override void TransferQueuedToDraggedObject(ref BaseNJSEvent dragged, BaseNJSEvent queued) =>
-        dragged.SetTimes(queued.JsonTime, queued.SongBpmTime);
+        dragged.SetTimes(queued.JsonTime);
     
     internal override void ApplyToMap() => CreateAndOpenNJSDialogue(isInitialPlacement: true);
     

--- a/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/NotePlacement.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/NotePlacement.cs
@@ -235,7 +235,7 @@ public class NotePlacement : PlacementController<BaseNote, NoteContainer, NoteGr
 
     public override void TransferQueuedToDraggedObject(ref BaseNote dragged, BaseNote queued)
     {
-        dragged.SetTimes(queued.JsonTime, queued.SongBpmTime);
+        dragged.SetTimes(queued.JsonTime);
         dragged.PosX = queued.PosX;
         dragged.PosY = queued.PosY;
         dragged.CutDirection = queued.CutDirection;
@@ -255,7 +255,7 @@ public class NotePlacement : PlacementController<BaseNote, NoteContainer, NoteGr
         var epsilon = BeatmapObjectContainerCollection.Epsilon;
         foreach (var baseSlider in DraggedAttachedSliderDatas[IndicatorType.Head])
         {
-            baseSlider.SetTimes(queued.JsonTime, queued.SongBpmTime);
+            baseSlider.SetTimes(queued.JsonTime);
             baseSlider.PosX = queued.PosX;
             baseSlider.PosY = queued.PosY;
             baseSlider.CutDirection = queued.CutDirection;
@@ -264,7 +264,7 @@ public class NotePlacement : PlacementController<BaseNote, NoteContainer, NoteGr
 
         foreach (var baseSlider in DraggedAttachedSliderDatas[IndicatorType.Tail])
         {
-            baseSlider.SetTailTimes(queued.JsonTime, queued.SongBpmTime);
+            baseSlider.SetTailTimes(queued.JsonTime);
             baseSlider.TailPosX = queued.PosX;
             baseSlider.TailPosY = queued.PosY;
             baseSlider.CustomTailCoordinate = queued.CustomCoordinate;

--- a/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/ObstaclePlacement.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/ObstaclePlacement.cs
@@ -57,7 +57,7 @@ public class ObstaclePlacement : PlacementController<BaseObstacle, ObstacleConta
         instantiatedContainer.ObstacleData.Duration = RoundedJsonTime - startJsonTime;
         obstacleAppearanceSo.SetObstacleAppearance(instantiatedContainer);
         var roundedHit = ParentTrack.InverseTransformPoint(hit.Point);
-        var songBpmDuration = BpmChangeGridContainer.JsonTimeToSongBpmTime(RoundedJsonTime) - startSongBpmTime;
+        var songBpmDuration = (float)BeatSaberSongContainer.Instance.Map.JsonTimeToSongBpmTime(RoundedJsonTime) - startSongBpmTime;
 
         // Check if Chroma Color notes button is active and apply _color
         queuedData.CustomColor = (CanPlaceChromaObjects && dropdown.Visible)
@@ -214,15 +214,14 @@ public class ObstaclePlacement : PlacementController<BaseObstacle, ObstacleConta
         if (IsPlacing)
         {
             IsPlacing = false;
-            queuedData.SetTimes(startJsonTime, startSongBpmTime);
+            queuedData.SetTimes(startJsonTime);
 
             var endSongBpmTime = startSongBpmTime + (instantiatedContainer.GetScale().z / EditorScaleController.EditorScale);
-            var endJsonTime = BpmChangeGridContainer.SongBpmTimeToJsonTime(endSongBpmTime);
 
             if (endSongBpmTime - startSongBpmTime < SmallestRankableWallDuration)
             {
                 endSongBpmTime = startSongBpmTime + SmallestRankableWallDuration;
-                endJsonTime = BpmChangeGridContainer.SongBpmTimeToJsonTime(endSongBpmTime);
+                var endJsonTime = (float)BeatSaberSongContainer.Instance.Map.SongBpmTimeToJsonTime(endSongBpmTime);
                 queuedData.Duration = endJsonTime - startJsonTime;
             }
 
@@ -246,7 +245,7 @@ public class ObstaclePlacement : PlacementController<BaseObstacle, ObstacleConta
 
     public override void TransferQueuedToDraggedObject(ref BaseObstacle dragged, BaseObstacle queued)
     {
-        dragged.SetTimes(queued.JsonTime, queued.SongBpmTime);
+        dragged.SetTimes(queued.JsonTime);
         dragged.PosX = queued.PosX;
         dragged.CustomCoordinate = queued.CustomCoordinate;
     }

--- a/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/PlacementController.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/PlacementControllers/PlacementController.cs
@@ -77,7 +77,7 @@ public abstract class PlacementController<TBo, TBoc, TBocc> : MonoBehaviour, CMI
         get => roundedJsonTime;
         set
         {
-            SongBpmTime = BpmChangeGridContainer.JsonTimeToSongBpmTime(value);
+            SongBpmTime = (float)BeatSaberSongContainer.Instance.Map.JsonTimeToSongBpmTime(value);
             roundedJsonTime = value;
         }
     }
@@ -184,7 +184,7 @@ public abstract class PlacementController<TBo, TBoc, TBocc> : MonoBehaviour, CMI
                 Mathf.Round(Mathf.Clamp(y, farBottomPoint, farTopPoint - 1)),
                 roundedHit.z);
 
-            queuedData.SetTimes(roundedJsonTime, SongBpmTime);
+            queuedData.SetTimes(roundedJsonTime);
             OnPhysicsRaycast(hit, roundedHit);
             if ((IsDraggingObject || IsDraggingObjectAtTime) && queuedData != null)
             {
@@ -348,7 +348,7 @@ public abstract class PlacementController<TBo, TBoc, TBocc> : MonoBehaviour, CMI
                        EditorScaleController.EditorScale;
         }
 
-        var hitPointJsonTime = BpmChangeGridContainer.SongBpmTimeToJsonTime(realTime);
+        var hitPointJsonTime = (float)BeatSaberSongContainer.Instance.Map.SongBpmTimeToJsonTime(realTime);
         roundedJsonTime = (float)Math.Round((hitPointJsonTime - offsetJsonTime) / snap, MidpointRounding.AwayFromZero) * snap;
 
         if (!Atsc.IsPlaying) roundedJsonTime += offsetJsonTime;

--- a/Assets/__Scripts/MapEditor/UI/Bookmarks/BookmarkManager.cs
+++ b/Assets/__Scripts/MapEditor/UI/Bookmarks/BookmarkManager.cs
@@ -108,18 +108,19 @@ public class BookmarkManager : MonoBehaviour, CMInput.IBookmarksActions
     // while the objects did. This ensures maps in this period display bookmarks in the correct place.
     private void ConvertBookmarkTimesFromOldDevVersions()
     {
-        var bookmarksUseOfficialBpmEventsKey = BeatSaberSongContainer.Instance.Map.BookmarksUseOfficialBpmEventsKey;
-        var bookmarksNeedConversion = !BeatSaberSongContainer.Instance.Map.CustomData.HasKey(bookmarksUseOfficialBpmEventsKey)
-            || !BeatSaberSongContainer.Instance.Map.CustomData[bookmarksUseOfficialBpmEventsKey].IsBoolean
-            || !BeatSaberSongContainer.Instance.Map.CustomData[bookmarksUseOfficialBpmEventsKey].AsBool;
+        var map = BeatSaberSongContainer.Instance.Map;
+        var bookmarksUseOfficialBpmEventsKey = map.BookmarksUseOfficialBpmEventsKey;
+        var bookmarksNeedConversion = !map.CustomData.HasKey(bookmarksUseOfficialBpmEventsKey)
+            || !map.CustomData[bookmarksUseOfficialBpmEventsKey].IsBoolean
+            || !map.CustomData[bookmarksUseOfficialBpmEventsKey].AsBool;
 
-        bookmarksNeedConversion &= BeatSaberSongContainer.Instance.Map.MajorVersion != 4;
+        bookmarksNeedConversion &= map.MajorVersion != 4;
         
-        foreach (var bookmark in BeatSaberSongContainer.Instance.Map.Bookmarks)
+        foreach (var bookmark in map.Bookmarks)
         {
             if (bookmarksNeedConversion)
             {
-                bookmark.SongBpmTime = bookmark.JsonTime;
+                bookmark.JsonTime = (float)map.SongBpmTimeToJsonTime(bookmark.JsonTime);
             }
             else
             {

--- a/Assets/__Scripts/MapEditor/UI/Counters+/CountersPlusController.cs
+++ b/Assets/__Scripts/MapEditor/UI/Counters+/CountersPlusController.cs
@@ -86,8 +86,7 @@ public class CountersPlusController : MonoBehaviour
 
     public float OverallSPS => swingsPerSecond.Total.Overall;
 
-    public float CurrentBPM
-        => bpm.FindLastBpm(atsc.CurrentSongBpmTime)?.Bpm ?? BeatSaberSongContainer.Instance.Info.BeatsPerMinute;
+    public float CurrentBPM => (float)BeatSaberSongContainer.Instance.Map.BpmAtJsonTime(atsc.CurrentJsonTime);
 
     public float RedBlueRatio
     {


### PR DESCRIPTION
**BPM event refactor:**
* songBpmTime is now nullable. If time conversion fails, it is set to null. Casting it to float when it's null will raise an exception. This is intentional; it means there is a serious bug and we should know about it.
* SongBpmTime cannot be set anymore. This was only used in one place, and you should set JsonTime instead.
* BPM time conversion logic is moved to from BPMChangeGridContainer to BaseDifficulty. BPM events must be bootstrapped after loading for this to function. All object songBpmTimes should be recomputed after doing this.
* SetTimes in BaseObject has been simplified since songBpmTime was getting recalculated anyway.

This fixes wrong saving of BPM info files (BPMInfo.dat/AudioData.dat) when saving diffs from the song edit screen. It should also make it impossible for such a bug to go unnoticed in the future.
I haven't found any new bugs stemming from this refactor, but more testing is of course welcome.

---
**mitigate accumulating numerical errors on BPM region load/save:**
* When saving BPM regions, properly round calculated sample indexes, and ensure continuity by setting start sample index to previous end sample index.
* When converting BPM regions into events, round the BPM value of resulting events if the unrounding was (likely) caused by numerical error.

Together these should (mostly) eliminate accumulating errors on load/save cycles, which is important for v4 maps, since they do not store the actual BPM events.