### PR TITLE
Fix copy paste + editing = ghost nodes

### DIFF
--- a/Assets/__Scripts/UI/Editor/NodeEditor/NodeEditorController.cs
+++ b/Assets/__Scripts/UI/Editor/NodeEditor/NodeEditorController.cs
@@ -230,12 +230,11 @@ public class NodeEditorController : MonoBehaviour, CMInput.INodeEditorActions
                 .Select(pair =>
                 {
                     var (reference, json) = pair;
-                    var original = reference.Clone() as BaseObject;
-                    reference.Apply(Activator.CreateInstance(reference.GetType(), new object[] { json }) as BaseObject);
-                    return new BeatmapObjectModifiedAction(
+                    var edited = BeatmapFactory.Clone(reference);
+                    edited.Apply(Activator.CreateInstance(reference.GetType(), new object[] { json }) as BaseObject);
+                    return new BeatmapObjectUpdatedAction(
+                        edited,
                         reference,
-                        reference,
-                        original,
                         $"Edited a {reference.ObjectType} with Node Editor.",
                         true);
                 })


### PR DESCRIPTION
Fix copy paste and then editing / moving the nodes without deselecting first producing ghost nodes.