### PR TITLE
Don't invoke SelectionChanged when selection didn't change

### DIFF
--- a/Assets/__Scripts/MapEditor/Mapping/Selection/BoxSelectionPlacementController.cs
+++ b/Assets/__Scripts/MapEditor/Mapping/Selection/BoxSelectionPlacementController.cs
@@ -241,9 +241,12 @@ public class BoxSelectionPlacementController : PlacementController<BaseEvent, Ev
 
     public override void CancelPlacement()
     {
-        IsSelecting = false;
-        foreach (var selectedObject in selected) SelectionController.Deselect(selectedObject, false);
-        SelectionController.SelectionChangedEvent?.Invoke();
+        if (IsSelecting)
+        {
+            IsSelecting = false;
+            foreach (var selectedObject in selected) SelectionController.Deselect(selectedObject, false);
+            SelectionController.SelectionChangedEvent?.Invoke();
+        }
     }
 
     public override void TransferQueuedToDraggedObject(ref BaseEvent dragged, BaseEvent queued) { }


### PR DESCRIPTION
Since ChroMapper 0.12, every right-click triggers a SelectionChangedEvent. This comes from CancelPlacement on the BoxSelectionPlacementController. This ignores that event when not actually selecting.