### PR TITLE
fix: v4 file objects do not appear before the spawn position

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -337,3 +337,6 @@ UserSettings/
 
 # NuGetForUnity packages folder (developers will automatically download NuGet packages when loading the project)
 /Assets/Packages
+
+*.local
+*.local.*

--- a/Assets/__Scripts/Beatmap/V4/V4Arc.cs
+++ b/Assets/__Scripts/Beatmap/V4/V4Arc.cs
@@ -1,7 +1,5 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using Beatmap.Base;
-using Beatmap.Enums;
 using SimpleJSON;
 
 namespace Beatmap.V4
@@ -26,20 +24,21 @@ namespace Beatmap.V4
             arc.Color = headNoteData.Color;
             arc.CutDirection = headNoteData.CutDirection;
             arc.AngleOffset = headNoteData.AngleOffset;
-            
+
             var tailIndex = node["ti"].AsInt;
             var tailNoteData = notesCommonData[tailIndex];
 
             arc.TailPosX = tailNoteData.PosX;
             arc.TailPosY = tailNoteData.PosY;
             arc.TailCutDirection = tailNoteData.CutDirection;
-            
+
             var arcIndex = node["ai"].AsInt;
             var arcData = arcsCommonData[arcIndex];
 
             arc.HeadControlPointLengthMultiplier = arcData.HeadControlPointLengthMultiplier;
             arc.TailControlPointLengthMultiplier = arcData.TailControlPointLengthMultiplier;
             arc.MidAnchorMode = arcData.MidAnchorMode;
+            arc.CustomData = node["customData"];
 
             return arc;
         }

--- a/Assets/__Scripts/Beatmap/V4/V4BombNote.cs
+++ b/Assets/__Scripts/Beatmap/V4/V4BombNote.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using Beatmap.Base;
 using Beatmap.Enums;
 using SimpleJSON;
@@ -11,7 +10,7 @@ namespace Beatmap.V4
         public static BaseNote GetFromJson(JSONNode node, IList<V4CommonData.Bomb> bombsCommonData)
         {
             var note = new BaseNote();
-            
+
             note.JsonTime = node["b"].AsFloat;
             note.Rotation = node["r"].AsInt;
 
@@ -21,7 +20,8 @@ namespace Beatmap.V4
             note.PosX = bombData.PosX;
             note.PosY = bombData.PosY;
             note.Type = (int)NoteType.Bomb;
-            
+            note.CustomData = node["customData"];
+
             return note;
         }
 

--- a/Assets/__Scripts/Beatmap/V4/V4Chain.cs
+++ b/Assets/__Scripts/Beatmap/V4/V4Chain.cs
@@ -1,7 +1,5 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using Beatmap.Base;
-using Beatmap.Enums;
 using SimpleJSON;
 
 namespace Beatmap.V4
@@ -34,6 +32,7 @@ namespace Beatmap.V4
             chain.TailPosY = chainData.TailPosY;
             chain.SliceCount = chainData.SliceCount;
             chain.Squish = chainData.Squish;
+            chain.CustomData = node["customData"];
 
             return chain;
         }

--- a/Assets/__Scripts/Beatmap/V4/V4ColorNote.cs
+++ b/Assets/__Scripts/Beatmap/V4/V4ColorNote.cs
@@ -1,7 +1,5 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using Beatmap.Base;
-using Beatmap.Enums;
 using SimpleJSON;
 
 namespace Beatmap.V4
@@ -23,7 +21,8 @@ namespace Beatmap.V4
             note.Color = noteData.Color;
             note.CutDirection = noteData.CutDirection;
             note.AngleOffset = noteData.AngleOffset;
-            
+            note.CustomData = node["customData"];
+
             return note;
         }
 

--- a/Assets/__Scripts/Beatmap/V4/V4Obstacle.cs
+++ b/Assets/__Scripts/Beatmap/V4/V4Obstacle.cs
@@ -1,7 +1,5 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using Beatmap.Base;
-using Beatmap.Enums;
 using SimpleJSON;
 
 namespace Beatmap.V4
@@ -23,7 +21,8 @@ namespace Beatmap.V4
             obstacle.Duration = obstacleData.Duration;
             obstacle.Width = obstacleData.Width;
             obstacle.Height = obstacleData.Height;
-            
+            obstacle.CustomData = node["customData"];
+
             return obstacle;
         }
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ The ChroMapper repository will also have miscellaneous branches for separate bug
 
 ChroMapper comes with a `.editorconfig` file which outlines most of the convention and styling guidelines used by the project.
 
-A nice quite from [OpenGovernment's contributing file](https://github.com/opengovernment/opengovernment/blob/master/CONTRIBUTING.md):
+A nice quote from [OpenGovernment's contributing file](https://github.com/opengovernment/opengovernment/blob/master/CONTRIBUTING.md):
 ```
 This is open source software. Consider the people who will read your code, and make it look nice for them. It's sort of like driving a car: Perhaps you love doing donuts when you're alone, but with passengers the goal is to make the ride as smooth as possible.
 ```


### PR DESCRIPTION
### Background

Close #619
- #619
- I want to ignore local files by inserting `.local.` to file name.

<details><summary>Analysis</summary>

In V2/V3 formats, the following chain ensures correct object spawning:
GetFromJson() → CustomData setter → ParseCustom() → RecomputeSpawnParameters() → Hjd calculated

In V4 format, this chain was broken:
GetFromJson() → CustomData NOT set ❌ → ParseCustom() NOT called → Hjd remains 0 → incorrect offset calculation

The BeatmapObjectCallbackController.RecursiveCheckNotes() (line 159) uses obj.Hjd + Track.JUMP_TIME to determine when objects should be displayed during playback. With Hjd = 0, V4 objects only appeared when very close to the player, making them seem invisible until the last moment.

Why it worked in pause mode: The chunk-based loading system in BeatmapObjectContainerCollection (lines 194-204) uses Settings.Instance.ChunkDistance and doesn't depend on Hjd, so objects displayed correctly when paused.

</details> 

### Changes

- Fixed V4 object deserialization: Added CustomData = node["customData"] to all V4 object types:
  - V4Arc.cs
  - V4BombNote.cs
  - V4Chain.cs - Chain/burst slider objects
  - V4ColorNote.cs - Color notes (red/blue)
  - V4Obstacle.cs - Walls/obstacles
- Documentation: Fixed typo in CONTRIBUTING.md#L61 ("quite" → "quote")
- Git configuration: Added *.local and *.local.* patterns to .gitignore

### Comments for Reviewers

Note on V4 CustomData serialization: This PR only addresses the loading side (GetFromJson). The corresponding saving logic (ToJson) for V4 CustomData is not yet implemented, unlike V2/V3 which call SaveCustom() and write to node["customData"]. This should be addressed in a future PR to fully support CustomData round-tripping in V4 format.

If this approach seems not appropriate, feel free to close this.

### Testing

I tested this on windows 11 25H2 only. See original issue for testing method.

### Checklist

- [x] The proposed code conforms to the code styling and guidelines set by the project's .editorconfig file.
- [x] The proposed code is platform-agnostic (ie. the code will run on Windows, MacOS, Linux, etc.) OR the platform-dependent code does not hinder ChroMapper's ability to run on other platforms.
