### PR TITLE
Automatically promote Dev builds to Stable on Release

### DIFF
--- a/.github/workflows/release-post.yml
+++ b/.github/workflows/release-post.yml
@@ -1,0 +1,15 @@
+name: Promote Stable Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Promote last Dev release to Stable
+        run: |
+          curl -X POST \
+            --fail -H "Authorization: Basic ${{ secrets.WEBHOOK_TOKEN }}" \
+            "${{ secrets.WEBHOOK_URL }}"


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to ChroMapper which sends a curl request to [Jenkins](https://jenkins.kirkstall.top-cat.me/job/ChroMapper/) to automatically promote the latest version of Dev to Stable.

The endpoint URL and authorization token are stored as secrets which I will store in the repository.