### PR TITLE
Pack spectrogram values into bytes

### DIFF
--- a/Assets/_Graphics/Shaders/Editor/Spectrogram.shader
+++ b/Assets/_Graphics/Shaders/Editor/Spectrogram.shader
@@ -86,12 +86,16 @@ Shader "ChroMapper/Editor/Spectrogram"
 
             float sampleSpectrogram(uint resultIdx)
             {
-                if (resultIdx >= FFTCount)
+                // oops sorry galaxymaster
+                // Fix spectrogram offset by subtracting by our FFT Size multiplied by quality setting
+                uint idx = resultIdx - (FFTSize * FFTQuality);
+
+                if (idx >= FFTCount)
                     return 0.0;
                 
                 // Unpack: each uint contains 4 values as RGBA bytes
-                uint packedIdx = resultIdx / 4;
-                uint byteOffset = resultIdx % 4;
+                uint packedIdx = idx / 4;
+                uint byteOffset = idx % 4;
                 uint packed = FFTResults[packedIdx];
                 
                 // Extract the specific byte and normalize back to [0, 1]

--- a/Assets/_Graphics/Shaders/Editor/Spectrogram.shader
+++ b/Assets/_Graphics/Shaders/Editor/Spectrogram.shader
@@ -67,7 +67,7 @@ Shader "ChroMapper/Editor/Spectrogram"
             uniform uint FFTQuality = 1;
             uniform uint GradientLength = 4;
 
-            uniform StructuredBuffer<float> FFTResults;
+            uniform StructuredBuffer<uint> FFTResults;
             uniform StructuredBuffer<float> GradientKeys;
             uniform StructuredBuffer<float4> GradientColors;
 
@@ -86,13 +86,17 @@ Shader "ChroMapper/Editor/Spectrogram"
 
             float sampleSpectrogram(uint resultIdx)
             {
-                // Fix spectrogram offset by subtracting by our FFT Size multiplied by quality setting
-                uint idx = resultIdx - (FFTSize * FFTQuality);
-
-                // Grab our FFT sample if its within bounds
-                return idx < FFTCount
-                           ? FFTResults[idx]
-                           : 0;
+                if (resultIdx >= FFTCount)
+                    return 0.0;
+                
+                // Unpack: each uint contains 4 values as RGBA bytes
+                uint packedIdx = resultIdx / 4;
+                uint byteOffset = resultIdx % 4;
+                uint packed = FFTResults[packedIdx];
+                
+                // Extract the specific byte and normalize back to [0, 1]
+                uint byteValue = (packed >> (byteOffset * 8)) & 0xFF;
+                return float(byteValue) / 255.0;
             }
 
             float calculateSpectrogramValue(float currentSeconds, float2 uv)

--- a/Assets/__Scripts/Editor/Audio/AudioManager.cs
+++ b/Assets/__Scripts/Editor/Audio/AudioManager.cs
@@ -1,7 +1,6 @@
 using System;
 using Unity.Collections;
 using UnityEngine;
-using UnityEngine.LightTransport;
 
 public class AudioManager : MonoBehaviour
 {
@@ -44,10 +43,8 @@ public class AudioManager : MonoBehaviour
 
         var sampleCount = SampleBufferManager.MonoSampleCount;
 
-        // TODO: Should we consider a CPU spectrogram fallback in cases where the GPU spectrogram would fail?
-
         // Reduce spectrogram quality if it would exceed max buffer size 
-        while ((long)sampleCount * quality * sizeof(float) > SystemInfo.maxGraphicsBufferSize)
+        while ((long)sampleCount * quality * sizeof(uint) > SystemInfo.maxGraphicsBufferSize)
         {
             quality /= 2;
             Debug.Log($"FFT buffer exceeded. Reduced spectrogram quality to: {quality}");

--- a/Assets/__Scripts/Editor/Audio/AudioManager.cs
+++ b/Assets/__Scripts/Editor/Audio/AudioManager.cs
@@ -1,6 +1,7 @@
 using System;
 using Unity.Collections;
 using UnityEngine;
+using UnityEngine.LightTransport;
 
 public class AudioManager : MonoBehaviour
 {
@@ -62,7 +63,7 @@ public class AudioManager : MonoBehaviour
         //   (Video memory should still be available for ChroMapper and other programs)
         var videoMemoryBytes = SystemInfo.graphicsMemorySize * 1024L * 1024L;
         const int fftCountBuffers = 3;
-        while ((long)sampleCount * quality * sizeof(float) * fftCountBuffers > videoMemoryBytes / 2L)
+        while ((long)sampleCount * quality * sizeof(uint) * fftCountBuffers > videoMemoryBytes / 2L)
         {
             quality /= 2;
             Debug.Log($"Video Memory exceeded. Reduced spectrogram quality to: {quality}");
@@ -89,7 +90,9 @@ public class AudioManager : MonoBehaviour
         Shader.SetGlobalFloat(fftFrequency, clip.frequency * quality);
         Shader.SetGlobalFloat(fftQuality, quality);
 
-        cachedFFTBuffer = new ComputeBuffer(fftCount, sizeof(float));
+        // Calculate packed buffer size: each uint stores 4 samples as bytes
+        var packedFftCount = (fftCount + 3) / 4; // Round up to ensure all values fit
+        cachedFFTBuffer = new ComputeBuffer(packedFftCount, sizeof(uint));
         Shader.SetGlobalBuffer(fftResults, cachedFFTBuffer);
 
         // Step 1: Prepare real components of our FFT by multiply song samples by window coefficients for FFT

--- a/Assets/__Scripts/Editor/Audio/AudioManager.cs
+++ b/Assets/__Scripts/Editor/Audio/AudioManager.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using Unity.Collections;
 using UnityEngine;
 
@@ -6,6 +7,7 @@ public class AudioManager : MonoBehaviour
 {
     private static readonly int sampleSize = Shader.PropertyToID("SampleSize");
     private static readonly int processingOffset = Shader.PropertyToID("ProcessingOffset");
+    private static readonly int chunkOffset = Shader.PropertyToID("ChunkOffset");
 
     private static readonly int fftSize = Shader.PropertyToID("FFTSize");
     private static readonly int fftCount = Shader.PropertyToID("FFTCount");
@@ -23,6 +25,9 @@ public class AudioManager : MonoBehaviour
     private static readonly int fftImaginary = Shader.PropertyToID("Imaginary");
     private static readonly int fftResults = Shader.PropertyToID("FFTResults");
 
+    // Number of FFT windows to process per frame during deferred generation
+    private const int chunkWindowCount = 512;
+
     [SerializeField] private ComputeShader multiplyShader;
     [SerializeField] private ComputeShader fftShader;
     [SerializeField] private ComputeShader initializeShader;
@@ -30,9 +35,22 @@ public class AudioManager : MonoBehaviour
     private ComputeBuffer cachedFFTBuffer;
     private ComputeBuffer dummyBuffer;
 
+    private Coroutine activeFFTCoroutine;
+
     // ReSharper disable ParameterHidesMember
     // ReSharper disable LocalVariableHidesMember
-    public void GenerateFFT(AudioClip clip, int sampleSize, int quality)
+    public void GenerateFFT(AudioClip clip, int sampleSize, int quality, bool showDuringGenerating = false)
+    {
+        if (activeFFTCoroutine != null)
+        {
+            StopCoroutine(activeFFTCoroutine);
+            activeFFTCoroutine = null;
+        }
+
+        activeFFTCoroutine = StartCoroutine(GenerateFFTDeferred(clip, sampleSize, quality, showDuringGenerating));
+    }
+
+    private IEnumerator GenerateFFTDeferred(AudioClip clip, int sampleSize, int quality, bool showDuringGenerating)
     {
         if (SampleBufferManager.MonoSamples == null)
         {
@@ -53,14 +71,16 @@ public class AudioManager : MonoBehaviour
         {
             Debug.LogWarning("Refusing to render spectrogram: Exceeds maximum Compute Buffer size.");
             PersistentUI.Instance.ShowDialogBox("PersistentUI", "spectrofailed.computebuffer", null, PersistentUI.DialogBoxPresetType.Ok);
-            return;
+            yield break;
         }
 
         // Reduce spectrogram quality if it would exceed half of total VRAM capacity
         //   (Video memory should still be available for ChroMapper and other programs)
         var videoMemoryBytes = SystemInfo.graphicsMemorySize * 1024L * 1024L;
-        const int fftCountBuffers = 3;
-        while ((long)sampleCount * quality * sizeof(uint) * fftCountBuffers > videoMemoryBytes / 2L)
+        var chunkBufferBytes = 2L * chunkWindowCount * sampleSize * sizeof(float);
+        var fftBufferBytes = (((long)sampleCount * quality * sizeof(byte)) + 3L) / 4L;
+        var fullVramUsage = fftBufferBytes + chunkBufferBytes;
+        while (fullVramUsage > videoMemoryBytes / 2L)
         {
             quality /= 2;
             Debug.Log($"Video Memory exceeded. Reduced spectrogram quality to: {quality}");
@@ -69,11 +89,12 @@ public class AudioManager : MonoBehaviour
         {
             Debug.LogWarning("Refusing to render spectrogram: Exceeds half of available video memory.");
             PersistentUI.Instance.ShowDialogBox("PersistentUI", "spectrofailed.vram", null, PersistentUI.DialogBoxPresetType.Ok);
-            return;
+            yield break;
         }
 
         var fftSize = sampleSize / 2;
         var fftCount = sampleCount * quality;
+        var totalWindows = fftCount / sampleSize;
 
         // Generate window coefficients and signal scale factor
         var window = WindowCoefficients.GetWindowForSize(sampleSize);
@@ -86,44 +107,78 @@ public class AudioManager : MonoBehaviour
         Shader.SetGlobalFloat(fftScaleFactor, signal);
         Shader.SetGlobalFloat(fftFrequency, clip.frequency * quality);
         Shader.SetGlobalFloat(fftQuality, quality);
+        Shader.SetGlobalInt(fftInitialized, showDuringGenerating ? 1 : 0);
 
         // Calculate packed buffer size: each uint stores 4 samples as bytes
         var packedFftCount = (fftCount + 3) / 4; // Round up to ensure all values fit
         cachedFFTBuffer = new ComputeBuffer(packedFftCount, sizeof(uint));
         Shader.SetGlobalBuffer(fftResults, cachedFFTBuffer);
 
-        // Step 1: Prepare real components of our FFT by multiply song samples by window coefficients for FFT
-        //   We allocate a temporary CPU buffer that will hold our real component data before copying to the GPU in one block.
-        using var windowedSamples = new ComputeBuffer(fftCount, sizeof(float));
-        using (var windowWrite = new NativeArray<float>(fftCount, Allocator.Temp, NativeArrayOptions.UninitializedMemory))
-        using (var windowCoeffBuffer = new ComputeBuffer(sampleSize, sizeof(float)))
-        {   
-            for (var i = 0; i < sampleCount; i += sampleSize / quality)
+        // Prepare window coefficient buffer (persists across all chunks)
+        using var windowCoeffBuffer = new ComputeBuffer(sampleSize, sizeof(float));
+        windowCoeffBuffer.SetData(window);
+
+        // Process FFT in chunks, one chunk per frame
+        var samplesPerWindow = sampleSize / quality;
+
+        // Allocate our temporary buffers once and reuse them for each chunk
+        var realBuffer = new ComputeBuffer(chunkWindowCount * sampleSize, sizeof(float));
+        var imaginaryBuffer = new ComputeBuffer(chunkWindowCount * sampleSize, sizeof(float));
+        var chunkData = new NativeArray<float>(chunkWindowCount * sampleSize, Allocator.Persistent);
+        var zeroData = new float[chunkWindowCount * sampleSize]; // Used to reinitialize buffers to zero
+
+        // We generate chucnkWindowCount FFT windows per frame.
+        // This keeps our VRAM usage manageable by keeping small buffers for FFT generation,
+        // at the slight cost of increased generation time.
+        for (var windowStart = 0; windowStart < totalWindows; windowStart += chunkWindowCount)
+        {
+            // Clear buffers to zero to remove garbage data
+            realBuffer.SetData(zeroData);
+            imaginaryBuffer.SetData(zeroData);
+            chunkData.CopyFrom(zeroData);
+
+            var windowsThisChunk = Mathf.Min(chunkWindowCount, totalWindows - windowStart);
+            var chunkElementCount = windowsThisChunk * sampleSize;
+
+            // Step 1: Prepare real components for this chunk
+            var globalSampleStart = windowStart * samplesPerWindow;
+            for (var i = 0; i < windowsThisChunk * samplesPerWindow; i += samplesPerWindow)
             {
-                var length = Mathf.Clamp(sampleCount - i, 0, sampleSize);
-                NativeArray<float>.Copy(SampleBufferManager.MonoSamples, i, windowWrite, i * quality, length);
+                var srcIndex = globalSampleStart + i;
+                var dstIndex = i * quality;
+                var length = Mathf.Clamp(sampleCount - srcIndex, 0, sampleSize);
+                if (length > 0)
+                    NativeArray<float>.Copy(SampleBufferManager.MonoSamples, srcIndex, chunkData, dstIndex, length);
             }
 
-            windowedSamples.SetData(windowWrite);
-            windowCoeffBuffer.SetData(window);
+            realBuffer.SetData(chunkData);
 
-            multiplyShader.SetBuffer(0, multiplyA, windowedSamples);
+            // Multiply by window coefficients
+            multiplyShader.SetBuffer(0, multiplyA, realBuffer);
             multiplyShader.SetBuffer(0, multiplyB, windowCoeffBuffer);
+            ExecuteOverLargeArray(multiplyShader, chunkElementCount);
 
-            ExecuteOverLargeArray(multiplyShader, fftCount);
+            // Step 2: Prepare imaginary components (zeroed)
+            initializeShader.SetBuffer(0, initializeBuffer, imaginaryBuffer);
+            ExecuteOverLargeArray(initializeShader, chunkElementCount);
+
+            // Step 3: Execute FFT for this chunk
+            fftShader.SetBuffer(0, fftReal, realBuffer);
+            fftShader.SetBuffer(0, fftImaginary, imaginaryBuffer);
+            fftShader.SetInt(chunkOffset, windowStart);
+
+            ExecuteOverLargeArray(fftShader, windowsThisChunk);
+
+            yield return null;
         }
 
-        // Step 2: Prepare imaginary components of our FFT by initializing the entire buffer to 0
-        using ComputeBuffer imaginaryBuffer = new(fftCount, sizeof(float));
-        initializeShader.SetBuffer(0, initializeBuffer, imaginaryBuffer);
-        ExecuteOverLargeArray(initializeShader, fftCount);
+        // Cleanup temporary buffers
+        // Using "using" statements seem to cause issues when used in a coroutine.
+        realBuffer.Dispose();
+        imaginaryBuffer.Dispose();
+        chunkData.Dispose();
 
-        // Step 3: Execute FFT
-        fftShader.SetBuffer(0, fftReal, windowedSamples);
-        fftShader.SetBuffer(0, fftImaginary, imaginaryBuffer);
-
-        ExecuteOverLargeArray(fftShader, fftCount / sampleSize);
-
+        activeFFTCoroutine = null;
         Shader.SetGlobalInt(fftInitialized, 1);
     }
     // ReSharper restore ParameterHidesMember
@@ -133,9 +188,9 @@ public class AudioManager : MonoBehaviour
     // this usually happens when our buffers get too big (quality go brrrr)
     // fix this by executing the shader in steps, adding the processed offset as a shader variable so we can
     //   correct for the offset.
-    private static void ExecuteOverLargeArray(ComputeShader shader, int length)
+    private static void ExecuteOverLargeArray(ComputeShader shader, int length, int maxThreadCount = 65535)
     {
-        const int maxThreadCount = 65535;
+        maxThreadCount = Mathf.Min(maxThreadCount, 65535);
 
         shader.GetKernelThreadGroupSizes(0, out var x, out var y, out var z);
         var kernelGroupArea = (int)(x * y * z);
@@ -158,7 +213,6 @@ public class AudioManager : MonoBehaviour
         cachedFFTBuffer = null;
 
         Shader.SetGlobalInt(fftCount, 0);
-        Shader.SetGlobalInt(fftInitialized, 0);
         Shader.SetGlobalBuffer(fftReal, dummyBuffer);
         Shader.SetGlobalBuffer(fftImaginary, dummyBuffer);
         Shader.SetGlobalBuffer(fftResults, dummyBuffer);
@@ -174,6 +228,12 @@ public class AudioManager : MonoBehaviour
 
     private void OnDestroy()
     {
+        if (activeFFTCoroutine != null)
+        {
+            StopCoroutine(activeFFTCoroutine);
+            activeFFTCoroutine = null;
+        }
+
         ClearFFTCache();
         
         dummyBuffer.Dispose();

--- a/Assets/__Scripts/Editor/Audio/GPU/FFT.compute
+++ b/Assets/__Scripts/Editor/Audio/GPU/FFT.compute
@@ -18,6 +18,9 @@ uint FFTSize;
 // If total shader threads > 65535, we perform the maximum amount of shader threads then add to ProcessingOffset
 uint ProcessingOffset;
 
+// Offset (in FFT windows) into the global output buffer for chunked processing
+uint ChunkOffset;
+
 // legitimately couldnt tell you where this comes from, this was from the C# FFT implementation
 float FFTScaleFactor;
 
@@ -45,7 +48,9 @@ void FFT (uint3 groupID : SV_GroupID)
     
     uint butterflyCount = SampleSize >> 1;
     uint spacing = SampleSize;
-    uint sampleOffset = (ProcessingOffset + groupID.x) * SampleSize;
+    uint localIndex = ProcessingOffset + groupID.x;
+    uint sampleOffset = localIndex * SampleSize;
+    uint globalSampleOffset = (ChunkOffset + localIndex) * SampleSize;
     
     // Temporary storage for unpacked float values before packing into uints
     // Regular array since we use numthreads(1,1,1)
@@ -130,7 +135,7 @@ void FFT (uint3 groupID : SV_GroupID)
     // Second pass: pack every 4 consecutive values into a single uint (RGBA byte packing)
     // Each byte represents one value mapped to [0, 255]
     uint packedCount = (SampleSize + 3) / 4; // Round up
-    uint packedOffset = sampleOffset / 4;
+    uint packedOffset = globalSampleOffset / 4;
     
     for (uint packIdx = 0; packIdx < packedCount; packIdx++)
     {

--- a/Assets/__Scripts/Editor/Audio/GPU/FFT.compute
+++ b/Assets/__Scripts/Editor/Audio/GPU/FFT.compute
@@ -7,7 +7,7 @@
 
 RWStructuredBuffer<float> Real;
 RWStructuredBuffer<float> Imaginary;
-RWStructuredBuffer<float> FFTResults;
+RWStructuredBuffer<uint> FFTResults;
 
 uint SampleCount;
 uint SampleSize;
@@ -41,11 +41,15 @@ uint BitReverse(uint num, uint bits)
 void FFT (uint3 groupID : SV_GroupID)
 {
     uint fftLog2 = log2(SampleSize);
-    float fftScale = ROOT_2 / (float)SampleSize;
+    float fftScale = ROOT_2 / (float) SampleSize;
     
     uint butterflyCount = SampleSize >> 1;
     uint spacing = SampleSize;
     uint sampleOffset = (ProcessingOffset + groupID.x) * SampleSize;
+    
+    // Temporary storage for unpacked float values before packing into uints
+    // Regular array since we use numthreads(1,1,1)
+    float tempResults[2048];
     
     // Perform stages of FFT
     for (uint stage = 0; stage < fftLog2; stage++)
@@ -95,6 +99,7 @@ void FFT (uint3 groupID : SV_GroupID)
     }
     
     // We are left with a scrambled order.
+    // Pass 1: calculate all values and store in our temporary buffer
     for (uint j = 0; j < SampleSize; j++)
     {
         uint target = BitReverse(j, fftLog2);
@@ -103,7 +108,7 @@ void FFT (uint3 groupID : SV_GroupID)
 		// Every other column of texture would be empty, which is solved by including the imaginary half
 		// We flip the imaginary half so it lines up with the real half
         if (target >= FFTSize)
-            target = FFTSize - target;
+            target = (SampleSize - target) + FFTSize;
                 
         // we convert to magnitude here because our shader will render magnitude results
         float real = Real[sampleOffset + j] * fftScale;
@@ -118,6 +123,32 @@ void FFT (uint3 groupID : SV_GroupID)
 		// basically does some more post-processing so our magnitude results better fit [0-1]
         value = ((log(value) + 255.0 / FFT_SCALE_FACTOR) * FFT_SCALE_FACTOR) / 255.0;
         
-        FFTResults[sampleOffset + target] = value;
+        // Store in temporary buffer (clamped to [0,1] for safe byte conversion)
+        tempResults[target] = saturate(value);
+    }
+    
+    // Second pass: pack every 4 consecutive values into a single uint (RGBA byte packing)
+    // Each byte represents one value mapped to [0, 255]
+    uint packedCount = (SampleSize + 3) / 4; // Round up
+    uint packedOffset = sampleOffset / 4;
+    
+    for (uint packIdx = 0; packIdx < packedCount; packIdx++)
+    {
+        uint baseIdx = packIdx * 4;
+        
+        // Extract 4 values (or pad with 0 if at the end)
+        float val0 = (baseIdx + 0 < SampleSize) ? tempResults[baseIdx + 0] : 0.0;
+        float val1 = (baseIdx + 1 < SampleSize) ? tempResults[baseIdx + 1] : 0.0;
+        float val2 = (baseIdx + 2 < SampleSize) ? tempResults[baseIdx + 2] : 0.0;
+        float val3 = (baseIdx + 3 < SampleSize) ? tempResults[baseIdx + 3] : 0.0;
+        
+        // Pack into uint as RGBA bytes (little-endian: R in lowest byte)
+        uint packed =
+            (uint(val0 * 255.0) << 0) | // R: bits 0-7
+            (uint(val1 * 255.0) << 8) | // G: bits 8-15
+            (uint(val2 * 255.0) << 16) | // B: bits 16-23
+            (uint(val3 * 255.0) << 24); // A: bits 24-31
+        
+        FFTResults[packedOffset + packIdx] = packed;
     }
 }

--- a/Assets/__Scripts/Editor/Audio/WaveformGenerator.cs
+++ b/Assets/__Scripts/Editor/Audio/WaveformGenerator.cs
@@ -16,6 +16,7 @@ public class WaveformGenerator : MonoBehaviour
         
         AudioManager.GenerateFFT(BeatSaberSongContainer.Instance.LoadedSong,
             Settings.Instance.SpectrogramSampleSize,
-            Settings.Instance.SpectrogramEditorQuality);
+            Settings.Instance.SpectrogramEditorQuality,
+            true);
     }
 }


### PR DESCRIPTION
This PR reduces the VRAM requirements of CM's spectrogram by 75%. This is achieved by packing each spectrogram sample into a single `byte` rather than a 4-byte `float`.

This *does* limit the quality resolution of the spectrogram to 256 possible values. However, I am considering this acceptable considering we already do a fair amount of filtering on top of these samples (color gradient, bilinear filtering, etc.) and we've already had a significant number of people who experienced crashing due to the current GPU spectrogram system.

If people do not like 1-byte/8-bit packing, other possible bit-packing possibilities can include:
- 2-byte samples, 50% savings but 65k possible spectrogram values.
- 4-bit samples. 1/8th total size compared to the current float-based spectrogram, but 16 possible values will absolutely cause visible artifacting within the spectrogram.
- 2-bit samples, now you're just being ridiculous. 