### PR TITLE
Log originating plugins when exceptions occur

### DIFF
--- a/Assets/__Scripts/PluginLoader/Plugin.cs
+++ b/Assets/__Scripts/PluginLoader/Plugin.cs
@@ -27,7 +27,6 @@ public class Plugin
     {
         Name = name;
         AssemblyName = assemblyName;
-        
         this.pluginInstance = pluginInstance;
         foreach (var methodInfo in pluginInstance.GetType().GetMethods(bindingFlags))
         {

--- a/Assets/__Scripts/PluginLoader/Plugin.cs
+++ b/Assets/__Scripts/PluginLoader/Plugin.cs
@@ -19,13 +19,13 @@ public class Plugin
 
     private readonly Dictionary<Type, MethodInfo> methods = new Dictionary<Type, MethodInfo>();
 
-    private readonly object pluginInstance;
+    public readonly object PluginInstance;
 
     public Plugin(string name, Version version, object pluginInstance)
     {
         Name = name;
         Version = version;
-        this.pluginInstance = pluginInstance;
+        this.PluginInstance = pluginInstance;
         foreach (var methodInfo in pluginInstance.GetType().GetMethods(bindingFlags))
         {
             foreach (var t in attributes)
@@ -44,7 +44,7 @@ public class Plugin
         methods.TryGetValue(typeof(T), out var methodInfo);
         try
         {
-            methodInfo?.Invoke(pluginInstance, new object[0]);
+            methodInfo?.Invoke(PluginInstance, new object[0]);
             return true;
         }
         catch (TargetInvocationException e)
@@ -59,7 +59,7 @@ public class Plugin
         methods.TryGetValue(typeof(T), out var methodInfo);
         try
         {
-            methodInfo?.Invoke(pluginInstance, new object[1] { obj });
+            methodInfo?.Invoke(PluginInstance, new object[1] { obj });
             return true;
         }
         catch (TargetInvocationException e)

--- a/Assets/__Scripts/PluginLoader/Plugin.cs
+++ b/Assets/__Scripts/PluginLoader/Plugin.cs
@@ -19,13 +19,16 @@ public class Plugin
 
     private readonly Dictionary<Type, MethodInfo> methods = new Dictionary<Type, MethodInfo>();
 
-    public readonly object PluginInstance;
+    private readonly object pluginInstance;
 
-    public Plugin(string name, Version version, object pluginInstance)
+    public readonly AssemblyName AssemblyName;
+
+    public Plugin(string name, AssemblyName assemblyName, object pluginInstance)
     {
         Name = name;
-        Version = version;
-        this.PluginInstance = pluginInstance;
+        AssemblyName = assemblyName;
+        
+        this.pluginInstance = pluginInstance;
         foreach (var methodInfo in pluginInstance.GetType().GetMethods(bindingFlags))
         {
             foreach (var t in attributes)
@@ -37,14 +40,14 @@ public class Plugin
     }
 
     public string Name { get; }
-    public Version Version { get; }
+    public Version Version => AssemblyName.Version;
 
     public bool CallMethod<T>()
     {
         methods.TryGetValue(typeof(T), out var methodInfo);
         try
         {
-            methodInfo?.Invoke(PluginInstance, new object[0]);
+            methodInfo?.Invoke(pluginInstance, new object[0]);
             return true;
         }
         catch (TargetInvocationException e)
@@ -59,7 +62,7 @@ public class Plugin
         methods.TryGetValue(typeof(T), out var methodInfo);
         try
         {
-            methodInfo?.Invoke(PluginInstance, new object[1] { obj });
+            methodInfo?.Invoke(pluginInstance, new object[1] { obj });
             return true;
         }
         catch (TargetInvocationException e)

--- a/Assets/__Scripts/PluginLoader/PluginLoader.cs
+++ b/Assets/__Scripts/PluginLoader/PluginLoader.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using UnityEngine;
 
@@ -17,6 +18,8 @@ internal class PluginLoader : MonoBehaviour
     ///     This does NOT include plugins added by external mod loaders (BepinEx, IPA, BSIPA, etc.)
     /// </summary>
     public static IReadOnlyList<Plugin> LoadedPlugins => plugins.AsReadOnly();
+    
+    public static Action<Plugin[]> PluginsLoadedEvent;
 
     private void Start()
     {
@@ -56,9 +59,11 @@ internal class PluginLoader : MonoBehaviour
                 }
             }
         }
-
+        
         foreach (var plugin in plugins)
             plugin.Init();
+        
+        PluginsLoadedEvent.Invoke(plugins.ToArray());
     }
 
     public static void BroadcastEvent<T>() where T : Attribute

--- a/Assets/__Scripts/PluginLoader/PluginLoader.cs
+++ b/Assets/__Scripts/PluginLoader/PluginLoader.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using UnityEngine;
 
@@ -50,7 +49,7 @@ internal class PluginLoader : MonoBehaviour
 
                 if (pluginAttribute == null) continue;
                 try {
-                    var plugin = new Plugin(pluginAttribute.Name, assembly.GetName().Version, Activator.CreateInstance(type));
+                    var plugin = new Plugin(pluginAttribute.Name, assembly.GetName(), Activator.CreateInstance(type));
                     plugins.Add(plugin);
                 }
                 catch (Exception e) {

--- a/Assets/__Scripts/UI/DevConsole.cs
+++ b/Assets/__Scripts/UI/DevConsole.cs
@@ -83,8 +83,13 @@ public class DevConsole : MonoBehaviour, ILogHandler, CMInput.IDebugActions
 
     private void UpdateLoadedPluginAssemblies(Plugin[] plugins)
     {
+        loadedPluginAssemblies.Clear();
+
         foreach (var plugin in plugins)
-            loadedPluginAssemblies.Add((plugin.PluginInstance.GetType().Assembly.GetName().Name, plugin.Name));
+        {
+            loadedPluginAssemblies
+                .Add((plugin.PluginInstance.GetType().Assembly.GetName().Name, plugin.Name));
+        }
     }
 
     private void SceneLoaded(Scene arg0, LoadSceneMode arg1)


### PR DESCRIPTION
**This change applies STRICTLY to exceptions that occur from plugins.** 
Such exceptions are logged normally with an extra line above stating the plugins name that's causing the exception to occur, giving users a guide to proceed with the error.