### PR TITLE
Shift lightIDs based on lanes, not max light id

### DIFF
--- a/Assets/__Scripts/MapEditor/Mapping/Selection/SelectionController.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/Selection/SelectionController.cs
@@ -568,15 +568,19 @@ public class SelectionController : MonoBehaviour, CMInput.ISelectingActions, CMI
                 var events = eventPlacement.objectContainerCollection;
                 if (eventPlacement.objectContainerCollection.PropagationEditing == EventGridContainer.PropMode.Light)
                 {
-                    var max = events.platformDescriptor.LightingManagers[events.EventTypeToPropagate].ControllingLights
-                        .Select(x => x.LightID).Max();
+                    var max = events.platformDescriptor.LightingManagers[events.EventTypeToPropagate].LightIDPlacementMap
+                        .Count - 1;
 
-                    var curId = e.CustomLightID != null ? e.CustomLightID[0] : 0;
-                    var newId = Math.Min(curId + leftRight, max);
-                    if (newId < 1)
+                    var curLane = (e.CustomLightID != null)
+                        ? labels.LightIDToEditor(e.Type, e.CustomLightID[0])
+                        : -1;
+                    var newLane = Math.Min(curLane + leftRight, max);
+                    if (newLane < 0)
                         e.CustomLightID = null;
-                    else
+                    else {
+                        var newId = labels.EditorToLightID(e.Type, newLane);
                         e.CustomLightID = new[] { newId };
+                    }
                 }
                 else if (eventPlacement.objectContainerCollection.PropagationEditing == EventGridContainer.PropMode.Prop)
                 {


### PR DESCRIPTION
The current logic leads to some weird behavior with ExtendedLightIDs, those being:

1. As noted in [here](https://discord.com/channels/702230714585710602/1316860775108972644), being unable to shift to id's without previewed lights, and
2. It doesn't skip light ids that should be skipped, eg are not referenced by and events, geometry or environment enhancements:

https://github.com/user-attachments/assets/dcdcbfc5-7060-4563-a46f-6b07993907af

This fixes both issues by shifting based on lane position instead.

