### PR TITLE
Validate ogg vorbis and wave audio file signature

### DIFF
--- a/Assets/__Scenes/02_SongEditMenu.unity
+++ b/Assets/__Scenes/02_SongEditMenu.unity
@@ -29568,6 +29568,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1757455336493702345, guid: 16c79367c31039f489988c1894e49e3f,
         type: 3}
+      propertyPath: fileValidationType
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1757455336493702345, guid: 16c79367c31039f489988c1894e49e3f,
+        type: 3}
       propertyPath: extensions.Array.size
       value: 2
       objectReference: {fileID: 0}

--- a/Assets/__Scripts/Extensions/BeatSaberSongExtensions.cs
+++ b/Assets/__Scripts/Extensions/BeatSaberSongExtensions.cs
@@ -10,11 +10,6 @@ using UnityEngine.Networking;
 
 public static class BeatSaberSongExtensions
 {
-    private static readonly Dictionary<string, AudioType> extensionToAudio = new()
-    {
-        {".ogg", AudioType.OGGVORBIS}, {".egg", AudioType.OGGVORBIS}, {".wav", AudioType.WAV}
-    };
-
     /// <summary>
     ///     Try and load the song, this is used for the song preview as well as later
     ///     passed to the mapping scene
@@ -26,13 +21,14 @@ public static class BeatSaberSongExtensions
         if (!Directory.Exists(mapInfo.Directory)) yield break;
 
         var fullPath = Path.Combine(mapInfo.Directory, overrideLocalPath ?? mapInfo.SongFilename);
+        if (!File.Exists(fullPath)) yield break;
 
-        // Commented out since Song Time Offset changes need to reload the song, even if its the same file
-        //if (fullPath == loadedSong)
-        //{
-        //    yield break;
-        //}
-        var audioType = extensionToAudio[Path.GetExtension(fullPath)];
+        var audioType = FileContentValidationHelper.GetAudioType(fullPath);
+        if (audioType == AudioType.UNKNOWN)
+        {
+            SceneTransitionManager.Instance.CancelLoading("load.error.audio2");
+            yield break;
+        }
 
         var uriPath = Application.platform is RuntimePlatform.WindowsPlayer or RuntimePlatform.WindowsEditor
             ? Uri.EscapeDataString(fullPath)
@@ -48,6 +44,7 @@ public static class BeatSaberSongExtensions
         {
             Debug.Log("Error getting Audio data!");
             SceneTransitionManager.Instance.CancelLoading("load.error.audio");
+            yield break;
         }
 
         clip.name = "Song";

--- a/Assets/__Scripts/FileContentValidationHelper.cs
+++ b/Assets/__Scripts/FileContentValidationHelper.cs
@@ -1,0 +1,62 @@
+using System;
+using System.IO;
+using UnityEngine;
+
+public static class FileContentValidationHelper
+{
+    private const int vorbisIdHeaderOffset = 28;
+    private static readonly int oggVorbisSignatureSize = vorbisIdHeaderOffset + "?vorbis".Length;
+    private static readonly int wavSignatureSize = "RIFF????WAVE".Length;
+
+    public static AudioType GetAudioType(string filePath)
+    {
+        using var stream = new FileStream(filePath, FileMode.Open);
+        var maxBufferSize = Math.Max(oggVorbisSignatureSize, wavSignatureSize);
+        var buffer = new byte[maxBufferSize];
+        _ = stream.Read(buffer, 0, maxBufferSize);
+
+        if (IsOggVorbisFileSignature(buffer))
+            return AudioType.OGGVORBIS;
+
+        if (IsWavFileSignature(buffer))
+            return AudioType.WAV;
+
+        return AudioType.UNKNOWN;
+    }
+
+    // Beat Saber and CM only supports ogg vorbis and wav
+    public static bool IsSupportedAudioFormat(string filePath) => GetAudioType(filePath) != AudioType.UNKNOWN;
+
+    private static bool IsWavFileSignature(byte[] buffer)
+    {
+        if (buffer.Length < wavSignatureSize)
+            return false;
+
+        return buffer[0] == 'R'
+               && buffer[1] == 'I'
+               && buffer[2] == 'F'
+               && buffer[3] == 'F'
+               && buffer[8] == 'W'
+               && buffer[9] == 'A'
+               && buffer[10] == 'V'
+               && buffer[11] == 'E';
+    }
+
+    private static bool IsOggVorbisFileSignature(byte[] buffer)
+    {
+        if (buffer.Length < oggVorbisSignatureSize)
+            return false;
+
+        var hasOggContainerFileSignature = buffer[0] == 'O'
+                                           && buffer[1] == 'g'
+                                           && buffer[2] == 'g'
+                                           && buffer[3] == 'S';
+        var hasVorbisFileSignature = buffer[vorbisIdHeaderOffset + 1] == 'v'
+                                     && buffer[vorbisIdHeaderOffset + 2] == 'o'
+                                     && buffer[vorbisIdHeaderOffset + 3] == 'r'
+                                     && buffer[vorbisIdHeaderOffset + 4] == 'b'
+                                     && buffer[vorbisIdHeaderOffset + 5] == 'i'
+                                     && buffer[vorbisIdHeaderOffset + 6] == 's';
+        return hasOggContainerFileSignature && hasVorbisFileSignature;
+    }
+}

--- a/Assets/__Scripts/FileContentValidationHelper.cs.meta
+++ b/Assets/__Scripts/FileContentValidationHelper.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 328693533c4c4ea98e4afebd70b762b9
+timeCreated: 1756732282

--- a/Assets/__Scripts/UI/InputBoxFileValidator.cs
+++ b/Assets/__Scripts/UI/InputBoxFileValidator.cs
@@ -21,10 +21,19 @@ public class InputBoxFileValidator : MonoBehaviour
     [SerializeField] private string filetypeName;
     [SerializeField] private string[] extensions;
 
+    [SerializeField] private FileValidationType fileValidationType;
+    
     [SerializeField] private bool enableValidation;
     [SerializeField] private bool forceStartupValidationAlign;
 
     private Vector2 startOffset;
+
+    public enum FileValidationType
+    {
+        None,
+        Audio,
+        // Image
+    }
 
     public void Awake()
     {
@@ -53,7 +62,14 @@ public class InputBoxFileValidator : MonoBehaviour
         }
 
         var path = Path.Combine(info.Directory, filename);
-        SetValidationState(true, File.Exists(path));
+
+        var validationState = File.Exists(path);
+        if (fileValidationType == FileValidationType.Audio)
+        {
+            validationState = validationState && FileContentValidationHelper.IsSupportedAudioFormat(path);
+        }
+        
+        SetValidationState(true, validationState);
     }
 
     public void SetValidationState(bool visible, bool state = false)
