### PR TITLE
Dont auto ref roslyn analyzer

### DIFF
--- a/Assets/Packages/Microsoft.Unity.Analyzers.1.26.0/analyzers/dotnet/cs/Microsoft.Unity.Analyzers.dll.meta
+++ b/Assets/Packages/Microsoft.Unity.Analyzers.1.26.0/analyzers/dotnet/cs/Microsoft.Unity.Analyzers.dll.meta
@@ -1,0 +1,75 @@
+fileFormatVersion: 2
+guid: 4b4d13f60542d494094fa0ed6b32c136
+labels:
+- NuGetForUnity
+- RoslynAnalyzer
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 3
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 1
+  validateReferences: 1
+  platformData:
+    Any:
+      enabled: 0
+      settings:
+        'Exclude ': 0
+        Exclude Android: 0
+        Exclude CloudRendering: 0
+        Exclude Editor: 1
+        Exclude EmbeddedLinux: 0
+        Exclude GameCoreScarlett: 0
+        Exclude GameCoreXboxOne: 0
+        Exclude Kepler: 0
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude PS4: 0
+        Exclude PS5: 0
+        Exclude QNX: 0
+        Exclude Switch: 0
+        Exclude Switch2: 0
+        Exclude VisionOS: 0
+        Exclude WebGL: 0
+        Exclude Win: 1
+        Exclude Win64: 1
+        Exclude WindowsStoreApps: 1
+        Exclude XboxOne: 0
+        Exclude iOS: 0
+        Exclude tvOS: 0
+    Editor:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+        DefaultValueInitialized: true
+        OS: AnyOS
+    Linux64:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+    OSXUniversal:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+    Win:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+    Win64:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+    WindowsStoreApps:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+        DontProcess: false
+        PlaceholderPath: 
+        SDK: AnySDK
+        ScriptingBackend: AnyScriptingBackend
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Dont auto ref rosly analyzer. This file was git ignored since we try not to check in packages, force checking it in to preserve the no-auto-reference that needs to be manually set for unity analyzer dlls apparently