### PR TITLE
Add check in CleanSongName to ensure a valid folder name on Windows

### DIFF
--- a/Assets/__Scripts/Beatmap/Info/Base/BaseInfo.cs
+++ b/Assets/__Scripts/Beatmap/Info/Base/BaseInfo.cs
@@ -87,11 +87,29 @@ namespace Beatmap.Info
 
         public string SongName { get; set; } = "New Song";
 
-        public string CleanSongName =>
-            Path
-                .GetInvalidFileNameChars()
-                .Aggregate(SongName, (res, el) => res.Replace(el.ToString(), string.Empty))
-                .Trim('.'); // Windows disallows trailing periods and macOS treats leading period as hidden folder
+        // Windows has reserved names that should not be used by folders or files
+        private static readonly HashSet<string> ReservedNamesWindows = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "CON", "PRN", "AUX", "NUL",
+            "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
+            "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"
+        };
+        public string CleanSongName
+        {
+            get
+            {   
+                var cleaned = Path.GetInvalidFileNameChars()
+                    .Aggregate(SongName, (res, el) => res.Replace(el.ToString(), string.Empty))
+                    .Trim('.'); // Windows disallows trailing periods and macOS treats leading period as hidden folder
+
+                if (ReservedNamesWindows.Contains(cleaned))
+                {
+                    return string.Empty;
+                }
+
+                return cleaned;
+            }
+        }
 
         public string SongSubName { get; set; } = "";
         public string SongAuthorName { get; set; } = "";


### PR DESCRIPTION
Currently, ChroMapper allows one to create songs with names that result in problematic folder names on Windows, such as: CON, PRN, AUX, NUL, etc. These folder names can be unstable and possibly cause unintended errors. More information on this can be found here: https://youtu.be/bC6tngl0PTI & https://bluescreencomputer.com/2022/02/07/forbidden-file-names/

I have updated the `CleanSongName` function to include a check for these names after prior cleanup, in which the cleaned song name will be returned as an empty string, allowing for the already included invalid new map name error message to be displayed.