@@ -124,6 +140,12 @@ public class InputBoxFileValidator : MonoBehaviour
 #else
             var ignoreCase = false;
 #endif
+
+            if (fileValidationType == FileValidationType.Audio && !FileContentValidationHelper.IsSupportedAudioFormat(fullFile))
+            {
+                PersistentUI.Instance.DisplayMessage("SongEditMenu", "load.error.audio2", PersistentUI.DisplayMessageType.Bottom);
+                return;
+            }
 
             if (!fullFile.StartsWith(fullDirectory, ignoreCase, CultureInfo.InvariantCulture))
             {

--- a/Assets/__Scripts/UI/SongInfoEditUI.cs
+++ b/Assets/__Scripts/UI/SongInfoEditUI.cs
@@ -332,6 +332,12 @@ public class SongInfoEditUI : MenuBase
         Debug.Log("Loading audio");
         if (File.Exists(fullPath))
         {
+            if (!FileContentValidationHelper.IsSupportedAudioFormat(fullPath))
+            {
+                SceneTransitionManager.Instance.CancelLoading("load.error.audio2");
+                yield break;
+            }
+
             yield return BeatSaberSongExtensions.LoadAudio(Info,(clip) =>
             {
                 previewAudio.clip = clip;


### PR DESCRIPTION
Only allow loading ogg vorbis and wav files. This prevents a common new mapper error of trying to use a renamed mp3 file which caused a bunch of exceptions.