### PR TITLE
Billion bugfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ Packages/Microsoft.Unity.Analyzer*
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
 
+# When profiling this is the default save location in unity when you want to compare profile results
+ProfilerCaptures/
+
 # Build results
 [Dd]ebug/
 [Dd]ebugPublic/

--- a/Assets/Input/Master.cs
+++ b/Assets/Input/Master.cs
@@ -4823,7 +4823,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
             ""id"": ""08122fed-0d6b-4568-96df-eecf068a7222"",
             ""actions"": [
                 {
-                    ""name"": ""TweakChainCount"",
+                    ""name"": ""Tweak Chain Count"",
                     ""type"": ""Value"",
                     ""id"": ""1c7ce6e2-975c-4349-ad23-ec3d12a4c640"",
                     ""expectedControlType"": ""Axis"",
@@ -4832,7 +4832,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""initialStateCheck"": true
                 },
                 {
-                    ""name"": ""TweakChainSquish"",
+                    ""name"": ""Tweak Chain Squish"",
                     ""type"": ""Value"",
                     ""id"": ""afed819c-0511-4541-be42-2272b16fd4cb"",
                     ""expectedControlType"": ""Axis"",
@@ -4849,7 +4849,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""TweakChainCount"",
+                    ""action"": ""Tweak Chain Count"",
                     ""isComposite"": true,
                     ""isPartOfComposite"": false
                 },
@@ -4860,7 +4860,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""TweakChainCount"",
+                    ""action"": ""Tweak Chain Count"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": true
                 },
@@ -4871,7 +4871,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""TweakChainCount"",
+                    ""action"": ""Tweak Chain Count"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": true
                 },
@@ -4882,7 +4882,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""TweakChainSquish"",
+                    ""action"": ""Tweak Chain Squish"",
                     ""isComposite"": true,
                     ""isPartOfComposite"": false
                 },
@@ -4893,7 +4893,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""TweakChainSquish"",
+                    ""action"": ""Tweak Chain Squish"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": true
                 },
@@ -4904,7 +4904,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""TweakChainSquish"",
+                    ""action"": ""Tweak Chain Squish"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": true
                 }
@@ -5150,9 +5150,18 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
             ""id"": ""e4de6044-1de0-48cb-bbea-f07027b50a3d"",
             ""actions"": [
                 {
-                    ""name"": ""Next Group"",
+                    ""name"": ""Next Groups Page"",
                     ""type"": ""Button"",
                     ""id"": ""49fa1c10-5df7-407e-9650-0b7d8ae1e6fc"",
+                    ""expectedControlType"": """",
+                    ""processors"": """",
+                    ""interactions"": ""Press"",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""Previous Groups Page"",
+                    ""type"": ""Button"",
+                    ""id"": ""fef538eb-56aa-48ae-9cb5-5558c6d23d8f"",
                     ""expectedControlType"": """",
                     ""processors"": """",
                     ""interactions"": ""Press"",
@@ -5161,13 +5170,24 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
             ],
             ""bindings"": [
                 {
-                    ""name"": """",
+                    ""name"": ""Next"",
                     ""id"": ""c064d927-7ad4-4e19-88ae-08b52a91d215"",
-                    ""path"": ""<Keyboard>/tab"",
+                    ""path"": ""<Keyboard>/pageUp"",
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""Next Group"",
+                    ""action"": ""Next Groups Page"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": ""Previous"",
+                    ""id"": ""c097e07c-7c52-46cc-8570-c1d67b8ad268"",
+                    ""path"": ""<Keyboard>/pageDown"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""Previous Groups Page"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": false
                 }
@@ -5246,7 +5266,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
             ""id"": ""37f9e19f-0f82-481f-ac35-5c6bf1432eef"",
             ""actions"": [
                 {
-                    ""name"": ""Color0 Light"",
+                    ""name"": ""Primary Light Color"",
                     ""type"": ""Button"",
                     ""id"": ""0806de86-cc21-48e2-8fbd-a03530b1ba3c"",
                     ""expectedControlType"": """",
@@ -5255,7 +5275,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""initialStateCheck"": false
                 },
                 {
-                    ""name"": ""Color1 Light"",
+                    ""name"": ""Secondary Light Color"",
                     ""type"": ""Button"",
                     ""id"": ""52046f1f-96a3-4708-aeb5-9835f7dffe8d"",
                     ""expectedControlType"": """",
@@ -5264,9 +5284,27 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""initialStateCheck"": false
                 },
                 {
-                    ""name"": ""ColorW Light"",
+                    ""name"": ""White Light Color"",
                     ""type"": ""Button"",
                     ""id"": ""369ad4a4-f027-441d-99ad-07a501a7f04b"",
+                    ""expectedControlType"": """",
+                    ""processors"": """",
+                    ""interactions"": ""Press"",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""Chroma Light Color"",
+                    ""type"": ""Button"",
+                    ""id"": ""a413f5eb-19a8-4e2e-a074-d144058054d7"",
+                    ""expectedControlType"": """",
+                    ""processors"": """",
+                    ""interactions"": ""Press"",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""Strobe Chroma Color"",
+                    ""type"": ""Button"",
+                    ""id"": ""785f959c-61be-4141-a167-ed33780790d1"",
                     ""expectedControlType"": """",
                     ""processors"": """",
                     ""interactions"": ""Press"",
@@ -5444,15 +5482,6 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""initialStateCheck"": false
                 },
                 {
-                    ""name"": ""Brightness (Hover)"",
-                    ""type"": ""Button"",
-                    ""id"": ""12efb566-15c0-4db8-a04f-f1af295c8e79"",
-                    ""expectedControlType"": """",
-                    ""processors"": """",
-                    ""interactions"": ""Press"",
-                    ""initialStateCheck"": false
-                },
-                {
                     ""name"": ""Strobe On"",
                     ""type"": ""Button"",
                     ""id"": ""f3cce743-71be-4383-a125-b5431b5af2c7"",
@@ -5471,27 +5500,9 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""initialStateCheck"": false
                 },
                 {
-                    ""name"": ""Strobe Frequency (Hover)"",
-                    ""type"": ""Button"",
-                    ""id"": ""8d8173b1-0211-441b-95b0-d820a206057a"",
-                    ""expectedControlType"": """",
-                    ""processors"": """",
-                    ""interactions"": ""Press"",
-                    ""initialStateCheck"": false
-                },
-                {
                     ""name"": ""Strobe Brightness"",
                     ""type"": ""Button"",
                     ""id"": ""b89aef46-41f6-4e26-aea2-4e7a6d8ac905"",
-                    ""expectedControlType"": """",
-                    ""processors"": """",
-                    ""interactions"": ""Press"",
-                    ""initialStateCheck"": false
-                },
-                {
-                    ""name"": ""Strobe Brightness (Hover)"",
-                    ""type"": ""Button"",
-                    ""id"": ""9acf7284-6b19-4fe2-9f57-4d62d467dd15"",
                     ""expectedControlType"": """",
                     ""processors"": """",
                     ""interactions"": ""Press"",
@@ -5516,6 +5527,33 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""initialStateCheck"": false
                 },
                 {
+                    ""name"": ""Tweak Brightness (Hover)"",
+                    ""type"": ""Button"",
+                    ""id"": ""12efb566-15c0-4db8-a04f-f1af295c8e79"",
+                    ""expectedControlType"": """",
+                    ""processors"": """",
+                    ""interactions"": ""Press"",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""Tweak Strobe Frequency (Hover)"",
+                    ""type"": ""Button"",
+                    ""id"": ""8d8173b1-0211-441b-95b0-d820a206057a"",
+                    ""expectedControlType"": """",
+                    ""processors"": """",
+                    ""interactions"": ""Press"",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""Tweak Strobe Brightness (Hover)"",
+                    ""type"": ""Button"",
+                    ""id"": ""9acf7284-6b19-4fe2-9f57-4d62d467dd15"",
+                    ""expectedControlType"": """",
+                    ""processors"": """",
+                    ""interactions"": ""Press"",
+                    ""initialStateCheck"": false
+                },
+                {
                     ""name"": ""Tweak Easing (Hover)"",
                     ""type"": ""Value"",
                     ""id"": ""9cfcd847-c28a-48ad-9e05-6cf5fdf3f171"",
@@ -5533,7 +5571,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""Color0 Light"",
+                    ""action"": ""Primary Light Color"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": false
                 },
@@ -5544,7 +5582,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""Color1 Light"",
+                    ""action"": ""Secondary Light Color"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": false
                 },
@@ -5555,7 +5593,29 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""ColorW Light"",
+                    ""action"": ""White Light Color"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""d65100ca-8bb6-4e21-8f7b-051481563eef"",
+                    ""path"": ""<Keyboard>/4"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""ChroMapper Default"",
+                    ""action"": ""Chroma Light Color"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""4e7dafd7-0102-4180-8a9e-60ef3831e4e2"",
+                    ""path"": ""<Keyboard>/c"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""ChroMapper Default"",
+                    ""action"": ""Strobe Chroma Color"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": false
                 },
@@ -5797,7 +5857,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""Strobe Frequency (Hover)"",
+                    ""action"": ""Tweak Strobe Frequency (Hover)"",
                     ""isComposite"": true,
                     ""isPartOfComposite"": false
                 },
@@ -5808,7 +5868,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""Strobe Frequency (Hover)"",
+                    ""action"": ""Tweak Strobe Frequency (Hover)"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": true
                 },
@@ -5819,7 +5879,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""Strobe Frequency (Hover)"",
+                    ""action"": ""Tweak Strobe Frequency (Hover)"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": true
                 },
@@ -5830,7 +5890,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""Strobe Frequency (Hover)"",
+                    ""action"": ""Tweak Strobe Frequency (Hover)"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": true
                 },
@@ -5874,7 +5934,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""Brightness (Hover)"",
+                    ""action"": ""Tweak Brightness (Hover)"",
                     ""isComposite"": true,
                     ""isPartOfComposite"": false
                 },
@@ -5885,7 +5945,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""Brightness (Hover)"",
+                    ""action"": ""Tweak Brightness (Hover)"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": true
                 },
@@ -5896,7 +5956,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""Brightness (Hover)"",
+                    ""action"": ""Tweak Brightness (Hover)"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": true
                 },
@@ -5907,7 +5967,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""Strobe Brightness (Hover)"",
+                    ""action"": ""Tweak Strobe Brightness (Hover)"",
                     ""isComposite"": true,
                     ""isPartOfComposite"": false
                 },
@@ -5918,7 +5978,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""Strobe Brightness (Hover)"",
+                    ""action"": ""Tweak Strobe Brightness (Hover)"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": true
                 },
@@ -5929,7 +5989,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""Strobe Brightness (Hover)"",
+                    ""action"": ""Tweak Strobe Brightness (Hover)"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": true
                 },
@@ -5940,7 +6000,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""Strobe Brightness (Hover)"",
+                    ""action"": ""Tweak Strobe Brightness (Hover)"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": true
                 },
@@ -5951,7 +6011,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""Strobe Brightness (Hover)"",
+                    ""action"": ""Tweak Strobe Brightness (Hover)"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": true
                 },
@@ -6042,15 +6102,6 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""initialStateCheck"": false
                 },
                 {
-                    ""name"": ""Angle (Hover)"",
-                    ""type"": ""Button"",
-                    ""id"": ""ec35709c-0503-45d5-a460-03450dad1b41"",
-                    ""expectedControlType"": """",
-                    ""processors"": """",
-                    ""interactions"": ""Press"",
-                    ""initialStateCheck"": false
-                },
-                {
                     ""name"": ""Rotation Direction (Left)"",
                     ""type"": ""Button"",
                     ""id"": ""f7d73af6-1611-41ae-81f0-1353716c426e"",
@@ -6096,6 +6147,15 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""initialStateCheck"": false
                 },
                 {
+                    ""name"": ""Tweak Angle (Hover)"",
+                    ""type"": ""Button"",
+                    ""id"": ""ec35709c-0503-45d5-a460-03450dad1b41"",
+                    ""expectedControlType"": """",
+                    ""processors"": """",
+                    ""interactions"": ""Press"",
+                    ""initialStateCheck"": false
+                },
+                {
                     ""name"": ""Tweak Loop (Hover)"",
                     ""type"": ""Value"",
                     ""id"": ""ee00d968-6cbc-40e8-921d-f31636675e13"",
@@ -6114,7 +6174,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""initialStateCheck"": true
                 },
                 {
-                    ""name"": ""Cycle Axis (Hover)"",
+                    ""name"": ""Tweak Axis (Hover)"",
                     ""type"": ""Value"",
                     ""id"": ""f5be2c40-29da-46cd-a64b-a61ff42eb564"",
                     ""expectedControlType"": ""Axis"",
@@ -6123,7 +6183,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""initialStateCheck"": true
                 },
                 {
-                    ""name"": ""Cycle Direction (Hover)"",
+                    ""name"": ""Tweak Direction (Hover)"",
                     ""type"": ""Button"",
                     ""id"": ""3973edf5-5bed-478d-a410-d72beb1bd603"",
                     ""expectedControlType"": """",
@@ -6239,7 +6299,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""Angle (Hover)"",
+                    ""action"": ""Tweak Angle (Hover)"",
                     ""isComposite"": true,
                     ""isPartOfComposite"": false
                 },
@@ -6250,7 +6310,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""Angle (Hover)"",
+                    ""action"": ""Tweak Angle (Hover)"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": true
                 },
@@ -6261,7 +6321,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""Angle (Hover)"",
+                    ""action"": ""Tweak Angle (Hover)"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": true
                 },
@@ -6272,7 +6332,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""Cycle Axis (Hover)"",
+                    ""action"": ""Tweak Axis (Hover)"",
                     ""isComposite"": true,
                     ""isPartOfComposite"": false
                 },
@@ -6283,7 +6343,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""Cycle Axis (Hover)"",
+                    ""action"": ""Tweak Axis (Hover)"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": true
                 },
@@ -6294,7 +6354,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""Cycle Axis (Hover)"",
+                    ""action"": ""Tweak Axis (Hover)"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": true
                 },
@@ -6305,7 +6365,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""Cycle Axis (Hover)"",
+                    ""action"": ""Tweak Axis (Hover)"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": true
                 },
@@ -6415,7 +6475,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""Cycle Direction (Hover)"",
+                    ""action"": ""Tweak Direction (Hover)"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": false
                 }
@@ -6471,7 +6531,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""initialStateCheck"": false
                 },
                 {
-                    ""name"": ""Value (Hover)"",
+                    ""name"": ""Tweak Value (Hover)"",
                     ""type"": ""Button"",
                     ""id"": ""b70438c0-b7a3-4dfa-8bd3-d6bf4906a769"",
                     ""expectedControlType"": """",
@@ -6489,7 +6549,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""initialStateCheck"": true
                 },
                 {
-                    ""name"": ""Cycle Axis (Hover)"",
+                    ""name"": ""Tweak Axis (Hover)"",
                     ""type"": ""Value"",
                     ""id"": ""b168aaf1-9e62-407e-9341-c11284a940d6"",
                     ""expectedControlType"": ""Axis"",
@@ -6561,7 +6621,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""Value (Hover)"",
+                    ""action"": ""Tweak Value (Hover)"",
                     ""isComposite"": true,
                     ""isPartOfComposite"": false
                 },
@@ -6572,7 +6632,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""Value (Hover)"",
+                    ""action"": ""Tweak Value (Hover)"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": true
                 },
@@ -6583,7 +6643,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""Value (Hover)"",
+                    ""action"": ""Tweak Value (Hover)"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": true
                 },
@@ -6594,7 +6654,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""Cycle Axis (Hover)"",
+                    ""action"": ""Tweak Axis (Hover)"",
                     ""isComposite"": true,
                     ""isPartOfComposite"": false
                 },
@@ -6605,7 +6665,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""Cycle Axis (Hover)"",
+                    ""action"": ""Tweak Axis (Hover)"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": true
                 },
@@ -6616,7 +6676,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""Cycle Axis (Hover)"",
+                    ""action"": ""Tweak Axis (Hover)"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": true
                 },
@@ -6627,7 +6687,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""Cycle Axis (Hover)"",
+                    ""action"": ""Tweak Axis (Hover)"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": true
                 },
@@ -6727,7 +6787,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""initialStateCheck"": false
                 },
                 {
-                    ""name"": ""Value (Hover)"",
+                    ""name"": ""Tweak Value (Hover)"",
                     ""type"": ""Button"",
                     ""id"": ""146a8e3f-7192-4cd3-bef6-45b7e5e5ec31"",
                     ""expectedControlType"": """",
@@ -6808,7 +6868,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""Value (Hover)"",
+                    ""action"": ""Tweak Value (Hover)"",
                     ""isComposite"": true,
                     ""isPartOfComposite"": false
                 },
@@ -6819,7 +6879,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""Value (Hover)"",
+                    ""action"": ""Tweak Value (Hover)"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": true
                 },
@@ -6830,7 +6890,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""Value (Hover)"",
+                    ""action"": ""Tweak Value (Hover)"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": true
                 },
@@ -7155,7 +7215,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                 {
                     ""name"": """",
                     ""id"": ""30a99391-cfa1-4371-bf37-4495a06a344c"",
-                    ""path"": ""<Keyboard>/4"",
+                    ""path"": ""<Keyboard>/6"",
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
@@ -7188,7 +7248,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                 {
                     ""name"": ""binding"",
                     ""id"": ""2fa4536d-9fc4-4224-a019-b6d1f057846e"",
-                    ""path"": ""<Keyboard>/4"",
+                    ""path"": ""<Keyboard>/6"",
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
@@ -7329,15 +7389,6 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""initialStateCheck"": false
                 },
                 {
-                    ""name"": ""Modify (Hover)"",
-                    ""type"": ""Value"",
-                    ""id"": ""0bacd048-031f-4ccd-bb5b-18c43f001614"",
-                    ""expectedControlType"": ""Axis"",
-                    ""processors"": """",
-                    ""interactions"": ""Press"",
-                    ""initialStateCheck"": true
-                },
-                {
                     ""name"": ""Invert"",
                     ""type"": ""Button"",
                     ""id"": ""7ae63c7f-cb46-4d12-a64c-1bf5b5490d46"",
@@ -7417,6 +7468,15 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""processors"": """",
                     ""interactions"": ""Press"",
                     ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""Tweak Modify (Hover)"",
+                    ""type"": ""Value"",
+                    ""id"": ""0bacd048-031f-4ccd-bb5b-18c43f001614"",
+                    ""expectedControlType"": ""Axis"",
+                    ""processors"": """",
+                    ""interactions"": ""Press"",
+                    ""initialStateCheck"": true
                 }
             ],
             ""bindings"": [
@@ -7482,7 +7542,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
-                    ""action"": ""Modify (Hover)"",
+                    ""action"": ""Tweak Modify (Hover)"",
                     ""isComposite"": true,
                     ""isPartOfComposite"": false
                 },
@@ -7493,7 +7553,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": "";ChroMapper Default"",
-                    ""action"": ""Modify (Hover)"",
+                    ""action"": ""Tweak Modify (Hover)"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": true
                 },
@@ -7504,7 +7564,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": "";ChroMapper Default"",
-                    ""action"": ""Modify (Hover)"",
+                    ""action"": ""Tweak Modify (Hover)"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": true
                 },
@@ -8114,8 +8174,8 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
         m_ArcObjects_ChangingTmu = m_ArcObjects.FindAction("ChangingTmu", throwIfNotFound: true);
         // Chain Objects
         m_ChainObjects = asset.FindActionMap("Chain Objects", throwIfNotFound: true);
-        m_ChainObjects_TweakChainCount = m_ChainObjects.FindAction("TweakChainCount", throwIfNotFound: true);
-        m_ChainObjects_TweakChainSquish = m_ChainObjects.FindAction("TweakChainSquish", throwIfNotFound: true);
+        m_ChainObjects_TweakChainCount = m_ChainObjects.FindAction("Tweak Chain Count", throwIfNotFound: true);
+        m_ChainObjects_TweakChainSquish = m_ChainObjects.FindAction("Tweak Chain Squish", throwIfNotFound: true);
         // Arc Placement
         m_ArcPlacement = asset.FindActionMap("Arc Placement", throwIfNotFound: true);
         m_ArcPlacement_SpawnArc = m_ArcPlacement.FindAction("SpawnArc", throwIfNotFound: true);
@@ -8135,7 +8195,8 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
         m_EditMode_BasicEventEdit = m_EditMode.FindAction("BasicEventEdit", throwIfNotFound: true);
         // GLS Group Tabs
         m_GLSGroupTabs = asset.FindActionMap("GLS Group Tabs", throwIfNotFound: true);
-        m_GLSGroupTabs_NextGroup = m_GLSGroupTabs.FindAction("Next Group", throwIfNotFound: true);
+        m_GLSGroupTabs_NextGroupsPage = m_GLSGroupTabs.FindAction("Next Groups Page", throwIfNotFound: true);
+        m_GLSGroupTabs_PreviousGroupsPage = m_GLSGroupTabs.FindAction("Previous Groups Page", throwIfNotFound: true);
         // GLS Group Select
         m_GLSGroupSelect = asset.FindActionMap("GLS Group Select", throwIfNotFound: true);
         m_GLSGroupSelect_EnterGroup = m_GLSGroupSelect.FindAction("Enter Group", throwIfNotFound: true);
@@ -8143,9 +8204,11 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
         m_GLSGroupSelect_MirrorHover = m_GLSGroupSelect.FindAction("Mirror (Hover)", throwIfNotFound: true);
         // GLS Color Objects
         m_GLSColorObjects = asset.FindActionMap("GLS Color Objects", throwIfNotFound: true);
-        m_GLSColorObjects_Color0Light = m_GLSColorObjects.FindAction("Color0 Light", throwIfNotFound: true);
-        m_GLSColorObjects_Color1Light = m_GLSColorObjects.FindAction("Color1 Light", throwIfNotFound: true);
-        m_GLSColorObjects_ColorWLight = m_GLSColorObjects.FindAction("ColorW Light", throwIfNotFound: true);
+        m_GLSColorObjects_PrimaryLightColor = m_GLSColorObjects.FindAction("Primary Light Color", throwIfNotFound: true);
+        m_GLSColorObjects_SecondaryLightColor = m_GLSColorObjects.FindAction("Secondary Light Color", throwIfNotFound: true);
+        m_GLSColorObjects_WhiteLightColor = m_GLSColorObjects.FindAction("White Light Color", throwIfNotFound: true);
+        m_GLSColorObjects_ChromaLightColor = m_GLSColorObjects.FindAction("Chroma Light Color", throwIfNotFound: true);
+        m_GLSColorObjects_StrobeChromaColor = m_GLSColorObjects.FindAction("Strobe Chroma Color", throwIfNotFound: true);
         m_GLSColorObjects_Static0Brightness = m_GLSColorObjects.FindAction("Static 0 Brightness", throwIfNotFound: true);
         m_GLSColorObjects_Static50Brightness = m_GLSColorObjects.FindAction("Static 50 Brightness", throwIfNotFound: true);
         m_GLSColorObjects_Static100Brightness = m_GLSColorObjects.FindAction("Static 100 Brightness", throwIfNotFound: true);
@@ -8165,14 +8228,14 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
         m_GLSColorObjects_Brightness100 = m_GLSColorObjects.FindAction("Brightness 100", throwIfNotFound: true);
         m_GLSColorObjects_Brightness120 = m_GLSColorObjects.FindAction("Brightness 120", throwIfNotFound: true);
         m_GLSColorObjects_Brightness150 = m_GLSColorObjects.FindAction("Brightness 150", throwIfNotFound: true);
-        m_GLSColorObjects_BrightnessHover = m_GLSColorObjects.FindAction("Brightness (Hover)", throwIfNotFound: true);
         m_GLSColorObjects_StrobeOn = m_GLSColorObjects.FindAction("Strobe On", throwIfNotFound: true);
         m_GLSColorObjects_StrobeOff = m_GLSColorObjects.FindAction("Strobe Off", throwIfNotFound: true);
-        m_GLSColorObjects_StrobeFrequencyHover = m_GLSColorObjects.FindAction("Strobe Frequency (Hover)", throwIfNotFound: true);
         m_GLSColorObjects_StrobeBrightness = m_GLSColorObjects.FindAction("Strobe Brightness", throwIfNotFound: true);
-        m_GLSColorObjects_StrobeBrightnessHover = m_GLSColorObjects.FindAction("Strobe Brightness (Hover)", throwIfNotFound: true);
         m_GLSColorObjects_SoftStrobe = m_GLSColorObjects.FindAction("Soft Strobe", throwIfNotFound: true);
         m_GLSColorObjects_MirrorHover = m_GLSColorObjects.FindAction("Mirror (Hover)", throwIfNotFound: true);
+        m_GLSColorObjects_TweakBrightnessHover = m_GLSColorObjects.FindAction("Tweak Brightness (Hover)", throwIfNotFound: true);
+        m_GLSColorObjects_TweakStrobeFrequencyHover = m_GLSColorObjects.FindAction("Tweak Strobe Frequency (Hover)", throwIfNotFound: true);
+        m_GLSColorObjects_TweakStrobeBrightnessHover = m_GLSColorObjects.FindAction("Tweak Strobe Brightness (Hover)", throwIfNotFound: true);
         m_GLSColorObjects_TweakEasingHover = m_GLSColorObjects.FindAction("Tweak Easing (Hover)", throwIfNotFound: true);
         // GLS Rotation Objects
         m_GLSRotationObjects = asset.FindActionMap("GLS Rotation Objects", throwIfNotFound: true);
@@ -8180,16 +8243,16 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
         m_GLSRotationObjects_Angle90 = m_GLSRotationObjects.FindAction("Angle 90", throwIfNotFound: true);
         m_GLSRotationObjects_Angle180 = m_GLSRotationObjects.FindAction("Angle 180", throwIfNotFound: true);
         m_GLSRotationObjects_Angle270 = m_GLSRotationObjects.FindAction("Angle 270", throwIfNotFound: true);
-        m_GLSRotationObjects_AngleHover = m_GLSRotationObjects.FindAction("Angle (Hover)", throwIfNotFound: true);
         m_GLSRotationObjects_RotationDirectionLeft = m_GLSRotationObjects.FindAction("Rotation Direction (Left)", throwIfNotFound: true);
         m_GLSRotationObjects_RotationDirectionAutomatic = m_GLSRotationObjects.FindAction("Rotation Direction (Automatic)", throwIfNotFound: true);
         m_GLSRotationObjects_RotationDirectionRight = m_GLSRotationObjects.FindAction("Rotation Direction (Right)", throwIfNotFound: true);
         m_GLSRotationObjects_ChangeLoopCount = m_GLSRotationObjects.FindAction("Change Loop Count", throwIfNotFound: true);
         m_GLSRotationObjects_ResetLoopCount = m_GLSRotationObjects.FindAction("Reset Loop Count", throwIfNotFound: true);
+        m_GLSRotationObjects_TweakAngleHover = m_GLSRotationObjects.FindAction("Tweak Angle (Hover)", throwIfNotFound: true);
         m_GLSRotationObjects_TweakLoopHover = m_GLSRotationObjects.FindAction("Tweak Loop (Hover)", throwIfNotFound: true);
         m_GLSRotationObjects_TweakEasingHover = m_GLSRotationObjects.FindAction("Tweak Easing (Hover)", throwIfNotFound: true);
-        m_GLSRotationObjects_CycleAxisHover = m_GLSRotationObjects.FindAction("Cycle Axis (Hover)", throwIfNotFound: true);
-        m_GLSRotationObjects_CycleDirectionHover = m_GLSRotationObjects.FindAction("Cycle Direction (Hover)", throwIfNotFound: true);
+        m_GLSRotationObjects_TweakAxisHover = m_GLSRotationObjects.FindAction("Tweak Axis (Hover)", throwIfNotFound: true);
+        m_GLSRotationObjects_TweakDirectionHover = m_GLSRotationObjects.FindAction("Tweak Direction (Hover)", throwIfNotFound: true);
         // GLS Translation Objects
         m_GLSTranslationObjects = asset.FindActionMap("GLS Translation Objects", throwIfNotFound: true);
         m_GLSTranslationObjects_Valuen100 = m_GLSTranslationObjects.FindAction("Value n100", throwIfNotFound: true);
@@ -8197,9 +8260,9 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
         m_GLSTranslationObjects_Value0 = m_GLSTranslationObjects.FindAction("Value 0", throwIfNotFound: true);
         m_GLSTranslationObjects_Value50 = m_GLSTranslationObjects.FindAction("Value 50", throwIfNotFound: true);
         m_GLSTranslationObjects_Value100 = m_GLSTranslationObjects.FindAction("Value 100", throwIfNotFound: true);
-        m_GLSTranslationObjects_ValueHover = m_GLSTranslationObjects.FindAction("Value (Hover)", throwIfNotFound: true);
+        m_GLSTranslationObjects_TweakValueHover = m_GLSTranslationObjects.FindAction("Tweak Value (Hover)", throwIfNotFound: true);
         m_GLSTranslationObjects_TweakEasingHover = m_GLSTranslationObjects.FindAction("Tweak Easing (Hover)", throwIfNotFound: true);
-        m_GLSTranslationObjects_CycleAxisHover = m_GLSTranslationObjects.FindAction("Cycle Axis (Hover)", throwIfNotFound: true);
+        m_GLSTranslationObjects_TweakAxisHover = m_GLSTranslationObjects.FindAction("Tweak Axis (Hover)", throwIfNotFound: true);
         // GLS FloatFX Objects
         m_GLSFloatFXObjects = asset.FindActionMap("GLS FloatFX Objects", throwIfNotFound: true);
         m_GLSFloatFXObjects_Valuen100 = m_GLSFloatFXObjects.FindAction("Value n100", throwIfNotFound: true);
@@ -8207,7 +8270,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
         m_GLSFloatFXObjects_Value0 = m_GLSFloatFXObjects.FindAction("Value 0", throwIfNotFound: true);
         m_GLSFloatFXObjects_Value50 = m_GLSFloatFXObjects.FindAction("Value 50", throwIfNotFound: true);
         m_GLSFloatFXObjects_Value100 = m_GLSFloatFXObjects.FindAction("Value 100", throwIfNotFound: true);
-        m_GLSFloatFXObjects_ValueHover = m_GLSFloatFXObjects.FindAction("Value (Hover)", throwIfNotFound: true);
+        m_GLSFloatFXObjects_TweakValueHover = m_GLSFloatFXObjects.FindAction("Tweak Value (Hover)", throwIfNotFound: true);
         m_GLSFloatFXObjects_TweakEasingHover = m_GLSFloatFXObjects.FindAction("Tweak Easing (Hover)", throwIfNotFound: true);
         // Easings Selection
         m_EasingsSelection = asset.FindActionMap("Easings Selection", throwIfNotFound: true);
@@ -8232,7 +8295,6 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
         m_RotationObjects_RotateCounterClockwiseGrid = m_RotationObjects.FindAction("Rotate Counter Clockwise (Grid)", throwIfNotFound: true);
         m_RotationObjects_RotateCopyHover = m_RotationObjects.FindAction("Rotate Copy (Hover)", throwIfNotFound: true);
         m_RotationObjects_RotateCopyGrid = m_RotationObjects.FindAction("Rotate Copy (Grid)", throwIfNotFound: true);
-        m_RotationObjects_ModifyHover = m_RotationObjects.FindAction("Modify (Hover)", throwIfNotFound: true);
         m_RotationObjects_Invert = m_RotationObjects.FindAction("Invert", throwIfNotFound: true);
         m_RotationObjects_Rotation15Degrees = m_RotationObjects.FindAction("Rotation 15 Degrees", throwIfNotFound: true);
         m_RotationObjects_Rotation15DegreesHover = m_RotationObjects.FindAction("Rotation 15 Degrees (Hover)", throwIfNotFound: true);
@@ -8242,6 +8304,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
         m_RotationObjects_Rotation45DegreesHover = m_RotationObjects.FindAction("Rotation 45 Degrees (Hover)", throwIfNotFound: true);
         m_RotationObjects_Rotation60Degrees = m_RotationObjects.FindAction("Rotation 60 Degrees", throwIfNotFound: true);
         m_RotationObjects_Rotation60DegreesHover = m_RotationObjects.FindAction("Rotation 60 Degrees (Hover)", throwIfNotFound: true);
+        m_RotationObjects_TweakModifyHover = m_RotationObjects.FindAction("Tweak Modify (Hover)", throwIfNotFound: true);
     }
 
     ~@CMInput()
@@ -14163,7 +14226,8 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
     // GLS Group Tabs
     private readonly InputActionMap m_GLSGroupTabs;
     private List<IGLSGroupTabsActions> m_GLSGroupTabsActionsCallbackInterfaces = new List<IGLSGroupTabsActions>();
-    private readonly InputAction m_GLSGroupTabs_NextGroup;
+    private readonly InputAction m_GLSGroupTabs_NextGroupsPage;
+    private readonly InputAction m_GLSGroupTabs_PreviousGroupsPage;
     /// <summary>
     /// Provides access to input actions defined in input action map "GLS Group Tabs".
     /// </summary>
@@ -14176,9 +14240,13 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
         /// </summary>
         public GLSGroupTabsActions(@CMInput wrapper) { m_Wrapper = wrapper; }
         /// <summary>
-        /// Provides access to the underlying input action "GLSGroupTabs/NextGroup".
+        /// Provides access to the underlying input action "GLSGroupTabs/NextGroupsPage".
         /// </summary>
-        public InputAction @NextGroup => m_Wrapper.m_GLSGroupTabs_NextGroup;
+        public InputAction @NextGroupsPage => m_Wrapper.m_GLSGroupTabs_NextGroupsPage;
+        /// <summary>
+        /// Provides access to the underlying input action "GLSGroupTabs/PreviousGroupsPage".
+        /// </summary>
+        public InputAction @PreviousGroupsPage => m_Wrapper.m_GLSGroupTabs_PreviousGroupsPage;
         /// <summary>
         /// Provides access to the underlying input action map instance.
         /// </summary>
@@ -14205,9 +14273,12 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
         {
             if (instance == null || m_Wrapper.m_GLSGroupTabsActionsCallbackInterfaces.Contains(instance)) return;
             m_Wrapper.m_GLSGroupTabsActionsCallbackInterfaces.Add(instance);
-            @NextGroup.started += instance.OnNextGroup;
-            @NextGroup.performed += instance.OnNextGroup;
-            @NextGroup.canceled += instance.OnNextGroup;
+            @NextGroupsPage.started += instance.OnNextGroupsPage;
+            @NextGroupsPage.performed += instance.OnNextGroupsPage;
+            @NextGroupsPage.canceled += instance.OnNextGroupsPage;
+            @PreviousGroupsPage.started += instance.OnPreviousGroupsPage;
+            @PreviousGroupsPage.performed += instance.OnPreviousGroupsPage;
+            @PreviousGroupsPage.canceled += instance.OnPreviousGroupsPage;
         }
 
         /// <summary>
@@ -14219,9 +14290,12 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
         /// <seealso cref="GLSGroupTabsActions" />
         private void UnregisterCallbacks(IGLSGroupTabsActions instance)
         {
-            @NextGroup.started -= instance.OnNextGroup;
-            @NextGroup.performed -= instance.OnNextGroup;
-            @NextGroup.canceled -= instance.OnNextGroup;
+            @NextGroupsPage.started -= instance.OnNextGroupsPage;
+            @NextGroupsPage.performed -= instance.OnNextGroupsPage;
+            @NextGroupsPage.canceled -= instance.OnNextGroupsPage;
+            @PreviousGroupsPage.started -= instance.OnPreviousGroupsPage;
+            @PreviousGroupsPage.performed -= instance.OnPreviousGroupsPage;
+            @PreviousGroupsPage.canceled -= instance.OnPreviousGroupsPage;
         }
 
         /// <summary>
@@ -14377,9 +14451,11 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
     // GLS Color Objects
     private readonly InputActionMap m_GLSColorObjects;
     private List<IGLSColorObjectsActions> m_GLSColorObjectsActionsCallbackInterfaces = new List<IGLSColorObjectsActions>();
-    private readonly InputAction m_GLSColorObjects_Color0Light;
-    private readonly InputAction m_GLSColorObjects_Color1Light;
-    private readonly InputAction m_GLSColorObjects_ColorWLight;
+    private readonly InputAction m_GLSColorObjects_PrimaryLightColor;
+    private readonly InputAction m_GLSColorObjects_SecondaryLightColor;
+    private readonly InputAction m_GLSColorObjects_WhiteLightColor;
+    private readonly InputAction m_GLSColorObjects_ChromaLightColor;
+    private readonly InputAction m_GLSColorObjects_StrobeChromaColor;
     private readonly InputAction m_GLSColorObjects_Static0Brightness;
     private readonly InputAction m_GLSColorObjects_Static50Brightness;
     private readonly InputAction m_GLSColorObjects_Static100Brightness;
@@ -14399,14 +14475,14 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
     private readonly InputAction m_GLSColorObjects_Brightness100;
     private readonly InputAction m_GLSColorObjects_Brightness120;
     private readonly InputAction m_GLSColorObjects_Brightness150;
-    private readonly InputAction m_GLSColorObjects_BrightnessHover;
     private readonly InputAction m_GLSColorObjects_StrobeOn;
     private readonly InputAction m_GLSColorObjects_StrobeOff;
-    private readonly InputAction m_GLSColorObjects_StrobeFrequencyHover;
     private readonly InputAction m_GLSColorObjects_StrobeBrightness;
-    private readonly InputAction m_GLSColorObjects_StrobeBrightnessHover;
     private readonly InputAction m_GLSColorObjects_SoftStrobe;
     private readonly InputAction m_GLSColorObjects_MirrorHover;
+    private readonly InputAction m_GLSColorObjects_TweakBrightnessHover;
+    private readonly InputAction m_GLSColorObjects_TweakStrobeFrequencyHover;
+    private readonly InputAction m_GLSColorObjects_TweakStrobeBrightnessHover;
     private readonly InputAction m_GLSColorObjects_TweakEasingHover;
     /// <summary>
     /// Provides access to input actions defined in input action map "GLS Color Objects".
@@ -14420,17 +14496,25 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
         /// </summary>
         public GLSColorObjectsActions(@CMInput wrapper) { m_Wrapper = wrapper; }
         /// <summary>
-        /// Provides access to the underlying input action "GLSColorObjects/Color0Light".
+        /// Provides access to the underlying input action "GLSColorObjects/PrimaryLightColor".
         /// </summary>
-        public InputAction @Color0Light => m_Wrapper.m_GLSColorObjects_Color0Light;
+        public InputAction @PrimaryLightColor => m_Wrapper.m_GLSColorObjects_PrimaryLightColor;
         /// <summary>
-        /// Provides access to the underlying input action "GLSColorObjects/Color1Light".
+        /// Provides access to the underlying input action "GLSColorObjects/SecondaryLightColor".
         /// </summary>
-        public InputAction @Color1Light => m_Wrapper.m_GLSColorObjects_Color1Light;
+        public InputAction @SecondaryLightColor => m_Wrapper.m_GLSColorObjects_SecondaryLightColor;
         /// <summary>
-        /// Provides access to the underlying input action "GLSColorObjects/ColorWLight".
+        /// Provides access to the underlying input action "GLSColorObjects/WhiteLightColor".
         /// </summary>
-        public InputAction @ColorWLight => m_Wrapper.m_GLSColorObjects_ColorWLight;
+        public InputAction @WhiteLightColor => m_Wrapper.m_GLSColorObjects_WhiteLightColor;
+        /// <summary>
+        /// Provides access to the underlying input action "GLSColorObjects/ChromaLightColor".
+        /// </summary>
+        public InputAction @ChromaLightColor => m_Wrapper.m_GLSColorObjects_ChromaLightColor;
+        /// <summary>
+        /// Provides access to the underlying input action "GLSColorObjects/StrobeChromaColor".
+        /// </summary>
+        public InputAction @StrobeChromaColor => m_Wrapper.m_GLSColorObjects_StrobeChromaColor;
         /// <summary>
         /// Provides access to the underlying input action "GLSColorObjects/Static0Brightness".
         /// </summary>
@@ -14508,10 +14592,6 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
         /// </summary>
         public InputAction @Brightness150 => m_Wrapper.m_GLSColorObjects_Brightness150;
         /// <summary>
-        /// Provides access to the underlying input action "GLSColorObjects/BrightnessHover".
-        /// </summary>
-        public InputAction @BrightnessHover => m_Wrapper.m_GLSColorObjects_BrightnessHover;
-        /// <summary>
         /// Provides access to the underlying input action "GLSColorObjects/StrobeOn".
         /// </summary>
         public InputAction @StrobeOn => m_Wrapper.m_GLSColorObjects_StrobeOn;
@@ -14520,17 +14600,9 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
         /// </summary>
         public InputAction @StrobeOff => m_Wrapper.m_GLSColorObjects_StrobeOff;
         /// <summary>
-        /// Provides access to the underlying input action "GLSColorObjects/StrobeFrequencyHover".
-        /// </summary>
-        public InputAction @StrobeFrequencyHover => m_Wrapper.m_GLSColorObjects_StrobeFrequencyHover;
-        /// <summary>
         /// Provides access to the underlying input action "GLSColorObjects/StrobeBrightness".
         /// </summary>
         public InputAction @StrobeBrightness => m_Wrapper.m_GLSColorObjects_StrobeBrightness;
-        /// <summary>
-        /// Provides access to the underlying input action "GLSColorObjects/StrobeBrightnessHover".
-        /// </summary>
-        public InputAction @StrobeBrightnessHover => m_Wrapper.m_GLSColorObjects_StrobeBrightnessHover;
         /// <summary>
         /// Provides access to the underlying input action "GLSColorObjects/SoftStrobe".
         /// </summary>
@@ -14539,6 +14611,18 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
         /// Provides access to the underlying input action "GLSColorObjects/MirrorHover".
         /// </summary>
         public InputAction @MirrorHover => m_Wrapper.m_GLSColorObjects_MirrorHover;
+        /// <summary>
+        /// Provides access to the underlying input action "GLSColorObjects/TweakBrightnessHover".
+        /// </summary>
+        public InputAction @TweakBrightnessHover => m_Wrapper.m_GLSColorObjects_TweakBrightnessHover;
+        /// <summary>
+        /// Provides access to the underlying input action "GLSColorObjects/TweakStrobeFrequencyHover".
+        /// </summary>
+        public InputAction @TweakStrobeFrequencyHover => m_Wrapper.m_GLSColorObjects_TweakStrobeFrequencyHover;
+        /// <summary>
+        /// Provides access to the underlying input action "GLSColorObjects/TweakStrobeBrightnessHover".
+        /// </summary>
+        public InputAction @TweakStrobeBrightnessHover => m_Wrapper.m_GLSColorObjects_TweakStrobeBrightnessHover;
         /// <summary>
         /// Provides access to the underlying input action "GLSColorObjects/TweakEasingHover".
         /// </summary>
@@ -14569,15 +14653,21 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
         {
             if (instance == null || m_Wrapper.m_GLSColorObjectsActionsCallbackInterfaces.Contains(instance)) return;
             m_Wrapper.m_GLSColorObjectsActionsCallbackInterfaces.Add(instance);
-            @Color0Light.started += instance.OnColor0Light;
-            @Color0Light.performed += instance.OnColor0Light;
-            @Color0Light.canceled += instance.OnColor0Light;
-            @Color1Light.started += instance.OnColor1Light;
-            @Color1Light.performed += instance.OnColor1Light;
-            @Color1Light.canceled += instance.OnColor1Light;
-            @ColorWLight.started += instance.OnColorWLight;
-            @ColorWLight.performed += instance.OnColorWLight;
-            @ColorWLight.canceled += instance.OnColorWLight;
+            @PrimaryLightColor.started += instance.OnPrimaryLightColor;
+            @PrimaryLightColor.performed += instance.OnPrimaryLightColor;
+            @PrimaryLightColor.canceled += instance.OnPrimaryLightColor;
+            @SecondaryLightColor.started += instance.OnSecondaryLightColor;
+            @SecondaryLightColor.performed += instance.OnSecondaryLightColor;
+            @SecondaryLightColor.canceled += instance.OnSecondaryLightColor;
+            @WhiteLightColor.started += instance.OnWhiteLightColor;
+            @WhiteLightColor.performed += instance.OnWhiteLightColor;
+            @WhiteLightColor.canceled += instance.OnWhiteLightColor;
+            @ChromaLightColor.started += instance.OnChromaLightColor;
+            @ChromaLightColor.performed += instance.OnChromaLightColor;
+            @ChromaLightColor.canceled += instance.OnChromaLightColor;
+            @StrobeChromaColor.started += instance.OnStrobeChromaColor;
+            @StrobeChromaColor.performed += instance.OnStrobeChromaColor;
+            @StrobeChromaColor.canceled += instance.OnStrobeChromaColor;
             @Static0Brightness.started += instance.OnStatic0Brightness;
             @Static0Brightness.performed += instance.OnStatic0Brightness;
             @Static0Brightness.canceled += instance.OnStatic0Brightness;
@@ -14635,30 +14725,30 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
             @Brightness150.started += instance.OnBrightness150;
             @Brightness150.performed += instance.OnBrightness150;
             @Brightness150.canceled += instance.OnBrightness150;
-            @BrightnessHover.started += instance.OnBrightnessHover;
-            @BrightnessHover.performed += instance.OnBrightnessHover;
-            @BrightnessHover.canceled += instance.OnBrightnessHover;
             @StrobeOn.started += instance.OnStrobeOn;
             @StrobeOn.performed += instance.OnStrobeOn;
             @StrobeOn.canceled += instance.OnStrobeOn;
             @StrobeOff.started += instance.OnStrobeOff;
             @StrobeOff.performed += instance.OnStrobeOff;
             @StrobeOff.canceled += instance.OnStrobeOff;
-            @StrobeFrequencyHover.started += instance.OnStrobeFrequencyHover;
-            @StrobeFrequencyHover.performed += instance.OnStrobeFrequencyHover;
-            @StrobeFrequencyHover.canceled += instance.OnStrobeFrequencyHover;
             @StrobeBrightness.started += instance.OnStrobeBrightness;
             @StrobeBrightness.performed += instance.OnStrobeBrightness;
             @StrobeBrightness.canceled += instance.OnStrobeBrightness;
-            @StrobeBrightnessHover.started += instance.OnStrobeBrightnessHover;
-            @StrobeBrightnessHover.performed += instance.OnStrobeBrightnessHover;
-            @StrobeBrightnessHover.canceled += instance.OnStrobeBrightnessHover;
             @SoftStrobe.started += instance.OnSoftStrobe;
             @SoftStrobe.performed += instance.OnSoftStrobe;
             @SoftStrobe.canceled += instance.OnSoftStrobe;
             @MirrorHover.started += instance.OnMirrorHover;
             @MirrorHover.performed += instance.OnMirrorHover;
             @MirrorHover.canceled += instance.OnMirrorHover;
+            @TweakBrightnessHover.started += instance.OnTweakBrightnessHover;
+            @TweakBrightnessHover.performed += instance.OnTweakBrightnessHover;
+            @TweakBrightnessHover.canceled += instance.OnTweakBrightnessHover;
+            @TweakStrobeFrequencyHover.started += instance.OnTweakStrobeFrequencyHover;
+            @TweakStrobeFrequencyHover.performed += instance.OnTweakStrobeFrequencyHover;
+            @TweakStrobeFrequencyHover.canceled += instance.OnTweakStrobeFrequencyHover;
+            @TweakStrobeBrightnessHover.started += instance.OnTweakStrobeBrightnessHover;
+            @TweakStrobeBrightnessHover.performed += instance.OnTweakStrobeBrightnessHover;
+            @TweakStrobeBrightnessHover.canceled += instance.OnTweakStrobeBrightnessHover;
             @TweakEasingHover.started += instance.OnTweakEasingHover;
             @TweakEasingHover.performed += instance.OnTweakEasingHover;
             @TweakEasingHover.canceled += instance.OnTweakEasingHover;
@@ -14673,15 +14763,21 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
         /// <seealso cref="GLSColorObjectsActions" />
         private void UnregisterCallbacks(IGLSColorObjectsActions instance)
         {
-            @Color0Light.started -= instance.OnColor0Light;
-            @Color0Light.performed -= instance.OnColor0Light;
-            @Color0Light.canceled -= instance.OnColor0Light;
-            @Color1Light.started -= instance.OnColor1Light;
-            @Color1Light.performed -= instance.OnColor1Light;
-            @Color1Light.canceled -= instance.OnColor1Light;
-            @ColorWLight.started -= instance.OnColorWLight;
-            @ColorWLight.performed -= instance.OnColorWLight;
-            @ColorWLight.canceled -= instance.OnColorWLight;
+            @PrimaryLightColor.started -= instance.OnPrimaryLightColor;
+            @PrimaryLightColor.performed -= instance.OnPrimaryLightColor;
+            @PrimaryLightColor.canceled -= instance.OnPrimaryLightColor;
+            @SecondaryLightColor.started -= instance.OnSecondaryLightColor;
+            @SecondaryLightColor.performed -= instance.OnSecondaryLightColor;
+            @SecondaryLightColor.canceled -= instance.OnSecondaryLightColor;
+            @WhiteLightColor.started -= instance.OnWhiteLightColor;
+            @WhiteLightColor.performed -= instance.OnWhiteLightColor;
+            @WhiteLightColor.canceled -= instance.OnWhiteLightColor;
+            @ChromaLightColor.started -= instance.OnChromaLightColor;
+            @ChromaLightColor.performed -= instance.OnChromaLightColor;
+            @ChromaLightColor.canceled -= instance.OnChromaLightColor;
+            @StrobeChromaColor.started -= instance.OnStrobeChromaColor;
+            @StrobeChromaColor.performed -= instance.OnStrobeChromaColor;
+            @StrobeChromaColor.canceled -= instance.OnStrobeChromaColor;
             @Static0Brightness.started -= instance.OnStatic0Brightness;
             @Static0Brightness.performed -= instance.OnStatic0Brightness;
             @Static0Brightness.canceled -= instance.OnStatic0Brightness;
@@ -14739,30 +14835,30 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
             @Brightness150.started -= instance.OnBrightness150;
             @Brightness150.performed -= instance.OnBrightness150;
             @Brightness150.canceled -= instance.OnBrightness150;
-            @BrightnessHover.started -= instance.OnBrightnessHover;
-            @BrightnessHover.performed -= instance.OnBrightnessHover;
-            @BrightnessHover.canceled -= instance.OnBrightnessHover;
             @StrobeOn.started -= instance.OnStrobeOn;
             @StrobeOn.performed -= instance.OnStrobeOn;
             @StrobeOn.canceled -= instance.OnStrobeOn;
             @StrobeOff.started -= instance.OnStrobeOff;
             @StrobeOff.performed -= instance.OnStrobeOff;
             @StrobeOff.canceled -= instance.OnStrobeOff;
-            @StrobeFrequencyHover.started -= instance.OnStrobeFrequencyHover;
-            @StrobeFrequencyHover.performed -= instance.OnStrobeFrequencyHover;
-            @StrobeFrequencyHover.canceled -= instance.OnStrobeFrequencyHover;
             @StrobeBrightness.started -= instance.OnStrobeBrightness;
             @StrobeBrightness.performed -= instance.OnStrobeBrightness;
             @StrobeBrightness.canceled -= instance.OnStrobeBrightness;
-            @StrobeBrightnessHover.started -= instance.OnStrobeBrightnessHover;
-            @StrobeBrightnessHover.performed -= instance.OnStrobeBrightnessHover;
-            @StrobeBrightnessHover.canceled -= instance.OnStrobeBrightnessHover;
             @SoftStrobe.started -= instance.OnSoftStrobe;
             @SoftStrobe.performed -= instance.OnSoftStrobe;
             @SoftStrobe.canceled -= instance.OnSoftStrobe;
             @MirrorHover.started -= instance.OnMirrorHover;
             @MirrorHover.performed -= instance.OnMirrorHover;
             @MirrorHover.canceled -= instance.OnMirrorHover;
+            @TweakBrightnessHover.started -= instance.OnTweakBrightnessHover;
+            @TweakBrightnessHover.performed -= instance.OnTweakBrightnessHover;
+            @TweakBrightnessHover.canceled -= instance.OnTweakBrightnessHover;
+            @TweakStrobeFrequencyHover.started -= instance.OnTweakStrobeFrequencyHover;
+            @TweakStrobeFrequencyHover.performed -= instance.OnTweakStrobeFrequencyHover;
+            @TweakStrobeFrequencyHover.canceled -= instance.OnTweakStrobeFrequencyHover;
+            @TweakStrobeBrightnessHover.started -= instance.OnTweakStrobeBrightnessHover;
+            @TweakStrobeBrightnessHover.performed -= instance.OnTweakStrobeBrightnessHover;
+            @TweakStrobeBrightnessHover.canceled -= instance.OnTweakStrobeBrightnessHover;
             @TweakEasingHover.started -= instance.OnTweakEasingHover;
             @TweakEasingHover.performed -= instance.OnTweakEasingHover;
             @TweakEasingHover.canceled -= instance.OnTweakEasingHover;
@@ -14807,16 +14903,16 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
     private readonly InputAction m_GLSRotationObjects_Angle90;
     private readonly InputAction m_GLSRotationObjects_Angle180;
     private readonly InputAction m_GLSRotationObjects_Angle270;
-    private readonly InputAction m_GLSRotationObjects_AngleHover;
     private readonly InputAction m_GLSRotationObjects_RotationDirectionLeft;
     private readonly InputAction m_GLSRotationObjects_RotationDirectionAutomatic;
     private readonly InputAction m_GLSRotationObjects_RotationDirectionRight;
     private readonly InputAction m_GLSRotationObjects_ChangeLoopCount;
     private readonly InputAction m_GLSRotationObjects_ResetLoopCount;
+    private readonly InputAction m_GLSRotationObjects_TweakAngleHover;
     private readonly InputAction m_GLSRotationObjects_TweakLoopHover;
     private readonly InputAction m_GLSRotationObjects_TweakEasingHover;
-    private readonly InputAction m_GLSRotationObjects_CycleAxisHover;
-    private readonly InputAction m_GLSRotationObjects_CycleDirectionHover;
+    private readonly InputAction m_GLSRotationObjects_TweakAxisHover;
+    private readonly InputAction m_GLSRotationObjects_TweakDirectionHover;
     /// <summary>
     /// Provides access to input actions defined in input action map "GLS Rotation Objects".
     /// </summary>
@@ -14845,10 +14941,6 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
         /// </summary>
         public InputAction @Angle270 => m_Wrapper.m_GLSRotationObjects_Angle270;
         /// <summary>
-        /// Provides access to the underlying input action "GLSRotationObjects/AngleHover".
-        /// </summary>
-        public InputAction @AngleHover => m_Wrapper.m_GLSRotationObjects_AngleHover;
-        /// <summary>
         /// Provides access to the underlying input action "GLSRotationObjects/RotationDirectionLeft".
         /// </summary>
         public InputAction @RotationDirectionLeft => m_Wrapper.m_GLSRotationObjects_RotationDirectionLeft;
@@ -14869,6 +14961,10 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
         /// </summary>
         public InputAction @ResetLoopCount => m_Wrapper.m_GLSRotationObjects_ResetLoopCount;
         /// <summary>
+        /// Provides access to the underlying input action "GLSRotationObjects/TweakAngleHover".
+        /// </summary>
+        public InputAction @TweakAngleHover => m_Wrapper.m_GLSRotationObjects_TweakAngleHover;
+        /// <summary>
         /// Provides access to the underlying input action "GLSRotationObjects/TweakLoopHover".
         /// </summary>
         public InputAction @TweakLoopHover => m_Wrapper.m_GLSRotationObjects_TweakLoopHover;
@@ -14877,13 +14973,13 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
         /// </summary>
         public InputAction @TweakEasingHover => m_Wrapper.m_GLSRotationObjects_TweakEasingHover;
         /// <summary>
-        /// Provides access to the underlying input action "GLSRotationObjects/CycleAxisHover".
+        /// Provides access to the underlying input action "GLSRotationObjects/TweakAxisHover".
         /// </summary>
-        public InputAction @CycleAxisHover => m_Wrapper.m_GLSRotationObjects_CycleAxisHover;
+        public InputAction @TweakAxisHover => m_Wrapper.m_GLSRotationObjects_TweakAxisHover;
         /// <summary>
-        /// Provides access to the underlying input action "GLSRotationObjects/CycleDirectionHover".
+        /// Provides access to the underlying input action "GLSRotationObjects/TweakDirectionHover".
         /// </summary>
-        public InputAction @CycleDirectionHover => m_Wrapper.m_GLSRotationObjects_CycleDirectionHover;
+        public InputAction @TweakDirectionHover => m_Wrapper.m_GLSRotationObjects_TweakDirectionHover;
         /// <summary>
         /// Provides access to the underlying input action map instance.
         /// </summary>
@@ -14922,9 +15018,6 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
             @Angle270.started += instance.OnAngle270;
             @Angle270.performed += instance.OnAngle270;
             @Angle270.canceled += instance.OnAngle270;
-            @AngleHover.started += instance.OnAngleHover;
-            @AngleHover.performed += instance.OnAngleHover;
-            @AngleHover.canceled += instance.OnAngleHover;
             @RotationDirectionLeft.started += instance.OnRotationDirectionLeft;
             @RotationDirectionLeft.performed += instance.OnRotationDirectionLeft;
             @RotationDirectionLeft.canceled += instance.OnRotationDirectionLeft;
@@ -14940,18 +15033,21 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
             @ResetLoopCount.started += instance.OnResetLoopCount;
             @ResetLoopCount.performed += instance.OnResetLoopCount;
             @ResetLoopCount.canceled += instance.OnResetLoopCount;
+            @TweakAngleHover.started += instance.OnTweakAngleHover;
+            @TweakAngleHover.performed += instance.OnTweakAngleHover;
+            @TweakAngleHover.canceled += instance.OnTweakAngleHover;
             @TweakLoopHover.started += instance.OnTweakLoopHover;
             @TweakLoopHover.performed += instance.OnTweakLoopHover;
             @TweakLoopHover.canceled += instance.OnTweakLoopHover;
             @TweakEasingHover.started += instance.OnTweakEasingHover;
             @TweakEasingHover.performed += instance.OnTweakEasingHover;
             @TweakEasingHover.canceled += instance.OnTweakEasingHover;
-            @CycleAxisHover.started += instance.OnCycleAxisHover;
-            @CycleAxisHover.performed += instance.OnCycleAxisHover;
-            @CycleAxisHover.canceled += instance.OnCycleAxisHover;
-            @CycleDirectionHover.started += instance.OnCycleDirectionHover;
-            @CycleDirectionHover.performed += instance.OnCycleDirectionHover;
-            @CycleDirectionHover.canceled += instance.OnCycleDirectionHover;
+            @TweakAxisHover.started += instance.OnTweakAxisHover;
+            @TweakAxisHover.performed += instance.OnTweakAxisHover;
+            @TweakAxisHover.canceled += instance.OnTweakAxisHover;
+            @TweakDirectionHover.started += instance.OnTweakDirectionHover;
+            @TweakDirectionHover.performed += instance.OnTweakDirectionHover;
+            @TweakDirectionHover.canceled += instance.OnTweakDirectionHover;
         }
 
         /// <summary>
@@ -14975,9 +15071,6 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
             @Angle270.started -= instance.OnAngle270;
             @Angle270.performed -= instance.OnAngle270;
             @Angle270.canceled -= instance.OnAngle270;
-            @AngleHover.started -= instance.OnAngleHover;
-            @AngleHover.performed -= instance.OnAngleHover;
-            @AngleHover.canceled -= instance.OnAngleHover;
             @RotationDirectionLeft.started -= instance.OnRotationDirectionLeft;
             @RotationDirectionLeft.performed -= instance.OnRotationDirectionLeft;
             @RotationDirectionLeft.canceled -= instance.OnRotationDirectionLeft;
@@ -14993,18 +15086,21 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
             @ResetLoopCount.started -= instance.OnResetLoopCount;
             @ResetLoopCount.performed -= instance.OnResetLoopCount;
             @ResetLoopCount.canceled -= instance.OnResetLoopCount;
+            @TweakAngleHover.started -= instance.OnTweakAngleHover;
+            @TweakAngleHover.performed -= instance.OnTweakAngleHover;
+            @TweakAngleHover.canceled -= instance.OnTweakAngleHover;
             @TweakLoopHover.started -= instance.OnTweakLoopHover;
             @TweakLoopHover.performed -= instance.OnTweakLoopHover;
             @TweakLoopHover.canceled -= instance.OnTweakLoopHover;
             @TweakEasingHover.started -= instance.OnTweakEasingHover;
             @TweakEasingHover.performed -= instance.OnTweakEasingHover;
             @TweakEasingHover.canceled -= instance.OnTweakEasingHover;
-            @CycleAxisHover.started -= instance.OnCycleAxisHover;
-            @CycleAxisHover.performed -= instance.OnCycleAxisHover;
-            @CycleAxisHover.canceled -= instance.OnCycleAxisHover;
-            @CycleDirectionHover.started -= instance.OnCycleDirectionHover;
-            @CycleDirectionHover.performed -= instance.OnCycleDirectionHover;
-            @CycleDirectionHover.canceled -= instance.OnCycleDirectionHover;
+            @TweakAxisHover.started -= instance.OnTweakAxisHover;
+            @TweakAxisHover.performed -= instance.OnTweakAxisHover;
+            @TweakAxisHover.canceled -= instance.OnTweakAxisHover;
+            @TweakDirectionHover.started -= instance.OnTweakDirectionHover;
+            @TweakDirectionHover.performed -= instance.OnTweakDirectionHover;
+            @TweakDirectionHover.canceled -= instance.OnTweakDirectionHover;
         }
 
         /// <summary>
@@ -15047,9 +15143,9 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
     private readonly InputAction m_GLSTranslationObjects_Value0;
     private readonly InputAction m_GLSTranslationObjects_Value50;
     private readonly InputAction m_GLSTranslationObjects_Value100;
-    private readonly InputAction m_GLSTranslationObjects_ValueHover;
+    private readonly InputAction m_GLSTranslationObjects_TweakValueHover;
     private readonly InputAction m_GLSTranslationObjects_TweakEasingHover;
-    private readonly InputAction m_GLSTranslationObjects_CycleAxisHover;
+    private readonly InputAction m_GLSTranslationObjects_TweakAxisHover;
     /// <summary>
     /// Provides access to input actions defined in input action map "GLS Translation Objects".
     /// </summary>
@@ -15082,17 +15178,17 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
         /// </summary>
         public InputAction @Value100 => m_Wrapper.m_GLSTranslationObjects_Value100;
         /// <summary>
-        /// Provides access to the underlying input action "GLSTranslationObjects/ValueHover".
+        /// Provides access to the underlying input action "GLSTranslationObjects/TweakValueHover".
         /// </summary>
-        public InputAction @ValueHover => m_Wrapper.m_GLSTranslationObjects_ValueHover;
+        public InputAction @TweakValueHover => m_Wrapper.m_GLSTranslationObjects_TweakValueHover;
         /// <summary>
         /// Provides access to the underlying input action "GLSTranslationObjects/TweakEasingHover".
         /// </summary>
         public InputAction @TweakEasingHover => m_Wrapper.m_GLSTranslationObjects_TweakEasingHover;
         /// <summary>
-        /// Provides access to the underlying input action "GLSTranslationObjects/CycleAxisHover".
+        /// Provides access to the underlying input action "GLSTranslationObjects/TweakAxisHover".
         /// </summary>
-        public InputAction @CycleAxisHover => m_Wrapper.m_GLSTranslationObjects_CycleAxisHover;
+        public InputAction @TweakAxisHover => m_Wrapper.m_GLSTranslationObjects_TweakAxisHover;
         /// <summary>
         /// Provides access to the underlying input action map instance.
         /// </summary>
@@ -15134,15 +15230,15 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
             @Value100.started += instance.OnValue100;
             @Value100.performed += instance.OnValue100;
             @Value100.canceled += instance.OnValue100;
-            @ValueHover.started += instance.OnValueHover;
-            @ValueHover.performed += instance.OnValueHover;
-            @ValueHover.canceled += instance.OnValueHover;
+            @TweakValueHover.started += instance.OnTweakValueHover;
+            @TweakValueHover.performed += instance.OnTweakValueHover;
+            @TweakValueHover.canceled += instance.OnTweakValueHover;
             @TweakEasingHover.started += instance.OnTweakEasingHover;
             @TweakEasingHover.performed += instance.OnTweakEasingHover;
             @TweakEasingHover.canceled += instance.OnTweakEasingHover;
-            @CycleAxisHover.started += instance.OnCycleAxisHover;
-            @CycleAxisHover.performed += instance.OnCycleAxisHover;
-            @CycleAxisHover.canceled += instance.OnCycleAxisHover;
+            @TweakAxisHover.started += instance.OnTweakAxisHover;
+            @TweakAxisHover.performed += instance.OnTweakAxisHover;
+            @TweakAxisHover.canceled += instance.OnTweakAxisHover;
         }
 
         /// <summary>
@@ -15169,15 +15265,15 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
             @Value100.started -= instance.OnValue100;
             @Value100.performed -= instance.OnValue100;
             @Value100.canceled -= instance.OnValue100;
-            @ValueHover.started -= instance.OnValueHover;
-            @ValueHover.performed -= instance.OnValueHover;
-            @ValueHover.canceled -= instance.OnValueHover;
+            @TweakValueHover.started -= instance.OnTweakValueHover;
+            @TweakValueHover.performed -= instance.OnTweakValueHover;
+            @TweakValueHover.canceled -= instance.OnTweakValueHover;
             @TweakEasingHover.started -= instance.OnTweakEasingHover;
             @TweakEasingHover.performed -= instance.OnTweakEasingHover;
             @TweakEasingHover.canceled -= instance.OnTweakEasingHover;
-            @CycleAxisHover.started -= instance.OnCycleAxisHover;
-            @CycleAxisHover.performed -= instance.OnCycleAxisHover;
-            @CycleAxisHover.canceled -= instance.OnCycleAxisHover;
+            @TweakAxisHover.started -= instance.OnTweakAxisHover;
+            @TweakAxisHover.performed -= instance.OnTweakAxisHover;
+            @TweakAxisHover.canceled -= instance.OnTweakAxisHover;
         }
 
         /// <summary>
@@ -15220,7 +15316,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
     private readonly InputAction m_GLSFloatFXObjects_Value0;
     private readonly InputAction m_GLSFloatFXObjects_Value50;
     private readonly InputAction m_GLSFloatFXObjects_Value100;
-    private readonly InputAction m_GLSFloatFXObjects_ValueHover;
+    private readonly InputAction m_GLSFloatFXObjects_TweakValueHover;
     private readonly InputAction m_GLSFloatFXObjects_TweakEasingHover;
     /// <summary>
     /// Provides access to input actions defined in input action map "GLS FloatFX Objects".
@@ -15254,9 +15350,9 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
         /// </summary>
         public InputAction @Value100 => m_Wrapper.m_GLSFloatFXObjects_Value100;
         /// <summary>
-        /// Provides access to the underlying input action "GLSFloatFXObjects/ValueHover".
+        /// Provides access to the underlying input action "GLSFloatFXObjects/TweakValueHover".
         /// </summary>
-        public InputAction @ValueHover => m_Wrapper.m_GLSFloatFXObjects_ValueHover;
+        public InputAction @TweakValueHover => m_Wrapper.m_GLSFloatFXObjects_TweakValueHover;
         /// <summary>
         /// Provides access to the underlying input action "GLSFloatFXObjects/TweakEasingHover".
         /// </summary>
@@ -15302,9 +15398,9 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
             @Value100.started += instance.OnValue100;
             @Value100.performed += instance.OnValue100;
             @Value100.canceled += instance.OnValue100;
-            @ValueHover.started += instance.OnValueHover;
-            @ValueHover.performed += instance.OnValueHover;
-            @ValueHover.canceled += instance.OnValueHover;
+            @TweakValueHover.started += instance.OnTweakValueHover;
+            @TweakValueHover.performed += instance.OnTweakValueHover;
+            @TweakValueHover.canceled += instance.OnTweakValueHover;
             @TweakEasingHover.started += instance.OnTweakEasingHover;
             @TweakEasingHover.performed += instance.OnTweakEasingHover;
             @TweakEasingHover.canceled += instance.OnTweakEasingHover;
@@ -15334,9 +15430,9 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
             @Value100.started -= instance.OnValue100;
             @Value100.performed -= instance.OnValue100;
             @Value100.canceled -= instance.OnValue100;
-            @ValueHover.started -= instance.OnValueHover;
-            @ValueHover.performed -= instance.OnValueHover;
-            @ValueHover.canceled -= instance.OnValueHover;
+            @TweakValueHover.started -= instance.OnTweakValueHover;
+            @TweakValueHover.performed -= instance.OnTweakValueHover;
+            @TweakValueHover.canceled -= instance.OnTweakValueHover;
             @TweakEasingHover.started -= instance.OnTweakEasingHover;
             @TweakEasingHover.performed -= instance.OnTweakEasingHover;
             @TweakEasingHover.canceled -= instance.OnTweakEasingHover;
@@ -15674,7 +15770,6 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
     private readonly InputAction m_RotationObjects_RotateCounterClockwiseGrid;
     private readonly InputAction m_RotationObjects_RotateCopyHover;
     private readonly InputAction m_RotationObjects_RotateCopyGrid;
-    private readonly InputAction m_RotationObjects_ModifyHover;
     private readonly InputAction m_RotationObjects_Invert;
     private readonly InputAction m_RotationObjects_Rotation15Degrees;
     private readonly InputAction m_RotationObjects_Rotation15DegreesHover;
@@ -15684,6 +15779,7 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
     private readonly InputAction m_RotationObjects_Rotation45DegreesHover;
     private readonly InputAction m_RotationObjects_Rotation60Degrees;
     private readonly InputAction m_RotationObjects_Rotation60DegreesHover;
+    private readonly InputAction m_RotationObjects_TweakModifyHover;
     /// <summary>
     /// Provides access to input actions defined in input action map "Rotation Objects".
     /// </summary>
@@ -15720,10 +15816,6 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
         /// </summary>
         public InputAction @RotateCopyGrid => m_Wrapper.m_RotationObjects_RotateCopyGrid;
         /// <summary>
-        /// Provides access to the underlying input action "RotationObjects/ModifyHover".
-        /// </summary>
-        public InputAction @ModifyHover => m_Wrapper.m_RotationObjects_ModifyHover;
-        /// <summary>
         /// Provides access to the underlying input action "RotationObjects/Invert".
         /// </summary>
         public InputAction @Invert => m_Wrapper.m_RotationObjects_Invert;
@@ -15759,6 +15851,10 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
         /// Provides access to the underlying input action "RotationObjects/Rotation60DegreesHover".
         /// </summary>
         public InputAction @Rotation60DegreesHover => m_Wrapper.m_RotationObjects_Rotation60DegreesHover;
+        /// <summary>
+        /// Provides access to the underlying input action "RotationObjects/TweakModifyHover".
+        /// </summary>
+        public InputAction @TweakModifyHover => m_Wrapper.m_RotationObjects_TweakModifyHover;
         /// <summary>
         /// Provides access to the underlying input action map instance.
         /// </summary>
@@ -15803,9 +15899,6 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
             @RotateCopyGrid.started += instance.OnRotateCopyGrid;
             @RotateCopyGrid.performed += instance.OnRotateCopyGrid;
             @RotateCopyGrid.canceled += instance.OnRotateCopyGrid;
-            @ModifyHover.started += instance.OnModifyHover;
-            @ModifyHover.performed += instance.OnModifyHover;
-            @ModifyHover.canceled += instance.OnModifyHover;
             @Invert.started += instance.OnInvert;
             @Invert.performed += instance.OnInvert;
             @Invert.canceled += instance.OnInvert;
@@ -15833,6 +15926,9 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
             @Rotation60DegreesHover.started += instance.OnRotation60DegreesHover;
             @Rotation60DegreesHover.performed += instance.OnRotation60DegreesHover;
             @Rotation60DegreesHover.canceled += instance.OnRotation60DegreesHover;
+            @TweakModifyHover.started += instance.OnTweakModifyHover;
+            @TweakModifyHover.performed += instance.OnTweakModifyHover;
+            @TweakModifyHover.canceled += instance.OnTweakModifyHover;
         }
 
         /// <summary>
@@ -15862,9 +15958,6 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
             @RotateCopyGrid.started -= instance.OnRotateCopyGrid;
             @RotateCopyGrid.performed -= instance.OnRotateCopyGrid;
             @RotateCopyGrid.canceled -= instance.OnRotateCopyGrid;
-            @ModifyHover.started -= instance.OnModifyHover;
-            @ModifyHover.performed -= instance.OnModifyHover;
-            @ModifyHover.canceled -= instance.OnModifyHover;
             @Invert.started -= instance.OnInvert;
             @Invert.performed -= instance.OnInvert;
             @Invert.canceled -= instance.OnInvert;
@@ -15892,6 +15985,9 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
             @Rotation60DegreesHover.started -= instance.OnRotation60DegreesHover;
             @Rotation60DegreesHover.performed -= instance.OnRotation60DegreesHover;
             @Rotation60DegreesHover.canceled -= instance.OnRotation60DegreesHover;
+            @TweakModifyHover.started -= instance.OnTweakModifyHover;
+            @TweakModifyHover.performed -= instance.OnTweakModifyHover;
+            @TweakModifyHover.canceled -= instance.OnTweakModifyHover;
         }
 
         /// <summary>
@@ -17304,14 +17400,14 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
     public interface IChainObjectsActions
     {
         /// <summary>
-        /// Method invoked when associated input action "TweakChainCount" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+        /// Method invoked when associated input action "Tweak Chain Count" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
         /// </summary>
         /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
         /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
         /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
         void OnTweakChainCount(InputAction.CallbackContext context);
         /// <summary>
-        /// Method invoked when associated input action "TweakChainSquish" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+        /// Method invoked when associated input action "Tweak Chain Squish" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
         /// </summary>
         /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
         /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
@@ -17415,12 +17511,19 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
     public interface IGLSGroupTabsActions
     {
         /// <summary>
-        /// Method invoked when associated input action "Next Group" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+        /// Method invoked when associated input action "Next Groups Page" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
         /// </summary>
         /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
         /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
         /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
-        void OnNextGroup(InputAction.CallbackContext context);
+        void OnNextGroupsPage(InputAction.CallbackContext context);
+        /// <summary>
+        /// Method invoked when associated input action "Previous Groups Page" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+        /// </summary>
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+        void OnPreviousGroupsPage(InputAction.CallbackContext context);
     }
     /// <summary>
     /// Interface to implement callback methods for all input action callbacks associated with input actions defined by "GLS Group Select" which allows adding and removing callbacks.
@@ -17459,26 +17562,40 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
     public interface IGLSColorObjectsActions
     {
         /// <summary>
-        /// Method invoked when associated input action "Color0 Light" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+        /// Method invoked when associated input action "Primary Light Color" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
         /// </summary>
         /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
         /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
         /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
-        void OnColor0Light(InputAction.CallbackContext context);
+        void OnPrimaryLightColor(InputAction.CallbackContext context);
         /// <summary>
-        /// Method invoked when associated input action "Color1 Light" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+        /// Method invoked when associated input action "Secondary Light Color" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
         /// </summary>
         /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
         /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
         /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
-        void OnColor1Light(InputAction.CallbackContext context);
+        void OnSecondaryLightColor(InputAction.CallbackContext context);
         /// <summary>
-        /// Method invoked when associated input action "ColorW Light" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+        /// Method invoked when associated input action "White Light Color" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
         /// </summary>
         /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
         /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
         /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
-        void OnColorWLight(InputAction.CallbackContext context);
+        void OnWhiteLightColor(InputAction.CallbackContext context);
+        /// <summary>
+        /// Method invoked when associated input action "Chroma Light Color" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+        /// </summary>
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+        void OnChromaLightColor(InputAction.CallbackContext context);
+        /// <summary>
+        /// Method invoked when associated input action "Strobe Chroma Color" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+        /// </summary>
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+        void OnStrobeChromaColor(InputAction.CallbackContext context);
         /// <summary>
         /// Method invoked when associated input action "Static 0 Brightness" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
         /// </summary>
@@ -17613,13 +17730,6 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
         /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
         void OnBrightness150(InputAction.CallbackContext context);
         /// <summary>
-        /// Method invoked when associated input action "Brightness (Hover)" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
-        /// </summary>
-        /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
-        /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
-        /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
-        void OnBrightnessHover(InputAction.CallbackContext context);
-        /// <summary>
         /// Method invoked when associated input action "Strobe On" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
         /// </summary>
         /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
@@ -17634,26 +17744,12 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
         /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
         void OnStrobeOff(InputAction.CallbackContext context);
         /// <summary>
-        /// Method invoked when associated input action "Strobe Frequency (Hover)" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
-        /// </summary>
-        /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
-        /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
-        /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
-        void OnStrobeFrequencyHover(InputAction.CallbackContext context);
-        /// <summary>
         /// Method invoked when associated input action "Strobe Brightness" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
         /// </summary>
         /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
         /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
         /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
         void OnStrobeBrightness(InputAction.CallbackContext context);
-        /// <summary>
-        /// Method invoked when associated input action "Strobe Brightness (Hover)" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
-        /// </summary>
-        /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
-        /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
-        /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
-        void OnStrobeBrightnessHover(InputAction.CallbackContext context);
         /// <summary>
         /// Method invoked when associated input action "Soft Strobe" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
         /// </summary>
@@ -17668,6 +17764,27 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
         /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
         /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
         void OnMirrorHover(InputAction.CallbackContext context);
+        /// <summary>
+        /// Method invoked when associated input action "Tweak Brightness (Hover)" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+        /// </summary>
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+        void OnTweakBrightnessHover(InputAction.CallbackContext context);
+        /// <summary>
+        /// Method invoked when associated input action "Tweak Strobe Frequency (Hover)" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+        /// </summary>
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+        void OnTweakStrobeFrequencyHover(InputAction.CallbackContext context);
+        /// <summary>
+        /// Method invoked when associated input action "Tweak Strobe Brightness (Hover)" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+        /// </summary>
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+        void OnTweakStrobeBrightnessHover(InputAction.CallbackContext context);
         /// <summary>
         /// Method invoked when associated input action "Tweak Easing (Hover)" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
         /// </summary>
@@ -17712,13 +17829,6 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
         /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
         void OnAngle270(InputAction.CallbackContext context);
         /// <summary>
-        /// Method invoked when associated input action "Angle (Hover)" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
-        /// </summary>
-        /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
-        /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
-        /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
-        void OnAngleHover(InputAction.CallbackContext context);
-        /// <summary>
         /// Method invoked when associated input action "Rotation Direction (Left)" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
         /// </summary>
         /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
@@ -17754,6 +17864,13 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
         /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
         void OnResetLoopCount(InputAction.CallbackContext context);
         /// <summary>
+        /// Method invoked when associated input action "Tweak Angle (Hover)" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+        /// </summary>
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+        void OnTweakAngleHover(InputAction.CallbackContext context);
+        /// <summary>
         /// Method invoked when associated input action "Tweak Loop (Hover)" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
         /// </summary>
         /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
@@ -17768,19 +17885,19 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
         /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
         void OnTweakEasingHover(InputAction.CallbackContext context);
         /// <summary>
-        /// Method invoked when associated input action "Cycle Axis (Hover)" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+        /// Method invoked when associated input action "Tweak Axis (Hover)" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
         /// </summary>
         /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
         /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
         /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
-        void OnCycleAxisHover(InputAction.CallbackContext context);
+        void OnTweakAxisHover(InputAction.CallbackContext context);
         /// <summary>
-        /// Method invoked when associated input action "Cycle Direction (Hover)" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+        /// Method invoked when associated input action "Tweak Direction (Hover)" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
         /// </summary>
         /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
         /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
         /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
-        void OnCycleDirectionHover(InputAction.CallbackContext context);
+        void OnTweakDirectionHover(InputAction.CallbackContext context);
     }
     /// <summary>
     /// Interface to implement callback methods for all input action callbacks associated with input actions defined by "GLS Translation Objects" which allows adding and removing callbacks.
@@ -17825,12 +17942,12 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
         /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
         void OnValue100(InputAction.CallbackContext context);
         /// <summary>
-        /// Method invoked when associated input action "Value (Hover)" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+        /// Method invoked when associated input action "Tweak Value (Hover)" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
         /// </summary>
         /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
         /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
         /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
-        void OnValueHover(InputAction.CallbackContext context);
+        void OnTweakValueHover(InputAction.CallbackContext context);
         /// <summary>
         /// Method invoked when associated input action "Tweak Easing (Hover)" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
         /// </summary>
@@ -17839,12 +17956,12 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
         /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
         void OnTweakEasingHover(InputAction.CallbackContext context);
         /// <summary>
-        /// Method invoked when associated input action "Cycle Axis (Hover)" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+        /// Method invoked when associated input action "Tweak Axis (Hover)" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
         /// </summary>
         /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
         /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
         /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
-        void OnCycleAxisHover(InputAction.CallbackContext context);
+        void OnTweakAxisHover(InputAction.CallbackContext context);
     }
     /// <summary>
     /// Interface to implement callback methods for all input action callbacks associated with input actions defined by "GLS FloatFX Objects" which allows adding and removing callbacks.
@@ -17889,12 +18006,12 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
         /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
         void OnValue100(InputAction.CallbackContext context);
         /// <summary>
-        /// Method invoked when associated input action "Value (Hover)" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+        /// Method invoked when associated input action "Tweak Value (Hover)" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
         /// </summary>
         /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
         /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
         /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
-        void OnValueHover(InputAction.CallbackContext context);
+        void OnTweakValueHover(InputAction.CallbackContext context);
         /// <summary>
         /// Method invoked when associated input action "Tweak Easing (Hover)" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
         /// </summary>
@@ -18046,13 +18163,6 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
         /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
         void OnRotateCopyGrid(InputAction.CallbackContext context);
         /// <summary>
-        /// Method invoked when associated input action "Modify (Hover)" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
-        /// </summary>
-        /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
-        /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
-        /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
-        void OnModifyHover(InputAction.CallbackContext context);
-        /// <summary>
         /// Method invoked when associated input action "Invert" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
         /// </summary>
         /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
@@ -18115,5 +18225,12 @@ public partial class @CMInput: IInputActionCollection2, IDisposable
         /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
         /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
         void OnRotation60DegreesHover(InputAction.CallbackContext context);
+        /// <summary>
+        /// Method invoked when associated input action "Tweak Modify (Hover)" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+        /// </summary>
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+        void OnTweakModifyHover(InputAction.CallbackContext context);
     }
 }

--- a/Assets/Input/Master.inputactions
+++ b/Assets/Input/Master.inputactions
@@ -4737,7 +4737,7 @@
             "id": "08122fed-0d6b-4568-96df-eecf068a7222",
             "actions": [
                 {
-                    "name": "TweakChainCount",
+                    "name": "Tweak Chain Count",
                     "type": "Value",
                     "id": "1c7ce6e2-975c-4349-ad23-ec3d12a4c640",
                     "expectedControlType": "Axis",
@@ -4746,7 +4746,7 @@
                     "initialStateCheck": true
                 },
                 {
-                    "name": "TweakChainSquish",
+                    "name": "Tweak Chain Squish",
                     "type": "Value",
                     "id": "afed819c-0511-4541-be42-2272b16fd4cb",
                     "expectedControlType": "Axis",
@@ -4763,7 +4763,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "TweakChainCount",
+                    "action": "Tweak Chain Count",
                     "isComposite": true,
                     "isPartOfComposite": false
                 },
@@ -4774,7 +4774,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "TweakChainCount",
+                    "action": "Tweak Chain Count",
                     "isComposite": false,
                     "isPartOfComposite": true
                 },
@@ -4785,7 +4785,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "TweakChainCount",
+                    "action": "Tweak Chain Count",
                     "isComposite": false,
                     "isPartOfComposite": true
                 },
@@ -4796,7 +4796,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "TweakChainSquish",
+                    "action": "Tweak Chain Squish",
                     "isComposite": true,
                     "isPartOfComposite": false
                 },
@@ -4807,7 +4807,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "TweakChainSquish",
+                    "action": "Tweak Chain Squish",
                     "isComposite": false,
                     "isPartOfComposite": true
                 },
@@ -4818,7 +4818,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "TweakChainSquish",
+                    "action": "Tweak Chain Squish",
                     "isComposite": false,
                     "isPartOfComposite": true
                 }
@@ -5064,9 +5064,18 @@
             "id": "e4de6044-1de0-48cb-bbea-f07027b50a3d",
             "actions": [
                 {
-                    "name": "Next Group",
+                    "name": "Next Groups Page",
                     "type": "Button",
                     "id": "49fa1c10-5df7-407e-9650-0b7d8ae1e6fc",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "Press",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Previous Groups Page",
+                    "type": "Button",
+                    "id": "fef538eb-56aa-48ae-9cb5-5558c6d23d8f",
                     "expectedControlType": "",
                     "processors": "",
                     "interactions": "Press",
@@ -5075,13 +5084,24 @@
             ],
             "bindings": [
                 {
-                    "name": "",
+                    "name": "Next",
                     "id": "c064d927-7ad4-4e19-88ae-08b52a91d215",
-                    "path": "<Keyboard>/tab",
+                    "path": "<Keyboard>/pageUp",
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "Next Group",
+                    "action": "Next Groups Page",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "Previous",
+                    "id": "c097e07c-7c52-46cc-8570-c1d67b8ad268",
+                    "path": "<Keyboard>/pageDown",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Previous Groups Page",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }
@@ -5160,7 +5180,7 @@
             "id": "37f9e19f-0f82-481f-ac35-5c6bf1432eef",
             "actions": [
                 {
-                    "name": "Color0 Light",
+                    "name": "Primary Light Color",
                     "type": "Button",
                     "id": "0806de86-cc21-48e2-8fbd-a03530b1ba3c",
                     "expectedControlType": "",
@@ -5169,7 +5189,7 @@
                     "initialStateCheck": false
                 },
                 {
-                    "name": "Color1 Light",
+                    "name": "Secondary Light Color",
                     "type": "Button",
                     "id": "52046f1f-96a3-4708-aeb5-9835f7dffe8d",
                     "expectedControlType": "",
@@ -5178,9 +5198,27 @@
                     "initialStateCheck": false
                 },
                 {
-                    "name": "ColorW Light",
+                    "name": "White Light Color",
                     "type": "Button",
                     "id": "369ad4a4-f027-441d-99ad-07a501a7f04b",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "Press",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Chroma Light Color",
+                    "type": "Button",
+                    "id": "a413f5eb-19a8-4e2e-a074-d144058054d7",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "Press",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Strobe Chroma Color",
+                    "type": "Button",
+                    "id": "785f959c-61be-4141-a167-ed33780790d1",
                     "expectedControlType": "",
                     "processors": "",
                     "interactions": "Press",
@@ -5358,15 +5396,6 @@
                     "initialStateCheck": false
                 },
                 {
-                    "name": "Brightness (Hover)",
-                    "type": "Button",
-                    "id": "12efb566-15c0-4db8-a04f-f1af295c8e79",
-                    "expectedControlType": "",
-                    "processors": "",
-                    "interactions": "Press",
-                    "initialStateCheck": false
-                },
-                {
                     "name": "Strobe On",
                     "type": "Button",
                     "id": "f3cce743-71be-4383-a125-b5431b5af2c7",
@@ -5385,27 +5414,9 @@
                     "initialStateCheck": false
                 },
                 {
-                    "name": "Strobe Frequency (Hover)",
-                    "type": "Button",
-                    "id": "8d8173b1-0211-441b-95b0-d820a206057a",
-                    "expectedControlType": "",
-                    "processors": "",
-                    "interactions": "Press",
-                    "initialStateCheck": false
-                },
-                {
                     "name": "Strobe Brightness",
                     "type": "Button",
                     "id": "b89aef46-41f6-4e26-aea2-4e7a6d8ac905",
-                    "expectedControlType": "",
-                    "processors": "",
-                    "interactions": "Press",
-                    "initialStateCheck": false
-                },
-                {
-                    "name": "Strobe Brightness (Hover)",
-                    "type": "Button",
-                    "id": "9acf7284-6b19-4fe2-9f57-4d62d467dd15",
                     "expectedControlType": "",
                     "processors": "",
                     "interactions": "Press",
@@ -5430,6 +5441,33 @@
                     "initialStateCheck": false
                 },
                 {
+                    "name": "Tweak Brightness (Hover)",
+                    "type": "Button",
+                    "id": "12efb566-15c0-4db8-a04f-f1af295c8e79",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "Press",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Tweak Strobe Frequency (Hover)",
+                    "type": "Button",
+                    "id": "8d8173b1-0211-441b-95b0-d820a206057a",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "Press",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Tweak Strobe Brightness (Hover)",
+                    "type": "Button",
+                    "id": "9acf7284-6b19-4fe2-9f57-4d62d467dd15",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "Press",
+                    "initialStateCheck": false
+                },
+                {
                     "name": "Tweak Easing (Hover)",
                     "type": "Value",
                     "id": "9cfcd847-c28a-48ad-9e05-6cf5fdf3f171",
@@ -5447,7 +5485,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "Color0 Light",
+                    "action": "Primary Light Color",
                     "isComposite": false,
                     "isPartOfComposite": false
                 },
@@ -5458,7 +5496,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "Color1 Light",
+                    "action": "Secondary Light Color",
                     "isComposite": false,
                     "isPartOfComposite": false
                 },
@@ -5469,7 +5507,29 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "ColorW Light",
+                    "action": "White Light Color",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "d65100ca-8bb6-4e21-8f7b-051481563eef",
+                    "path": "<Keyboard>/4",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "ChroMapper Default",
+                    "action": "Chroma Light Color",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "4e7dafd7-0102-4180-8a9e-60ef3831e4e2",
+                    "path": "<Keyboard>/c",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "ChroMapper Default",
+                    "action": "Strobe Chroma Color",
                     "isComposite": false,
                     "isPartOfComposite": false
                 },
@@ -5711,7 +5771,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "Strobe Frequency (Hover)",
+                    "action": "Tweak Strobe Frequency (Hover)",
                     "isComposite": true,
                     "isPartOfComposite": false
                 },
@@ -5722,7 +5782,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "Strobe Frequency (Hover)",
+                    "action": "Tweak Strobe Frequency (Hover)",
                     "isComposite": false,
                     "isPartOfComposite": true
                 },
@@ -5733,7 +5793,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "Strobe Frequency (Hover)",
+                    "action": "Tweak Strobe Frequency (Hover)",
                     "isComposite": false,
                     "isPartOfComposite": true
                 },
@@ -5744,7 +5804,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "Strobe Frequency (Hover)",
+                    "action": "Tweak Strobe Frequency (Hover)",
                     "isComposite": false,
                     "isPartOfComposite": true
                 },
@@ -5788,7 +5848,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "Brightness (Hover)",
+                    "action": "Tweak Brightness (Hover)",
                     "isComposite": true,
                     "isPartOfComposite": false
                 },
@@ -5799,7 +5859,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "Brightness (Hover)",
+                    "action": "Tweak Brightness (Hover)",
                     "isComposite": false,
                     "isPartOfComposite": true
                 },
@@ -5810,7 +5870,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "Brightness (Hover)",
+                    "action": "Tweak Brightness (Hover)",
                     "isComposite": false,
                     "isPartOfComposite": true
                 },
@@ -5821,7 +5881,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "Strobe Brightness (Hover)",
+                    "action": "Tweak Strobe Brightness (Hover)",
                     "isComposite": true,
                     "isPartOfComposite": false
                 },
@@ -5832,7 +5892,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "Strobe Brightness (Hover)",
+                    "action": "Tweak Strobe Brightness (Hover)",
                     "isComposite": false,
                     "isPartOfComposite": true
                 },
@@ -5843,7 +5903,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "Strobe Brightness (Hover)",
+                    "action": "Tweak Strobe Brightness (Hover)",
                     "isComposite": false,
                     "isPartOfComposite": true
                 },
@@ -5854,7 +5914,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "Strobe Brightness (Hover)",
+                    "action": "Tweak Strobe Brightness (Hover)",
                     "isComposite": false,
                     "isPartOfComposite": true
                 },
@@ -5865,7 +5925,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "Strobe Brightness (Hover)",
+                    "action": "Tweak Strobe Brightness (Hover)",
                     "isComposite": false,
                     "isPartOfComposite": true
                 },
@@ -5956,15 +6016,6 @@
                     "initialStateCheck": false
                 },
                 {
-                    "name": "Angle (Hover)",
-                    "type": "Button",
-                    "id": "ec35709c-0503-45d5-a460-03450dad1b41",
-                    "expectedControlType": "",
-                    "processors": "",
-                    "interactions": "Press",
-                    "initialStateCheck": false
-                },
-                {
                     "name": "Rotation Direction (Left)",
                     "type": "Button",
                     "id": "f7d73af6-1611-41ae-81f0-1353716c426e",
@@ -6010,6 +6061,15 @@
                     "initialStateCheck": false
                 },
                 {
+                    "name": "Tweak Angle (Hover)",
+                    "type": "Button",
+                    "id": "ec35709c-0503-45d5-a460-03450dad1b41",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "Press",
+                    "initialStateCheck": false
+                },
+                {
                     "name": "Tweak Loop (Hover)",
                     "type": "Value",
                     "id": "ee00d968-6cbc-40e8-921d-f31636675e13",
@@ -6028,7 +6088,7 @@
                     "initialStateCheck": true
                 },
                 {
-                    "name": "Cycle Axis (Hover)",
+                    "name": "Tweak Axis (Hover)",
                     "type": "Value",
                     "id": "f5be2c40-29da-46cd-a64b-a61ff42eb564",
                     "expectedControlType": "Axis",
@@ -6037,7 +6097,7 @@
                     "initialStateCheck": true
                 },
                 {
-                    "name": "Cycle Direction (Hover)",
+                    "name": "Tweak Direction (Hover)",
                     "type": "Button",
                     "id": "3973edf5-5bed-478d-a410-d72beb1bd603",
                     "expectedControlType": "",
@@ -6153,7 +6213,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "Angle (Hover)",
+                    "action": "Tweak Angle (Hover)",
                     "isComposite": true,
                     "isPartOfComposite": false
                 },
@@ -6164,7 +6224,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "Angle (Hover)",
+                    "action": "Tweak Angle (Hover)",
                     "isComposite": false,
                     "isPartOfComposite": true
                 },
@@ -6175,7 +6235,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "Angle (Hover)",
+                    "action": "Tweak Angle (Hover)",
                     "isComposite": false,
                     "isPartOfComposite": true
                 },
@@ -6186,7 +6246,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "Cycle Axis (Hover)",
+                    "action": "Tweak Axis (Hover)",
                     "isComposite": true,
                     "isPartOfComposite": false
                 },
@@ -6197,7 +6257,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "Cycle Axis (Hover)",
+                    "action": "Tweak Axis (Hover)",
                     "isComposite": false,
                     "isPartOfComposite": true
                 },
@@ -6208,7 +6268,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "Cycle Axis (Hover)",
+                    "action": "Tweak Axis (Hover)",
                     "isComposite": false,
                     "isPartOfComposite": true
                 },
@@ -6219,7 +6279,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "Cycle Axis (Hover)",
+                    "action": "Tweak Axis (Hover)",
                     "isComposite": false,
                     "isPartOfComposite": true
                 },
@@ -6329,7 +6389,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "Cycle Direction (Hover)",
+                    "action": "Tweak Direction (Hover)",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }
@@ -6385,7 +6445,7 @@
                     "initialStateCheck": false
                 },
                 {
-                    "name": "Value (Hover)",
+                    "name": "Tweak Value (Hover)",
                     "type": "Button",
                     "id": "b70438c0-b7a3-4dfa-8bd3-d6bf4906a769",
                     "expectedControlType": "",
@@ -6403,7 +6463,7 @@
                     "initialStateCheck": true
                 },
                 {
-                    "name": "Cycle Axis (Hover)",
+                    "name": "Tweak Axis (Hover)",
                     "type": "Value",
                     "id": "b168aaf1-9e62-407e-9341-c11284a940d6",
                     "expectedControlType": "Axis",
@@ -6475,7 +6535,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "Value (Hover)",
+                    "action": "Tweak Value (Hover)",
                     "isComposite": true,
                     "isPartOfComposite": false
                 },
@@ -6486,7 +6546,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "Value (Hover)",
+                    "action": "Tweak Value (Hover)",
                     "isComposite": false,
                     "isPartOfComposite": true
                 },
@@ -6497,7 +6557,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "Value (Hover)",
+                    "action": "Tweak Value (Hover)",
                     "isComposite": false,
                     "isPartOfComposite": true
                 },
@@ -6508,7 +6568,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "Cycle Axis (Hover)",
+                    "action": "Tweak Axis (Hover)",
                     "isComposite": true,
                     "isPartOfComposite": false
                 },
@@ -6519,7 +6579,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "Cycle Axis (Hover)",
+                    "action": "Tweak Axis (Hover)",
                     "isComposite": false,
                     "isPartOfComposite": true
                 },
@@ -6530,7 +6590,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "Cycle Axis (Hover)",
+                    "action": "Tweak Axis (Hover)",
                     "isComposite": false,
                     "isPartOfComposite": true
                 },
@@ -6541,7 +6601,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "Cycle Axis (Hover)",
+                    "action": "Tweak Axis (Hover)",
                     "isComposite": false,
                     "isPartOfComposite": true
                 },
@@ -6641,7 +6701,7 @@
                     "initialStateCheck": false
                 },
                 {
-                    "name": "Value (Hover)",
+                    "name": "Tweak Value (Hover)",
                     "type": "Button",
                     "id": "146a8e3f-7192-4cd3-bef6-45b7e5e5ec31",
                     "expectedControlType": "",
@@ -6722,7 +6782,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "Value (Hover)",
+                    "action": "Tweak Value (Hover)",
                     "isComposite": true,
                     "isPartOfComposite": false
                 },
@@ -6733,7 +6793,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "Value (Hover)",
+                    "action": "Tweak Value (Hover)",
                     "isComposite": false,
                     "isPartOfComposite": true
                 },
@@ -6744,7 +6804,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "Value (Hover)",
+                    "action": "Tweak Value (Hover)",
                     "isComposite": false,
                     "isPartOfComposite": true
                 },
@@ -7069,7 +7129,7 @@
                 {
                     "name": "",
                     "id": "30a99391-cfa1-4371-bf37-4495a06a344c",
-                    "path": "<Keyboard>/4",
+                    "path": "<Keyboard>/6",
                     "interactions": "",
                     "processors": "",
                     "groups": "",
@@ -7102,7 +7162,7 @@
                 {
                     "name": "binding",
                     "id": "2fa4536d-9fc4-4224-a019-b6d1f057846e",
-                    "path": "<Keyboard>/4",
+                    "path": "<Keyboard>/6",
                     "interactions": "",
                     "processors": "",
                     "groups": "",
@@ -7243,15 +7303,6 @@
                     "initialStateCheck": false
                 },
                 {
-                    "name": "Modify (Hover)",
-                    "type": "Value",
-                    "id": "0bacd048-031f-4ccd-bb5b-18c43f001614",
-                    "expectedControlType": "Axis",
-                    "processors": "",
-                    "interactions": "Press",
-                    "initialStateCheck": true
-                },
-                {
                     "name": "Invert",
                     "type": "Button",
                     "id": "7ae63c7f-cb46-4d12-a64c-1bf5b5490d46",
@@ -7331,6 +7382,15 @@
                     "processors": "",
                     "interactions": "Press",
                     "initialStateCheck": false
+                },
+                {
+                    "name": "Tweak Modify (Hover)",
+                    "type": "Value",
+                    "id": "0bacd048-031f-4ccd-bb5b-18c43f001614",
+                    "expectedControlType": "Axis",
+                    "processors": "",
+                    "interactions": "Press",
+                    "initialStateCheck": true
                 }
             ],
             "bindings": [
@@ -7396,7 +7456,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "Modify (Hover)",
+                    "action": "Tweak Modify (Hover)",
                     "isComposite": true,
                     "isPartOfComposite": false
                 },
@@ -7407,7 +7467,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": ";ChroMapper Default",
-                    "action": "Modify (Hover)",
+                    "action": "Tweak Modify (Hover)",
                     "isComposite": false,
                     "isPartOfComposite": true
                 },
@@ -7418,7 +7478,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": ";ChroMapper Default",
-                    "action": "Modify (Hover)",
+                    "action": "Tweak Modify (Hover)",
                     "isComposite": false,
                     "isPartOfComposite": true
                 },

--- a/Assets/Tests/Editor/NodeEditorTest.cs
+++ b/Assets/Tests/Editor/NodeEditorTest.cs
@@ -251,6 +251,47 @@ namespace Tests.Editor
             }
         }
 
+        // Node-editor GLS edits must round-trip the authored node state without duplicating or orphaning inner nodes.
+        [Test]
+        public void GLSNodeEditorEditRoundTripsInnerNodeWithoutDuplicates()
+        {
+            var nodeEditor = Object.FindAnyObjectByType<NodeEditorController>();
+            var provider = Object.FindAnyObjectByType<GLSEventGridProvider>();
+            var group = BeatmapFactory.LightColorEventBoxGroups(JSON.Parse(
+                @"{ ""b"": 2, ""g"": 1, ""e"": [ { ""f"": { ""f"": 0, ""p"": 0, ""t"": 0, ""r"": 0, ""c"": 0, ""n"": 0, ""s"": 0, ""l"": 0, ""d"": 0 }, ""w"": 1, ""d"": 0, ""r"": 0, ""t"": 0, ""b"": 0, ""i"": 0, ""e"": [ { ""b"": 0.5, ""c"": 0, ""s"": 1, ""i"": 0, ""f"": 0, ""sb"": 0, ""sf"": 0, ""customData"": { ""color"": [1, 0, 0] } } ] } ] }"));
+
+            provider.GroupContext = group;
+            PlaceGlsGroup(group);
+            SelectionController.Select(group.ReadOnlyBoxes[0].ReadOnlyEvents[0]);
+            // Isolate this edit so a second undo precisely detects an action leaked by the inner GLS replacement path.
+            var actionContainer = Object.FindAnyObjectByType<BeatmapActionContainer>();
+            actionContainer.ClearBeatmapActions();
+
+            nodeEditor.NodeEditor_EndEdit(
+                @"{ ""b"": 0.5, ""c"": 0, ""s"": 1, ""i"": 0, ""f"": 0, ""sb"": 0, ""sf"": 0, ""customData"": { ""color"": [0, 1, 0] } }");
+            AssertSingleInnerGlsColor(provider.GroupContext, Color.green);
+
+            actionContainer.Undo();
+            AssertSingleInnerGlsColor(provider.GroupContext, Color.red);
+            actionContainer.Redo();
+            AssertSingleInnerGlsColor(provider.GroupContext, Color.green);
+            actionContainer.Undo();
+            AssertSingleInnerGlsColor(provider.GroupContext, Color.red);
+            Assert.IsNull(actionContainer.Undo(), "The node edit must not leave an extra inner-GLS undo action behind.");
+        }
+
+        // Assert the saved GLS group remains structurally valid after each history operation, rather than inspecting its action implementation.
+        private static void AssertSingleInnerGlsColor(BaseEventBoxGroup group, Color expectedColor)
+        {
+            var colorEvents = group.ReadOnlyBoxes
+                .SelectMany(box => box.ReadOnlyEvents)
+                .OfType<BaseLightColorBase>()
+                .ToArray();
+            Assert.AreEqual(1, colorEvents.Length);
+            Assert.True(colorEvents[0].CustomColor.HasValue);
+            Assert.AreEqual(expectedColor, colorEvents[0].CustomColor.Value);
+        }
+
         [Test]
         public void GLSGroupCustomDataApply()
         {

--- a/Assets/Tests/Editor/NodeEditorTest.cs
+++ b/Assets/Tests/Editor/NodeEditorTest.cs
@@ -146,7 +146,7 @@ namespace Tests.Editor
 
             // Merge only nodes from one active GLS group, matching ordinary node multi-selection semantics.
             var group = BeatmapFactory.LightColorEventBoxGroups(JSON.Parse(
-                @"{ ""b"": 2, ""g"": 1, ""e"": [ { ""f"": { ""f"": 0, ""p"": 0, ""t"": 0, ""r"": 0, ""c"": 0, ""n"": 0, ""s"": 0, ""l"": 0, ""d"": 0 }, ""w"": 1, ""d"": 0, ""r"": 0, ""t"": 0, ""b"": 0, ""i"": 0, ""e"": [ { ""b"": 0.5, ""c"": 0, ""s"": 1, ""i"": 0, ""f"": 0, ""sb"": 0, ""sf"": 0, ""customData"": { ""color"": [1, 0, 0] } }, { ""b"": 0.5, ""c"": 0, ""s"": 1, ""i"": 0, ""f"": 0, ""sb"": 0, ""sf"": 0, ""customData"": { ""color"": [0, 0, 1] } } ] } ] }"));
+                @"{ ""b"": 2, ""g"": 1, ""e"": [ { ""f"": { ""f"": 0, ""p"": 0, ""t"": 0, ""r"": 0, ""c"": 0, ""n"": 0, ""s"": 0, ""l"": 0, ""d"": 0 }, ""w"": 1, ""d"": 0, ""r"": 0, ""t"": 0, ""b"": 0, ""i"": 0, ""e"": [ { ""b"": 0.5, ""c"": 0, ""s"": 1, ""i"": 0, ""f"": 0, ""sb"": 0, ""sf"": 0, ""customData"": { ""color"": [1, 0, 0] } }, { ""b"": 0.75, ""c"": 0, ""s"": 1, ""i"": 0, ""f"": 0, ""sb"": 0, ""sf"": 0, ""customData"": { ""color"": [0, 0, 1] } } ] } ] }"));
 
             provider.GroupContext = group;
             PlaceGlsGroup(group);
@@ -228,7 +228,7 @@ namespace Tests.Editor
                 selected[0].ToJson().ToString());
 
             var group2 = BeatmapFactory.LightColorEventBoxGroups(JSON.Parse(
-                @"{ ""b"": 2, ""g"": 1, ""e"": [ { ""f"": { ""f"": 0, ""p"": 0, ""t"": 0, ""r"": 0, ""c"": 0, ""n"": 0, ""s"": 0, ""l"": 0, ""d"": 0 }, ""w"": 1, ""d"": 0, ""r"": 0, ""t"": 0, ""b"": 0, ""i"": 0, ""e"": [ { ""b"": 0.5, ""c"": 0, ""s"": 1, ""i"": 0, ""f"": 0, ""sb"": 0, ""sf"": 0, ""customData"": { ""color"": [1, 0, 0] } }, { ""b"": 0.5, ""c"": 0, ""s"": 1, ""i"": 0, ""f"": 0, ""sb"": 0, ""sf"": 0, ""customData"": { ""color"": [0, 0, 1] } } ] } ] }"));
+                @"{ ""b"": 2, ""g"": 1, ""e"": [ { ""f"": { ""f"": 0, ""p"": 0, ""t"": 0, ""r"": 0, ""c"": 0, ""n"": 0, ""s"": 0, ""l"": 0, ""d"": 0 }, ""w"": 1, ""d"": 0, ""r"": 0, ""t"": 0, ""b"": 0, ""i"": 0, ""e"": [ { ""b"": 0.5, ""c"": 0, ""s"": 1, ""i"": 0, ""f"": 0, ""sb"": 0, ""sf"": 0, ""customData"": { ""color"": [1, 0, 0] } }, { ""b"": 0.75, ""c"": 0, ""s"": 1, ""i"": 0, ""f"": 0, ""sb"": 0, ""sf"": 0, ""customData"": { ""color"": [0, 0, 1] } } ] } ] }"));
 
             provider.GroupContext = group2;
             PlaceGlsGroup(group2);

--- a/Assets/Tests/Editor/SelectionControllerTest.cs
+++ b/Assets/Tests/Editor/SelectionControllerTest.cs
@@ -357,7 +357,7 @@ namespace Tests.Editor
             var group = CreateEmptyColorGroup();
             var epsilon = BeatmapObjectContainerCollection.Epsilon;
 
-            Assert.False(group.OrderedEventsInitialized);
+            Assert.True(group.OrderedEventsInitialized);
             Assert.False(BoxSelectionPlacement.HasGlsPreviewEventBetween(group, 0f, 1f, epsilon));
             var initializedCache = group.OrderedEvents;
             Assert.True(group.OrderedEventsInitialized);
@@ -467,37 +467,56 @@ namespace Tests.Editor
             Assert.AreEqual(2, redoneGroup.ReadOnlyBoxes[1].ReadOnlyEvents.Count);
         }
 
-        // Verify duplicate GLS identities consume distinct replacement nodes instead of collapsing selection.
+        // Selecting an outer GLS group beside its inner node must not apply two competing parent replacements during mirror.
+        [Test]
+        public void MirrorSkipsSelectedGlsParentOwnedBySelectedInnerNode()
+        {
+            SelectionController.DeselectAll();
+            var group = PlaceGlsGroup(CreateTwoLaneColorGroup());
+            var selectedEvent = group.ReadOnlyBoxes[0].ReadOnlyEvents[0];
+            SelectionController.Select(selectedEvent);
+            SelectionController.Select(group, true);
+
+            Object.FindAnyObjectByType<MirrorSelection>().Mirror();
+
+            var selectedEvents = SelectionController.SelectedObjects.OfType<BaseGLSEvent>().ToArray();
+            Assert.AreEqual(1, selectedEvents.Length);
+            Assert.False(SelectionController.SelectedObjects.Any(obj => obj is BaseEventBoxGroup));
+            Assert.AreSame(
+                Object.FindAnyObjectByType<GLSEventGridProvider>().GroupContext,
+                selectedEvents[0].EventBoxGroupData);
+        }
+
+        // Same-lane same-beat GLS nodes normalize to the later event before movement can rebuild the group.
         [Test]
         public void MoveSelectionRebindsDuplicateGlsEvents()
         {
             var selectionController = Object.FindAnyObjectByType<SelectionController>();
             var group = PlaceGlsGroup(CreateDuplicateColorGroup());
+            Assert.AreEqual(1, group.ReadOnlyBoxes[0].ReadOnlyEvents.Count);
             SelectionController.Select(group.ReadOnlyBoxes[0].ReadOnlyEvents[0]);
-            SelectionController.Select(group.ReadOnlyBoxes[0].ReadOnlyEvents[1], true);
 
             selectionController.MoveSelection(0.25f);
 
             var movedEvents = SelectionController.SelectedObjects.OfType<BaseGLSEvent>().ToArray();
-            Assert.AreEqual(2, movedEvents.Length);
+            Assert.AreEqual(1, movedEvents.Length);
             Assert.True(movedEvents.All(evt => Mathf.Approximately(evt.RelativeJsonTime, 0.75f)));
-            Assert.AreNotSame(movedEvents[0], movedEvents[1]);
-            Assert.AreEqual(2, movedEvents[0].EventBoxData.ReadOnlyEvents.Count);
+            Assert.AreEqual(1, movedEvents[0].EventBoxData.ReadOnlyEvents.Count);
         }
 
-        // Verify duplicate identities remain independently selected when a lane replacement moves both nodes.
+        // Same-lane same-beat GLS nodes normalize before a lane replacement moves the surviving node.
         [Test]
         public void ShiftSelectionRebindsDuplicateGlsEvents()
         {
             var selectionController = Object.FindAnyObjectByType<SelectionController>();
             var group = PlaceGlsGroup(CreateDuplicateColorGroup());
+            Assert.AreEqual(1, group.ReadOnlyBoxes[0].ReadOnlyEvents.Count);
             SelectionController.Select(group.ReadOnlyBoxes[0].ReadOnlyEvents[0]);
-            SelectionController.Select(group.ReadOnlyBoxes[0].ReadOnlyEvents[1], true);
 
             selectionController.ShiftSelection(1, 0);
 
             var shiftedEvents = SelectionController.SelectedObjects.OfType<BaseGLSEvent>().ToArray();
-            Assert.AreEqual(2, shiftedEvents.Length);
+            Assert.AreEqual(1, shiftedEvents.Length);
             Assert.True(shiftedEvents.All(evt => evt.BoxIndex == 1));
             Assert.True(shiftedEvents.All(evt => ReferenceEquals(evt.EventBoxData, evt.EventBoxGroupData.ReadOnlyBoxes[1])));
         }

--- a/Assets/Tests/Editor/SelectionControllerTest.cs
+++ b/Assets/Tests/Editor/SelectionControllerTest.cs
@@ -528,6 +528,101 @@ namespace Tests.Editor
             }
         }
 
+        // Reproduce an outer alt-drag after an inner mutation preserves its now-empty first filter lane.
+        [Test]
+        public void OuterGlsColorPreviewSurvivesEmptyStarterLaneAfterInnerDrag()
+        {
+            var editModeContext = Object.FindAnyObjectByType<EditModeContext>();
+            var originalMode = editModeContext.EditingMode;
+            editModeContext.EditingMode = EditingMode.GLS;
+            var hitParent = new GameObject("GLS outer placement test surface");
+            var hitObject = new GameObject("GLS outer placement test hit");
+            hitObject.transform.SetParent(hitParent.transform);
+            GLSGroupColorPlacement placement = null;
+            GLSGroupContainer dragContainer = null;
+            try
+            {
+                var group = BeatmapFactory.LightColorEventBoxGroups(JSON.Parse(
+                    @"{ ""b"": 2, ""g"": 1, ""e"": [
+                        { ""f"": { ""f"": 0, ""p"": 0, ""t"": 0, ""r"": 0, ""c"": 0, ""n"": 0, ""s"": 0, ""l"": 0, ""d"": 0 }, ""w"": 1, ""d"": 0, ""r"": 0, ""t"": 0, ""b"": 0, ""i"": 0, ""e"": [] },
+                        { ""f"": { ""f"": 1, ""p"": 0, ""t"": 0, ""r"": 0, ""c"": 0, ""n"": 0, ""s"": 0, ""l"": 0, ""d"": 0 }, ""w"": 1, ""d"": 0, ""r"": 0, ""t"": 0, ""b"": 0, ""i"": 0,
+                          ""e"": [ { ""b"": 0.5, ""c"": 0, ""s"": 1, ""i"": 0, ""f"": 0, ""sb"": 0, ""sf"": 0 } ] }
+                    ] }"));
+                (placement, dragContainer) = StartOuterColorGroupDrag(group);
+
+                Assert.DoesNotThrow(() => placement.UpdateState(
+                    new Intersections.IntersectionHit(
+                        hitObject,
+                        new Bounds(Vector3.zero, Vector3.one),
+                        new Ray(Vector3.zero, Vector3.forward),
+                        0f),
+                    PlacementInputState.Hover));
+            }
+            finally
+            {
+                if (placement != null && placement.IsDragging)
+                {
+                    placement.FinishDrag();
+                }
+
+                if (dragContainer != null)
+                {
+                    Object.DestroyImmediate(dragContainer.gameObject);
+                }
+
+                Object.DestroyImmediate(hitParent);
+                editModeContext.EditingMode = originalMode;
+            }
+        }
+
+        // Outer GLS group drags must stop at the map start instead of authoring invalid negative beats.
+        [Test]
+        public void OuterGlsColorDragClampsAtBeatZero()
+        {
+            var editModeContext = Object.FindAnyObjectByType<EditModeContext>();
+            var originalMode = editModeContext.EditingMode;
+            editModeContext.EditingMode = EditingMode.GLS;
+            var atsc = Object.FindAnyObjectByType<AudioTimeSyncController>();
+            var originalJsonTime = atsc.CurrentJsonTime;
+            var hitParent = new GameObject("GLS negative drag test surface");
+            var hitObject = new GameObject("GLS negative drag test hit");
+            hitObject.transform.SetParent(hitParent.transform);
+            GLSGroupColorPlacement placement = null;
+            GLSGroupContainer dragContainer = null;
+            try
+            {
+                (placement, dragContainer) = StartOuterColorGroupDrag(CreateTwoLaneColorGroup());
+                atsc.MoveToJsonTime(0f);
+                var negativeHitPoint = placement.PlacementTrack.TransformPoint(Vector3.back * EditorScaleController.EditorScale);
+
+                placement.UpdateState(
+                    new Intersections.IntersectionHit(
+                        hitObject,
+                        new Bounds(Vector3.zero, Vector3.one),
+                        new Ray(negativeHitPoint, Vector3.forward),
+                        0f),
+                    PlacementInputState.Drag);
+
+                Assert.Zero(placement.DraggedObjectData.JsonTime);
+            }
+            finally
+            {
+                if (placement != null && placement.IsDragging)
+                {
+                    placement.FinishDrag();
+                }
+
+                if (dragContainer != null)
+                {
+                    Object.DestroyImmediate(dragContainer.gameObject);
+                }
+
+                atsc.MoveToJsonTime(originalJsonTime);
+                Object.DestroyImmediate(hitParent);
+                editModeContext.EditingMode = originalMode;
+            }
+        }
+
         // Same-lane same-beat GLS nodes normalize to the later event before movement can rebuild the group.
         [Test]
         public void MoveSelectionRebindsDuplicateGlsEvents()
@@ -584,10 +679,39 @@ namespace Tests.Editor
         // Place the parent through its real collection so replacement actions update the open GLS child context.
         private static BaseLightColorEventBoxGroup PlaceGlsGroup(BaseLightColorEventBoxGroup group)
         {
+            // Factory-created groups need the same map/time initialization as normal map-load objects before pool range queries can render them.
+            group.SetMap(BeatSaberSongContainer.Instance.Map);
+            group.RecomputeSongBpmTime();
             var collection = BeatmapObjectContainerCollection.GetCollectionForType(group.ObjectType);
             collection.SpawnObject(group, false, false, true);
             Object.FindAnyObjectByType<GLSEventGridProvider>().GroupContext = group;
             return group;
+        }
+
+        // Start an outer drag through the real GLS group container prefab without coupling this behavioral test to viewport pooling.
+        private static (GLSGroupColorPlacement Placement, GLSGroupContainer DragContainer) StartOuterColorGroupDrag(
+            BaseLightColorEventBoxGroup group)
+        {
+            var groupCollection = BeatmapObjectContainerCollection
+                .GetCollectionForType<GLSGroupColorGridContainer>(ObjectType.GLSColor);
+            // Select the live placement for this collection so the drag starts through the same initialized scene wiring as the editor.
+            var placement = Object.FindObjectsByType<GLSGroupColorPlacement>(FindObjectsInactive.Include, FindObjectsSortMode.None)
+                .Where(candidate => candidate.ObjectContainerCollection == groupCollection
+                                    && candidate.ObjectDataType == ObjectType.GLSColor)
+                .OrderByDescending(candidate => candidate.isActiveAndEnabled)
+                .FirstOrDefault();
+            Assert.NotNull(placement);
+            // Insert into the same collection StartDrag will remove from; unrelated selection tests use a separate convenience helper.
+            group.SetMap(BeatSaberSongContainer.Instance.Map);
+            group.RecomputeSongBpmTime();
+            groupCollection.SpawnObject(group, false, false, true);
+            Object.FindAnyObjectByType<GLSEventGridProvider>().GroupContext = group;
+            var groupContainer = groupCollection.CreateContainer() as GLSGroupContainer;
+            Assert.NotNull(groupContainer);
+            groupContainer.ObjectData = group;
+            groupContainer.Setup();
+            Assert.NotNull(placement.StartDrag(groupContainer.gameObject));
+            return (placement, groupContainer);
         }
 
         // Build distinct events in adjacent filter lanes for parent replacement and boundary-shift coverage.

--- a/Assets/Tests/Editor/SelectionControllerTest.cs
+++ b/Assets/Tests/Editor/SelectionControllerTest.cs
@@ -487,6 +487,47 @@ namespace Tests.Editor
                 selectedEvents[0].EventBoxGroupData);
         }
 
+        // Alt-drag replaces the parent group, so initial placement, undo, and redo must never select that outer group in the inner GLS view.
+        [Test]
+        public void AltDraggingInnerGlsNodeNeverSelectsOuterGroupAcrossUndoRedo()
+        {
+            var editModeContext = Object.FindAnyObjectByType<EditModeContext>();
+            var originalMode = editModeContext.EditingMode;
+            editModeContext.EditingMode = EditingMode.EventBox;
+            try
+            {
+                SelectionController.DeselectAll();
+                var group = PlaceGlsGroup(CreateTwoLaneColorGroup());
+                var eventCollection = BeatmapObjectContainerCollection
+                    .GetCollectionForType<GLSEventGridContainer>(ObjectType.GLSEvent);
+                var draggedEvent = group.ReadOnlyBoxes[0].ReadOnlyEvents[0];
+                var originalGroup = BeatmapFactory.Clone(group);
+
+                // Mirror the drag path: temporarily remove the live child, then publish its destination against the pre-drag parent.
+                eventCollection.SilentRemoveObject(draggedEvent);
+                eventCollection.UseOriginalGroupForNextReplacement(originalGroup);
+                eventCollection.SpawnObject(draggedEvent, out _);
+                AssertNoOuterGlsGroupSelection();
+
+                PlaceUtils.Undo();
+                AssertNoOuterGlsGroupSelection();
+                PlaceUtils.Redo();
+                AssertNoOuterGlsGroupSelection();
+
+                var replacementEvents = Object.FindAnyObjectByType<GLSEventGridProvider>()
+                    .GroupContext.ReadOnlyBoxes.SelectMany(box => box.ReadOnlyEvents).ToArray();
+                SelectionController.Select(replacementEvents[0]);
+                SelectionController.Select(replacementEvents[1], true);
+
+                Assert.AreEqual(2, SelectionController.SelectedObjects.Count);
+                Assert.True(SelectionController.SelectedObjects.All(obj => obj is BaseLightColorBase));
+            }
+            finally
+            {
+                editModeContext.EditingMode = originalMode;
+            }
+        }
+
         // Same-lane same-beat GLS nodes normalize to the later event before movement can rebuild the group.
         [Test]
         public void MoveSelectionRebindsDuplicateGlsEvents()
@@ -532,6 +573,12 @@ namespace Tests.Editor
                 objects.Count,
                 SelectionController.SelectedObjects.Count,
                 "Selection should be the exact amount");
+        }
+
+        private static void AssertNoOuterGlsGroupSelection()
+        {
+            Assert.False(SelectionController.SelectedObjects.Any(obj => obj is BaseEventBoxGroup));
+            Assert.IsEmpty(SelectionController.SelectedObjects);
         }
 
         // Place the parent through its real collection so replacement actions update the open GLS child context.

--- a/Assets/Tests/Placement/WallTest.cs
+++ b/Assets/Tests/Placement/WallTest.cs
@@ -182,6 +182,31 @@ namespace Tests.Placement
             BeatmapAssertion.IsUnchanged(originalWallA, undoHyperObjects[0], "Undo hyper wall");
         }
 
+        // Reverse wall drags must preserve both selected endpoints instead of collapsing to the minimum duration.
+        [Test]
+        public void ReverseWallPlacementUsesForwardTimeRange()
+        {
+            var obstaclePlacement = Object.FindAnyObjectByType<ObstaclePlacement>();
+            obstaclePlacement.QueuedData = new BaseObstacle
+            {
+                PosX = (int)GridX.Left,
+                Type = (int)ObstacleType.Full,
+                Width = 1
+            };
+
+            obstaclePlacement.RoundedJsonTime = 4f;
+            obstaclePlacement.HandleApply();
+            obstaclePlacement.RoundedJsonTime = 2f;
+            obstaclePlacement.HandleApply();
+
+            // The placement action has no conflicts to return on undo, so inspect the authored wall still in the obstacle collection.
+            var obstacleCollection =
+                BeatmapObjectContainerCollection.GetCollectionForType<ObstacleGridContainer>(ObjectType.Obstacle);
+            var placedWall = obstacleCollection.MapObjects.Single();
+            Assert.That(placedWall.JsonTime, Is.EqualTo(2f));
+            Assert.That(placedWall.Duration, Is.EqualTo(2f));
+        }
+
         [Test]
         public void PlacementPersistsCustomProperty()
         {

--- a/Assets/Tests/Visual/PaintTest.cs
+++ b/Assets/Tests/Visual/PaintTest.cs
@@ -1,5 +1,7 @@
 ﻿using System.Linq;
 using Beatmap.Base;
+using Beatmap.Enums;
+using Beatmap.Helper;
 using Beatmap.Shared;
 using NUnit.Framework;
 using SimpleJSON;
@@ -18,7 +20,9 @@ namespace Tests.Visual
         {
             Settings.Instance.MapVersion = 3;
 
-            _colorPicker = Object.FindAnyObjectByType<ColorPicker>();
+            // The paint control is serialized to Picker 2.0; FindAnyObject can instead return the strobe picker.
+            _colorPicker = ColourPicker.ActivePicker;
+            Assert.NotNull(_colorPicker);
             _painter = Object.FindAnyObjectByType<PaintSelectedObjects>();
         }
 
@@ -126,6 +130,50 @@ namespace Tests.Visual
             Assert.AreEqual(2, eventA.JsonTime);
             Assert.AreEqual(1, eventA.Type);
             Assert.AreEqual(true, eventA.CustomData == null || !eventA.CustomData.HasKey(eventA.CustomKeyColor));
+        }
+
+        // Painting an inner GLS node must round-trip the rendered map data and leave no second undo action behind.
+        [Test]
+        public void PaintSelectedInnerGlsColorNodeRoundTripsWithoutExtraUndo()
+        {
+            var group = BeatmapFactory.LightColorEventBoxGroups(JSON.Parse(
+                @"{ ""b"": 6, ""g"": 0, ""e"": [
+                    { ""f"": { ""f"": 0, ""p"": 0, ""t"": 0, ""r"": 0, ""c"": 0, ""n"": 0, ""s"": 0, ""l"": 0, ""d"": 0 }, ""w"": 1, ""d"": 0, ""r"": 0, ""t"": 0, ""b"": 0, ""i"": 0,
+                      ""e"": [ { ""b"": 0.5, ""c"": 0, ""s"": 1, ""i"": 0, ""f"": 0, ""sb"": 0, ""sf"": 0 } ] }
+                ] }"));
+            var groupCollection = BeatmapObjectContainerCollection
+                .GetCollectionForType<GLSGroupColorGridContainer>(ObjectType.GLSColor);
+            groupCollection.SpawnObject(group, false, false, true);
+
+            var provider = Object.FindAnyObjectByType<GLSEventGridProvider>();
+            provider.GroupContext = group;
+            SelectionController.Select(group.ReadOnlyBoxes[0].ReadOnlyEvents[0]);
+            // Isolate the paint operation so an extra undo directly reproduces the mapper's reported follow-up undo.
+            var actionContainer = Object.FindAnyObjectByType<BeatmapActionContainer>();
+            actionContainer.ClearBeatmapActions();
+
+            _colorPicker.CurrentColor = Color.magenta;
+            _painter.Paint();
+            AssertSingleInnerGlsColor(provider.GroupContext, Color.magenta);
+
+            actionContainer.Undo();
+            AssertSingleInnerGlsColor(provider.GroupContext, null);
+            actionContainer.Redo();
+            AssertSingleInnerGlsColor(provider.GroupContext, Color.magenta);
+            actionContainer.Undo();
+            AssertSingleInnerGlsColor(provider.GroupContext, null);
+            Assert.IsNull(actionContainer.Undo(), "Painting must not leave a second undoable GLS child action behind.");
+        }
+
+        // Assert persisted GLS node state after each operation instead of coupling the test to a particular action implementation.
+        private static void AssertSingleInnerGlsColor(BaseEventBoxGroup group, Color? expectedColor)
+        {
+            var colorEvents = group.ReadOnlyBoxes
+                .SelectMany(box => box.ReadOnlyEvents)
+                .OfType<BaseLightColorBase>()
+                .ToArray();
+            Assert.AreEqual(1, colorEvents.Length);
+            Assert.AreEqual(expectedColor, colorEvents[0].CustomColor);
         }
     }
 }

--- a/Assets/__Scenes/03_Mapper.unity
+++ b/Assets/__Scenes/03_Mapper.unity
@@ -5996,6 +5996,7 @@ MonoBehaviour:
   dropdown: {fileID: 81479822}
   toggle: {fileID: 157530501}
   placeChromaToggle: {fileID: 1427203218}
+  placeChromaObjectsToggle: {fileID: 3267473903278256629}
 --- !u!114 &81479824
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -22338,6 +22339,7 @@ MonoBehaviour:
   dropdown: {fileID: 436703757}
   toggle: {fileID: 0}
   placeChromaToggle: {fileID: 0}
+  placeChromaObjectsToggle: {fileID: 0}
 --- !u!114 &436703757
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -106550,7 +106552,6 @@ MonoBehaviour:
   gridViewController: {fileID: 617466178}
   obstacleAppearance: {fileID: 11400000, guid: 7a50c9a2cc4ae50499232fe511d6437e, type: 2}
   colorPicker: {fileID: 1225848101}
-  dropdown: {fileID: 81479822}
 --- !u!1 &2089025414
 GameObject:
   m_ObjectHideFlags: 0
@@ -107556,1713 +107557,6 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 436703755}
     m_Modifications:
-    - target: {fileID: 2802170249901438, guid: 29b0e711db3f65542a213179a4cab985, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2802170249901438, guid: 29b0e711db3f65542a213179a4cab985, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2802170249901438, guid: 29b0e711db3f65542a213179a4cab985, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2802170249901438, guid: 29b0e711db3f65542a213179a4cab985, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 51944099077899885, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 51944099077899885, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 51944099077899885, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 51944099077899885, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 51944099102051753, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 51944099102051753, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 51944099102051753, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 51944099102051753, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 51944099368068473, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 51944099368068473, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 51944099368068473, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 51944099368068473, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 51944099610064692, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 51944099610064692, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 51944099610064692, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 51944099610064692, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 51944100433275656, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 51944100433275656, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 51944100433275656, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 51944100433275656, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 51944100608940087, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 51944100608940087, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 51944100608940087, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 51944100608940087, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3085983833561883719, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
-      value: 1801810542
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903239561669, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903239561669, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 2013932235}
-    - target: {fileID: 3267473903239561669, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: PlaceChromaObjects
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903239561691, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903239561691, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903239561691, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903239561691, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903361687667, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_Color.b
-      value: 0.87
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903361687667, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.87
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903361687667, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.87
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903366379305, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903366379305, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903366379305, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903366379305, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903371203264, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903371203264, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903371203264, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903371203264, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903371203264, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903371203264, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903393556593, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 436703756}
-    - target: {fileID: 3267473903393556599, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903393556599, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903393556599, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903393556599, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903496143986, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903496143986, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903496143986, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903496143986, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903496143986, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903496143986, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903496143987, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
-      value: 1801810542
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903530270198, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903530270198, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903530270198, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903530270198, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903541505237, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903612824384, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903612824384, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903612824384, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903612824384, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903612824384, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903612824384, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903693438555, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903693438555, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903693438555, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903693438555, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903693438555, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903693438555, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903716978322, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903716978322, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903716978322, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903716978322, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903716978322, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903716978322, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903730534656, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903730534656, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903730534656, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903730534656, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903730534656, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903730534656, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903736876738, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903736876738, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903736876738, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903736876738, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903736876738, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903736876738, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903849509382, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903849509382, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903849509382, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903849509382, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903849509382, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903849509382, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903849509383, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
-      value: 1801810542
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903897216951, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903897216951, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903897216951, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473903897216951, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904037017051, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904037017051, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904037017051, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904037017051, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904037017051, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904037017051, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904407507856, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904407507856, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904407507856, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904407507856, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904407507856, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904407507856, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904434571528, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904434571528, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904434571528, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904434571528, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904434571528, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904434571528, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904434571529, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
-      value: 1801810542
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904438485380, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_Color.b
-      value: 0.42
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904438485380, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.42
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904438485380, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.42
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904441988782, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904441988782, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904441988782, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904441988782, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476168881, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476168881, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476168881, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476168881, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476168881, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476168881, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476227401, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476227401, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476227401, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476227401, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476227401, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476227401, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476245639, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476245639, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476245639, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476245639, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476245639, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476245639, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476246435, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476246435, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476246435, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476246435, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476246435, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476246435, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476253219, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476253219, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476253219, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476253219, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476253219, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476253219, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476257331, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476257331, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476257331, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476257331, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476257331, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476257331, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476272117, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476272117, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476272117, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476272117, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476272117, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476272117, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476275583, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476275583, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476275583, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476275583, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476275583, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476275583, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476330605, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476330605, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476330605, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476330605, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476347703, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476347703, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476347703, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476347703, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476347703, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476347703, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476352327, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476352327, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476352327, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476352327, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476352327, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904476352327, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904537638244, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904537638244, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904537638244, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904537638244, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904537638246, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904537638246, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 648123637}
-    - target: {fileID: 3267473904537638246, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: PlaceChroma
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904592195589, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904592195589, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904592195589, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904592195589, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904633944619, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904633944619, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904633944619, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904633944619, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904633944619, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904633944619, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904671193639, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904671193639, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904671193639, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904671193639, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904671193639, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904671193639, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904731916710, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904731916710, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904731916710, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904731916710, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904731916710, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904731916710, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904739333182, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904739333182, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904739333182, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904739333182, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904739333182, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904739333182, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904797627535, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_Color.b
-      value: 0.6094118
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904797627535, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.7182353
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473904797627535, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.87058824
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473905038001440, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473905038001440, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473905038001440, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473905038001440, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473905038001440, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473905038001440, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473905038001441, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
-      value: 1801810542
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473905076002016, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473905076002016, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473905076002016, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473905076002016, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473905076002016, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473905076002016, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473905130024862, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: 733f04facbc92a741a806acbfb941cc3,
-        type: 3}
-    - target: {fileID: 3267473905130024862, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_Color.b
-      value: 0.42
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473905130024862, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.42
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473905130024862, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.42
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473905152526751, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473905152526751, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473905152526751, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473905152526751, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473905152526751, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473905152526751, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473905169125337, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473905169125337, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473905169125337, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473905169125337, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473905169125337, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473905169125337, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3267473905169125338, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
-      value: 1801810542
-      objectReference: {fileID: 0}
-    - target: {fileID: 3333889866512137483, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3333889866512137483, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3333889866512137483, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3333889866512137483, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3333889866512137483, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3333889866512137483, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4399897670183957066, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
-      value: 1801810542
-      objectReference: {fileID: 0}
-    - target: {fileID: 4399897670883967349, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
-      value: 1801810542
-      objectReference: {fileID: 0}
-    - target: {fileID: 4399897671183392073, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
-      value: 1801810542
-      objectReference: {fileID: 0}
-    - target: {fileID: 4399897671683074004, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
-      value: 1801810542
-      objectReference: {fileID: 0}
-    - target: {fileID: 4399897671707159568, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
-      value: 1801810542
-      objectReference: {fileID: 0}
-    - target: {fileID: 4399897671949209348, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
-      value: 1801810542
-      objectReference: {fileID: 0}
-    - target: {fileID: 4685523036779863368, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4685523036779863368, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4685523036779863368, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4685523036779863368, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4685523036858412699, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4685523037356971014, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4685523037381124034, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4685523037621448311, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4685523037621448311, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4685523037621448311, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4685523037621448311, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4685523037627841750, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4685523037872488856, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4685523037946786379, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4685523037946786379, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4685523037946786379, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4685523037946786379, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4685523038453795030, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4685523038453795030, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4685523038453795030, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4685523038453795030, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4685523038477878034, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4685523038477878034, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4685523038477878034, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4685523038477878034, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4685523038709822119, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4685523038720466950, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4685523038720466950, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4685523038720466950, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4685523038720466950, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5083906087220029706, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
-      value: 1801810542
-      objectReference: {fileID: 0}
-    - target: {fileID: 5083906087590795829, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
-      value: 1801810542
-      objectReference: {fileID: 0}
-    - target: {fileID: 5083906088385136137, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
-      value: 1801810542
-      objectReference: {fileID: 0}
-    - target: {fileID: 5083906088689587268, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
-      value: 1801810542
-      objectReference: {fileID: 0}
-    - target: {fileID: 5083906088919398224, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
-      value: 1801810542
-      objectReference: {fileID: 0}
-    - target: {fileID: 5083906088960326804, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
-      value: 1801810542
-      objectReference: {fileID: 0}
-    - target: {fileID: 5859649077710290695, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
-      value: 1801810542
-      objectReference: {fileID: 0}
-    - target: {fileID: 7806920528214742832, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7806920528214742832, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7806920528214742832, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7806920528214742832, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7806920528738510441, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7806920528738510441, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7806920528738510441, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7806920528738510441, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7806920528781471149, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7806920528781471149, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7806920528781471149, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7806920528781471149, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7806920529047995773, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7806920529047995773, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7806920529047995773, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7806920529047995773, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7806920529329764403, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7806920529329764403, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7806920529329764403, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7806920529329764403, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7806920530096687884, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7806920530096687884, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7806920530096687884, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7806920530096687884, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7847169092699477370, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7847169092699477370, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7847169092699477370, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7847169092699477370, guid: 29b0e711db3f65542a213179a4cab985,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 2802170249901438, guid: c4319b692e16e5f42a0f7b3b9f822618, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -111354,6 +109648,1713 @@ PrefabInstance:
       propertyPath: strobeColorToggle
       value: 
       objectReference: {fileID: 78269161}
+    - target: {fileID: 2802170249901438, guid: 29b0e711db3f65542a213179a4cab985, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2802170249901438, guid: 29b0e711db3f65542a213179a4cab985, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2802170249901438, guid: 29b0e711db3f65542a213179a4cab985, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2802170249901438, guid: 29b0e711db3f65542a213179a4cab985, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 51944099077899885, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 51944099077899885, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 51944099077899885, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 51944099077899885, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 51944099102051753, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 51944099102051753, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 51944099102051753, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 51944099102051753, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 51944099368068473, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 51944099368068473, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 51944099368068473, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 51944099368068473, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 51944099610064692, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 51944099610064692, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 51944099610064692, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 51944099610064692, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 51944100433275656, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 51944100433275656, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 51944100433275656, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 51944100433275656, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 51944100608940087, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 51944100608940087, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 51944100608940087, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 51944100608940087, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3085983833561883719, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903239561669, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903239561669, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 2013932235}
+    - target: {fileID: 3267473903239561669, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: PlaceChromaObjects
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903239561691, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903239561691, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903239561691, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903239561691, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903361687667, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 0.87
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903361687667, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.87
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903361687667, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.87
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903366379305, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903366379305, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903366379305, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903366379305, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903371203264, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903371203264, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903371203264, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903371203264, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903371203264, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903371203264, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903393556593, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 436703756}
+    - target: {fileID: 3267473903393556599, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903393556599, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903393556599, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903393556599, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903496143986, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903496143986, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903496143986, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903496143986, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903496143986, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903496143986, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903496143987, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903530270198, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903530270198, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903530270198, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903530270198, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903541505237, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903612824384, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903612824384, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903612824384, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903612824384, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903612824384, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903612824384, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903693438555, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903693438555, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903693438555, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903693438555, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903693438555, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903693438555, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903716978322, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903716978322, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903716978322, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903716978322, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903716978322, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903716978322, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903730534656, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903730534656, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903730534656, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903730534656, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903730534656, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903730534656, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903736876738, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903736876738, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903736876738, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903736876738, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903736876738, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903736876738, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903849509382, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903849509382, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903849509382, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903849509382, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903849509382, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903849509382, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903849509383, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903897216951, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903897216951, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903897216951, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473903897216951, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904037017051, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904037017051, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904037017051, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904037017051, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904037017051, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904037017051, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904407507856, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904407507856, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904407507856, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904407507856, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904407507856, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904407507856, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904434571528, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904434571528, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904434571528, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904434571528, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904434571528, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904434571528, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904434571529, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904438485380, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 0.42
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904438485380, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.42
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904438485380, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.42
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904441988782, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904441988782, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904441988782, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904441988782, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476168881, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476168881, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476168881, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476168881, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476168881, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476168881, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476227401, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476227401, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476227401, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476227401, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476227401, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476227401, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476245639, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476245639, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476245639, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476245639, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476245639, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476245639, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476246435, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476246435, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476246435, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476246435, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476246435, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476246435, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476253219, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476253219, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476253219, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476253219, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476253219, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476253219, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476257331, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476257331, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476257331, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476257331, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476257331, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476257331, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476272117, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476272117, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476272117, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476272117, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476272117, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476272117, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476275583, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476275583, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476275583, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476275583, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476275583, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476275583, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476330605, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476330605, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476330605, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476330605, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476347703, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476347703, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476347703, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476347703, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476347703, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476347703, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476352327, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476352327, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476352327, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476352327, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476352327, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904476352327, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904537638244, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904537638244, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904537638244, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904537638244, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904537638246, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904537638246, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 648123637}
+    - target: {fileID: 3267473904537638246, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: PlaceChroma
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904592195589, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904592195589, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904592195589, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904592195589, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904633944619, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904633944619, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904633944619, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904633944619, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904633944619, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904633944619, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904671193639, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904671193639, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904671193639, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904671193639, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904671193639, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904671193639, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904731916710, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904731916710, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904731916710, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904731916710, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904731916710, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904731916710, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904739333182, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904739333182, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904739333182, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904739333182, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904739333182, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904739333182, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904797627535, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 0.6094118
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904797627535, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.7182353
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473904797627535, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.87058824
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473905038001440, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473905038001440, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473905038001440, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473905038001440, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473905038001440, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473905038001440, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473905038001441, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473905076002016, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473905076002016, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473905076002016, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473905076002016, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473905076002016, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473905076002016, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473905130024862, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 733f04facbc92a741a806acbfb941cc3,
+        type: 3}
+    - target: {fileID: 3267473905130024862, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 0.42
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473905130024862, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.42
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473905130024862, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.42
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473905152526751, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473905152526751, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473905152526751, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473905152526751, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473905152526751, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473905152526751, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473905169125337, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473905169125337, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473905169125337, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473905169125337, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473905169125337, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473905169125337, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3267473905169125338, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
+    - target: {fileID: 3333889866512137483, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3333889866512137483, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3333889866512137483, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3333889866512137483, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3333889866512137483, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3333889866512137483, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4399897670183957066, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
+    - target: {fileID: 4399897670883967349, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
+    - target: {fileID: 4399897671183392073, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
+    - target: {fileID: 4399897671683074004, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
+    - target: {fileID: 4399897671707159568, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
+    - target: {fileID: 4399897671949209348, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
+    - target: {fileID: 4685523036779863368, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4685523036779863368, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4685523036779863368, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4685523036779863368, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4685523036858412699, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4685523037356971014, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4685523037381124034, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4685523037621448311, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4685523037621448311, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4685523037621448311, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4685523037621448311, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4685523037627841750, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4685523037872488856, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4685523037946786379, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4685523037946786379, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4685523037946786379, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4685523037946786379, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4685523038453795030, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4685523038453795030, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4685523038453795030, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4685523038453795030, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4685523038477878034, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4685523038477878034, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4685523038477878034, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4685523038477878034, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4685523038709822119, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4685523038720466950, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4685523038720466950, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4685523038720466950, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4685523038720466950, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5083906087220029706, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
+    - target: {fileID: 5083906087590795829, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
+    - target: {fileID: 5083906088385136137, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
+    - target: {fileID: 5083906088689587268, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
+    - target: {fileID: 5083906088919398224, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
+    - target: {fileID: 5083906088960326804, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
+    - target: {fileID: 5859649077710290695, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
+    - target: {fileID: 7806920528214742832, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7806920528214742832, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7806920528214742832, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7806920528214742832, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7806920528738510441, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7806920528738510441, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7806920528738510441, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7806920528738510441, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7806920528781471149, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7806920528781471149, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7806920528781471149, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7806920528781471149, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7806920529047995773, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7806920529047995773, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7806920529047995773, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7806920529047995773, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7806920529329764403, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7806920529329764403, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7806920529329764403, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7806920529329764403, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7806920530096687884, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7806920530096687884, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7806920530096687884, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7806920530096687884, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7847169092699477370, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7847169092699477370, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7847169092699477370, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7847169092699477370, guid: 29b0e711db3f65542a213179a4cab985,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects:
@@ -111819,7 +111820,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 20, y: -0.0002822876}
+  m_AnchoredPosition: {x: 20, y: 0.0002822876}
   m_SizeDelta: {x: 20, y: 0}
   m_Pivot: {x: 1, y: 1}
 --- !u!114 &2122688343
@@ -116858,6 +116859,18 @@ PrefabInstance:
       addedObject: {fileID: 1219345030}
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 29b0e711db3f65542a213179a4cab985, type: 3}
+--- !u!114 &3267473903278256629 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3267473903239561669, guid: 29b0e711db3f65542a213179a4cab985,
+    type: 3}
+  m_PrefabInstance: {fileID: 3267473903278256628}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &7019164393237906219 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 5413720432969109321, guid: 54a8306856d05d14f8626082697dc22a,

--- a/Assets/__Scenes/03_Mapper.unity
+++ b/Assets/__Scenes/03_Mapper.unity
@@ -9690,6 +9690,7 @@ MonoBehaviour:
   editMode: 9
   obstaclePlacement: {fileID: 2087881065}
   ignoreBaseInput: 1
+  placementModeController: {fileID: 1243231048}
 --- !u!4 &171301929
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/__Scripts/Actions/BeatmapActions/BeatmapObjectModifiedCollectionAction.cs
+++ b/Assets/__Scripts/Actions/BeatmapActions/BeatmapObjectModifiedCollectionAction.cs
@@ -60,7 +60,10 @@ public class BeatmapObjectModifiedCollectionAction : BeatmapAction
         
         RefreshPools(Data);
         RefreshEventAppearance();
-        EndGlsEventReplacementBatch(glsEventCollection, "Restored GLS event collection.");
+        EndGlsEventReplacementBatch(
+            glsEventCollection,
+            OriginalObjects.OfType<BaseGLSEvent>(),
+            "Restored GLS event collection.");
     }
 
     public override void Redo(BeatmapActionContainer.BeatmapActionParams param)
@@ -88,7 +91,10 @@ public class BeatmapObjectModifiedCollectionAction : BeatmapAction
         
         RefreshPools(Data);
         RefreshEventAppearance();
-        EndGlsEventReplacementBatch(glsEventCollection, "Modified GLS event collection.");
+        EndGlsEventReplacementBatch(
+            glsEventCollection,
+            EditedObjects.OfType<BaseGLSEvent>(),
+            "Modified GLS event collection.");
     }
 
     private GLSEventGridContainer BeginGlsEventReplacementBatch()
@@ -105,13 +111,21 @@ public class BeatmapObjectModifiedCollectionAction : BeatmapAction
         return collection;
     }
 
-    private static void EndGlsEventReplacementBatch(GLSEventGridContainer collection, string message)
+    private void EndGlsEventReplacementBatch(
+        GLSEventGridContainer collection,
+        IEnumerable<BaseGLSEvent> selectionSources,
+        string message)
     {
         // The final replacement supplies the simulator with every edited child event in one cache update.
         // Unity collections need their overloaded null comparison before batch replacement ends.
         if (collection != null)
         {
             collection.EndGroupReplacementBatch(message);
+            // Rebind selected inner nodes after the replacement action's default parent selection has completed.
+            if (!Networked)
+            {
+                collection.RebindSelectionAfterBatch(selectionSources);
+            }
         }
     }
 

--- a/Assets/__Scripts/Beatmap/Appearances/GLSEventAppearanceSO.cs
+++ b/Assets/__Scripts/Beatmap/Appearances/GLSEventAppearanceSO.cs
@@ -14,7 +14,6 @@ namespace Beatmap.Appearances
         private static readonly int colorId = Shader.PropertyToID("_Color");
         private static readonly int strobeColorId = Shader.PropertyToID("_StrobeColor");
         private static readonly int strobeColorEnabledId = Shader.PropertyToID("_StrobeColorEnabled");
-
         public void SetAppearance(
             GLSEventContainer container,
             bool final = true,

--- a/Assets/__Scripts/Beatmap/Appearances/GLSEventCommon.cs
+++ b/Assets/__Scripts/Beatmap/Appearances/GLSEventCommon.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Beatmap.Appearances;
 using Beatmap.Base;
@@ -12,8 +13,6 @@ public static class GLSEventCommon
 {
     // Keep zero-brightness GLS sections 30% darker than the previous 25%-of-source off endpoint.
     private const float DimmedColorFraction = 0.175f;
-    // Retain one diagnostic per source node while GLS color-ribbon matching is being verified.
-    private static readonly HashSet<string> ribbonDiagnosticKeys = new();
     // Partition color-transition timelines by GLS group ID so unrelated light groups never share cache work.
     private static readonly Dictionary<int, ColorTransitionGroupCache> colorTransitionCaches = new();
     // Index only sources with active transition intervals so viewport retention never scans all color sequences.
@@ -24,6 +23,36 @@ public static class GLSEventCommon
     private static readonly Comparer<BaseLightColorBase> colorEventComparer =
         Comparer<BaseLightColorBase>.Create(CompareColorEvents);
     private static BaseDifficulty cachedColorTransitionMap;
+
+    // GLS edits replace groups and child objects with clones, so diagnostics must expose reference identity as well as serialized values.
+    public static string DescribeEvent(BaseGLSEvent evt)
+    {
+        if (evt == null)
+        {
+            return "null";
+        }
+
+        var color = evt is BaseLightColorBase colorEvent
+            ? $", color={colorEvent.Color}, custom={FormatColor(colorEvent.CustomColor)}, usePrevious={colorEvent.UsePrevious}, easing={colorEvent.Easing}"
+            : string.Empty;
+        return $"{evt.GetType().Name}@{ReferenceId(evt)} abs={evt.JsonTime:R} rel={evt.RelativeJsonTime:R} " +
+               $"box={evt.BoxIndex}/@{ReferenceId(evt.EventBoxData)} group={DescribeGroup(evt.EventBoxGroupData)}{color}";
+    }
+
+    // Group identity is logged separately because equal serialized GLS groups are routinely replaced by new instances.
+    public static string DescribeGroup(BaseEventBoxGroup group) => group == null
+        ? "null"
+        : $"{group.GetType().Name}@{ReferenceId(group)} id={group.ID} beat={group.JsonTime:R} boxes={group.ReadOnlyBoxes.Count}";
+
+    // Reference IDs remain null-safe while exposing identity independently of mutable beatmap equality.
+    public static int ReferenceId(object value) => value == null
+        ? 0
+        : RuntimeHelpers.GetHashCode(value);
+
+    // Nullable Chroma values need an invariant compact representation so cloned-event logs can be compared directly.
+    public static string FormatColor(Color? color) => color.HasValue
+        ? $"({color.Value.r:R},{color.Value.g:R},{color.Value.b:R},{color.Value.a:R})"
+        : "null";
 
     public static Color GetColor(BaseLightColorBase evt, bool boost, EventAppearanceSO eventAppearance)
     {
@@ -373,6 +402,8 @@ public static class GLSEventCommon
         private readonly List<ColorFilterSequence> sequences = new();
         // Resolve an event's filter timeline without scanning its sibling filters during ribbon rendering.
         private readonly Dictionary<BaseLightColorBase, ColorFilterSequence> sequenceByEvent = new();
+        // A cache miss may occur during repeated appearance refreshes, so compare equivalent identities only once per requested clone.
+        private readonly HashSet<BaseLightColorBase> identityMissDiagnosticSources = new();
 
         // Drop an ID cache once it contains no event identities, even if an empty authored box remains.
         public bool IsEmpty => sequenceByEvent.Count == 0;
@@ -452,12 +483,26 @@ public static class GLSEventCommon
 
         public bool TryGetFollowingEvent(BaseLightColorBase source, out BaseLightColorBase followingEvent)
         {
-            if (sequenceByEvent.TryGetValue(source, out var sequence))
+            var sourceFound = sequenceByEvent.TryGetValue(source, out var sequence);
+            if (sourceFound)
             {
                 if (sequence.FollowingEvents.TryGetValue(source, out followingEvent))
                 {
                     return true;
                 }
+            }
+
+            // An equivalent event is only an identity miss when the requested source itself is absent, not merely the final node in a sequence.
+            if (sourceFound)
+            {
+                followingEvent = null;
+                return false;
+            }
+
+            if (!identityMissDiagnosticSources.Add(source))
+            {
+                followingEvent = null;
+                return false;
             }
 
             followingEvent = null;
@@ -625,23 +670,6 @@ public static class GLSEventCommon
             Maximum = Mathf.Max(Maximum, time);
         }
     }
-
-    // // Keep the current match evidence in the Console until the GLS ribbon behavior is confirmed in-editor.
-    // private static void LogRibbonDiagnostic(
-    //     BaseLightColorBase source,
-    //     BaseLightColorBase followingEvent,
-    //     Color? startColor,
-    //     Color? endColor)
-    // {
-    //     var key = $"{source.EventBoxGroupData?.ID}:{source.JsonTime:F4}:{source.BoxIndex}:{source.EventBoxData?.IndexFilter?.ToJson()}";
-    //     if (!ribbonDiagnosticKeys.Add(key))
-    //         return;
-
-    //     Debug.Log(
-    //         $"[GLS Ribbon] group:{source.EventBoxGroupData?.ID}, source=time:{source.JsonTime:F3}, easing:{source.Easing}, color:{source.Color}; " +
-    //         $"following={(followingEvent == null ? "none" : $"time:{followingEvent.JsonTime:F3}, easing:{followingEvent.Easing}, usePrevious:{followingEvent.UsePrevious}, color:{followingEvent.Color}")}; " +
-    //         $"gradient={startColor?.ToString() ?? "none"}->{endColor?.ToString() ?? "none"}.");
-    // }
 
     // Index filters are cloned per GLS group, so compare their serialized matching parameters instead of references.
     private static bool IndexFiltersMatch(BaseIndexFilter left, BaseIndexFilter right) =>

--- a/Assets/__Scripts/Beatmap/Appearances/GLSGroupAppearanceSO.cs
+++ b/Assets/__Scripts/Beatmap/Appearances/GLSGroupAppearanceSO.cs
@@ -26,14 +26,14 @@ namespace Beatmap.Appearances
                 ? EventAppearanceSO.FinalNodeScale
                 : EventAppearanceSO.PreviewNodeScale);
             container.MpbController.Mpb.SetFloat(strobeColorEnabledId, 0f);
+
+            // Appearance refreshes are frequent, so only build ordering when the group has not initialized its maintained cache.
+            if (container.EventBoxGroupData is not null && !container.EventBoxGroupData.OrderedEventsInitialized)
+                container.EventBoxGroupData.ResortOrderedEvents();
+
             switch (container.EventBoxGroupData)
             {
                 case BaseLightColorEventBoxGroup lcebg:
-                    // Appearance refreshes are frequent, so only build ordering when the group has not initialized its maintained cache.
-                    if (!lcebg.OrderedEventsInitialized)
-                    {
-                        lcebg.ResortOrderedEvents();
-                    }
                     // Prefer the represented ghost node while preserving the original single-node fallback.
                     var colorEvt = container.PreviewEventData as BaseLightColorBase
                         ?? lcebg.OrderedEvents.AsValueEnumerable().OfType<BaseLightColorBase>().FirstOrDefault();
@@ -62,10 +62,6 @@ namespace Beatmap.Appearances
 
                     break;
                 case BaseLightRotationEventBoxGroup lrebg:
-                    if (!lrebg.OrderedEventsInitialized)
-                    {
-                        lrebg.ResortOrderedEvents();
-                    }
                     // Prefer the represented ghost node while preserving the original single-node fallback.
                     var rotationEvt = container.PreviewEventData as BaseLightRotationBase
                         ?? lrebg.OrderedEvents.AsValueEnumerable().OfType<BaseLightRotationBase>().FirstOrDefault();
@@ -84,10 +80,6 @@ namespace Beatmap.Appearances
 
                     break;
                 case BaseLightTranslationEventBoxGroup ltebg:
-                    if (!ltebg.OrderedEventsInitialized)
-                    {
-                        ltebg.ResortOrderedEvents();
-                    }
                     // Prefer the represented ghost node while preserving the original single-node fallback.
                     var translationEvt = container.PreviewEventData as BaseLightTranslationBase
                         ?? ltebg.OrderedEvents.AsValueEnumerable().OfType<BaseLightTranslationBase>().FirstOrDefault();
@@ -106,10 +98,6 @@ namespace Beatmap.Appearances
 
                     break;
                 case BaseVfxEventEventBoxGroup ffbg:
-                    if (!ffbg.OrderedEventsInitialized)
-                    {
-                        ffbg.ResortOrderedEvents();
-                    }
                     // Prefer the represented ghost node while preserving the original single-node fallback.
                     var fxEvt = container.PreviewEventData as BaseFxEventFloat
                         ?? ffbg.OrderedEvents.AsValueEnumerable().OfType<BaseFxEventFloat>().FirstOrDefault();

--- a/Assets/__Scripts/Beatmap/Appearances/GLSGroupAppearanceSO.cs
+++ b/Assets/__Scripts/Beatmap/Appearances/GLSGroupAppearanceSO.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Globalization;
 using ZLinq;
 using Beatmap.Base;
@@ -17,7 +16,6 @@ namespace Beatmap.Appearances
         private static readonly int colorId = Shader.PropertyToID("_Color");
         private static readonly int strobeColorId = Shader.PropertyToID("_StrobeColor");
         private static readonly int strobeColorEnabledId = Shader.PropertyToID("_StrobeColorEnabled");
-
         public void SetAppearance(
             GLSGroupContainer container,
             bool final = true,
@@ -31,8 +29,11 @@ namespace Beatmap.Appearances
             switch (container.EventBoxGroupData)
             {
                 case BaseLightColorEventBoxGroup lcebg:
-                    // The outer preview represents the earliest node, with lane order used as the tie-breaker.
-                    lcebg.ResortOrderedEvents();
+                    // Appearance refreshes are frequent, so only build ordering when the group has not initialized its maintained cache.
+                    if (!lcebg.OrderedEventsInitialized)
+                    {
+                        lcebg.ResortOrderedEvents();
+                    }
                     // Prefer the represented ghost node while preserving the original single-node fallback.
                     var colorEvt = container.PreviewEventData as BaseLightColorBase
                         ?? lcebg.OrderedEvents.AsValueEnumerable().OfType<BaseLightColorBase>().FirstOrDefault();
@@ -61,7 +62,10 @@ namespace Beatmap.Appearances
 
                     break;
                 case BaseLightRotationEventBoxGroup lrebg:
-                    lrebg.ResortOrderedEvents();
+                    if (!lrebg.OrderedEventsInitialized)
+                    {
+                        lrebg.ResortOrderedEvents();
+                    }
                     // Prefer the represented ghost node while preserving the original single-node fallback.
                     var rotationEvt = container.PreviewEventData as BaseLightRotationBase
                         ?? lrebg.OrderedEvents.AsValueEnumerable().OfType<BaseLightRotationBase>().FirstOrDefault();
@@ -80,7 +84,10 @@ namespace Beatmap.Appearances
 
                     break;
                 case BaseLightTranslationEventBoxGroup ltebg:
-                    ltebg.ResortOrderedEvents();
+                    if (!ltebg.OrderedEventsInitialized)
+                    {
+                        ltebg.ResortOrderedEvents();
+                    }
                     // Prefer the represented ghost node while preserving the original single-node fallback.
                     var translationEvt = container.PreviewEventData as BaseLightTranslationBase
                         ?? ltebg.OrderedEvents.AsValueEnumerable().OfType<BaseLightTranslationBase>().FirstOrDefault();
@@ -99,7 +106,10 @@ namespace Beatmap.Appearances
 
                     break;
                 case BaseVfxEventEventBoxGroup ffbg:
-                    ffbg.ResortOrderedEvents();
+                    if (!ffbg.OrderedEventsInitialized)
+                    {
+                        ffbg.ResortOrderedEvents();
+                    }
                     // Prefer the represented ghost node while preserving the original single-node fallback.
                     var fxEvt = container.PreviewEventData as BaseFxEventFloat
                         ?? ffbg.OrderedEvents.AsValueEnumerable().OfType<BaseFxEventFloat>().FirstOrDefault();

--- a/Assets/__Scripts/Beatmap/Base/BaseEventBox.cs
+++ b/Assets/__Scripts/Beatmap/Base/BaseEventBox.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections.Generic;
 using Beatmap.Enums;
+using UnityEngine;
 
 namespace Beatmap.Base
 {
@@ -37,6 +39,88 @@ namespace Beatmap.Base
         public abstract IReadOnlyList<BaseGLSEvent> ReadOnlyEvents { get; }
         public abstract void ClearEvents();
         public abstract void SetEvents(BaseGLSEvent[] data);
+
+        // Editor mutations must replace an existing node at the same relative beat instead of creating overlapping, ambiguous GLS nodes.
+        protected static BaseGLSEvent[] ResolveSameBeatConflicts(BaseGLSEvent[] data)
+        {
+            if (data == null || data.Length < 2)
+            {
+                return data ?? Array.Empty<BaseGLSEvent>();
+            }
+
+            // SetEvents callers normally supply chronological unique nodes, so keep that hot mutation path allocation-free here.
+            var requiresResolution = false;
+            for (var index = 1; index < data.Length; index++)
+            {
+                var previousTime = data[index - 1].RelativeJsonTime;
+                var currentTime = data[index].RelativeJsonTime;
+                if (currentTime < previousTime
+                    || Math.Abs(currentTime - previousTime) < BeatmapObjectContainerCollection.Epsilon)
+                {
+                    requiresResolution = true;
+                    break;
+                }
+            }
+
+            if (!requiresResolution)
+            {
+                return data;
+            }
+
+            var indexedEvents = new IndexedEvent[data.Length];
+            for (var index = 0; index < data.Length; index++)
+            {
+                indexedEvents[index] = new IndexedEvent(data[index], index);
+            }
+
+            Array.Sort(indexedEvents, static (left, right) =>
+            {
+                var comparison = left.Event.RelativeJsonTime.CompareTo(right.Event.RelativeJsonTime);
+                return comparison != 0
+                    ? comparison
+                    : left.OriginalIndex.CompareTo(right.OriginalIndex);
+            });
+
+            var resolved = new List<BaseGLSEvent>(indexedEvents.Length);
+            for (var index = 0; index < indexedEvents.Length; index++)
+            {
+                var evt = indexedEvents[index].Event;
+                if (resolved.Count > 0
+                    && Math.Abs(resolved[resolved.Count - 1].RelativeJsonTime - evt.RelativeJsonTime)
+                    < BeatmapObjectContainerCollection.Epsilon)
+                {
+                    // Preserve normal replacement semantics and identify every discarded node precisely enough to repair the source JSON.
+                    var deletedEvent = resolved[resolved.Count - 1];
+                    var outerBeat = evt.EventBoxGroupData != null
+                        ? evt.EventBoxGroupData.JsonTime
+                        : evt.JsonTime - evt.RelativeJsonTime;
+                    Debug.LogWarning(
+                        $"[GLSEventConflict] Deleted duplicate GLS node outerGroupBeat={outerBeat:R} " +
+                        $"innerBeatOffset={deletedEvent.RelativeJsonTime:R} filterLane={deletedEvent.BoxIndex} " +
+                        $"deleted={GLSEventCommon.DescribeEvent(deletedEvent)} kept={GLSEventCommon.DescribeEvent(evt)}.");
+                    resolved[resolved.Count - 1] = evt;
+                }
+                else
+                {
+                    resolved.Add(evt);
+                }
+            }
+
+            return resolved.ToArray();
+        }
+
+        // Stable source indexes make the last supplied node win even though Array.Sort itself is unstable on equal keys.
+        private readonly struct IndexedEvent
+        {
+            public IndexedEvent(BaseGLSEvent evt, int originalIndex)
+            {
+                Event = evt;
+                OriginalIndex = originalIndex;
+            }
+
+            public BaseGLSEvent Event { get; }
+            public int OriginalIndex { get; }
+        }
 
         public virtual Axis GetAxis() => Axis.X;
 

--- a/Assets/__Scripts/Beatmap/Base/BaseEventBoxGroup.cs
+++ b/Assets/__Scripts/Beatmap/Base/BaseEventBoxGroup.cs
@@ -32,6 +32,9 @@ namespace Beatmap.Base
         // Expose the generic group's maintained preview ordering to base-type viewport code without re-walking boxes.
         public abstract IReadOnlyList<BaseGLSEvent> ReadOnlyOrderedEvents { get; }
 
+        // Shared GLS mutation code receives the non-generic group base, so expose its required ordering refresh polymorphically.
+        public abstract void ResortOrderedEvents();
+
         // Keep event invocation in the declaring base type so generic groups can invalidate their data-only indexes.
         protected void NotifyOrderedEventsResorted() => OnOrderedEventsResorted?.Invoke(this);
     }
@@ -60,7 +63,7 @@ namespace Beatmap.Base
         // Distinguish an initialized empty authored group from a cache that has not been built yet.
         public bool OrderedEventsInitialized { get; private set; }
 
-        public void ResortOrderedEvents()
+        public override void ResortOrderedEvents()
         {
             // Preserve each event's array/JSON index as the final tie-breaker because sort stability is not guaranteed.
             // Without it, stacked events with identical time and BoxIndex can randomly alternate as the outer preview.
@@ -89,6 +92,25 @@ namespace Beatmap.Base
             OrderedEventsInitialized = true;
             // Refresh only indexes that own this group instead of coupling selection to rendered containers.
             NotifyOrderedEventsResorted();
+        }
+
+        // Deserialization has complete group ownership here, so normalize each filter lane once and report accurate outer/inner beats.
+        public void NormalizeLoadedEventConflicts()
+        {
+            for (var boxIndex = 0; boxIndex < Boxes.Count; boxIndex++)
+            {
+                var box = Boxes[boxIndex];
+                box.SetEvents(box.ReadOnlyEvents.AsValueEnumerable().ToArray());
+                foreach (var evt in box.ReadOnlyEvents)
+                {
+                    evt.EventBoxData = box;
+                    evt.EventBoxGroupData = this;
+                    evt.BoxIndex = boxIndex;
+                    evt.JsonTime = JsonTime + evt.RelativeJsonTime;
+                }
+            }
+
+            ResortOrderedEvents();
         }
 
         public override int CompareTo(BaseObject other)

--- a/Assets/__Scripts/Beatmap/Base/BaseEventBoxGroup.cs
+++ b/Assets/__Scripts/Beatmap/Base/BaseEventBoxGroup.cs
@@ -32,8 +32,8 @@ namespace Beatmap.Base
 
         public abstract IReadOnlyList<BaseEventBox> ReadOnlyBoxes { get; }
 
-        // Expose the generic group's maintained preview ordering to base-type viewport code without re-walking boxes.
-        public abstract IReadOnlyList<BaseGLSEvent> ReadOnlyOrderedEvents { get; }
+        // Base-type viewport code needs the cached List so it can use the shared allocation-free binary-search helper.
+        public abstract List<BaseGLSEvent> OrderedEvents { get; protected set; }
 
         // Shared GLS mutation code receives the non-generic group base, so expose its required ordering refresh polymorphically.
         public abstract void ResortOrderedEvents();
@@ -58,10 +58,7 @@ namespace Beatmap.Base
         public List<TBox> Boxes = new();
 
         // Cached node ordering supports deterministic outer previews and future ghost-node rendering.
-        public List<BaseGLSEvent> OrderedEvents { get; private set; } = new();
-
-        // Preserve the mutable concrete cache while exposing a read-only base-type view for shared GLS retention logic.
-        public override IReadOnlyList<BaseGLSEvent> ReadOnlyOrderedEvents => OrderedEvents;
+        public override List<BaseGLSEvent> OrderedEvents { get; protected set; } = new();
 
         public override void ResortOrderedEvents()
         {

--- a/Assets/__Scripts/Beatmap/Base/BaseEventBoxGroup.cs
+++ b/Assets/__Scripts/Beatmap/Base/BaseEventBoxGroup.cs
@@ -27,6 +27,9 @@ namespace Beatmap.Base
             return false;
         }
 
+        // Distinguish an initialized empty authored group from a cache that has not been built yet.
+        public bool OrderedEventsInitialized { get; set; }
+
         public abstract IReadOnlyList<BaseEventBox> ReadOnlyBoxes { get; }
 
         // Expose the generic group's maintained preview ordering to base-type viewport code without re-walking boxes.
@@ -59,9 +62,6 @@ namespace Beatmap.Base
 
         // Preserve the mutable concrete cache while exposing a read-only base-type view for shared GLS retention logic.
         public override IReadOnlyList<BaseGLSEvent> ReadOnlyOrderedEvents => OrderedEvents;
-
-        // Distinguish an initialized empty authored group from a cache that has not been built yet.
-        public bool OrderedEventsInitialized { get; private set; }
 
         public override void ResortOrderedEvents()
         {

--- a/Assets/__Scripts/Beatmap/Base/BaseLightColorEventBox.cs
+++ b/Assets/__Scripts/Beatmap/Base/BaseLightColorEventBox.cs
@@ -27,6 +27,7 @@ namespace Beatmap.Base
             BrightnessDistribution = brightnessDistribution;
             BrightnessDistributionType = brightnessDistributionType;
             BrightnessAffectFirst = brightnessAffectFirst;
+            // Group-level load finalization removes conflicts after parent beat and lane ownership are available for diagnostics.
             Events = events;
         }
 
@@ -43,6 +44,7 @@ namespace Beatmap.Base
             BrightnessDistribution = brightnessDistribution;
             BrightnessDistributionType = brightnessDistributionType;
             BrightnessAffectFirst = brightnessAffectFirst;
+            // Group-level load finalization removes conflicts after parent beat and lane ownership are available for diagnostics.
             Events = events;
         }
 
@@ -75,6 +77,8 @@ namespace Beatmap.Base
 
         public override void ClearEvents() => Events = Array.Empty<BaseLightColorBase>();
 
-        public override void SetEvents(BaseGLSEvent[] data) => Events = data.OfType<BaseLightColorBase>().ToArray();
+        // Color-lane mutations use the shared occupied-beat replacement invariant before restoring their typed array.
+        public override void SetEvents(BaseGLSEvent[] data) =>
+            Events = ResolveSameBeatConflicts(data).OfType<BaseLightColorBase>().ToArray();
     }
 }

--- a/Assets/__Scripts/Beatmap/Base/BaseLightRotationEventBox.cs
+++ b/Assets/__Scripts/Beatmap/Base/BaseLightRotationEventBox.cs
@@ -34,6 +34,7 @@ namespace Beatmap.Base
             RotationAffectFirst = rotationAffectFirst;
             Axis = axis;
             Flip = flip;
+            // Group-level load finalization removes conflicts after parent beat and lane ownership are available for diagnostics.
             Events = events;
         }
 
@@ -58,6 +59,7 @@ namespace Beatmap.Base
             RotationAffectFirst = rotationAffectFirst;
             Axis = axis;
             Flip = flip;
+            // Group-level load finalization removes conflicts after parent beat and lane ownership are available for diagnostics.
             Events = events;
         }
 
@@ -94,7 +96,9 @@ namespace Beatmap.Base
 
         public override void ClearEvents() => Events = Array.Empty<BaseLightRotationBase>();
         
-        public override void SetEvents(BaseGLSEvent[] data) => Events = data.OfType<BaseLightRotationBase>().ToArray();
+        // Rotation-axis mutations use the shared occupied-beat replacement invariant before restoring their typed array.
+        public override void SetEvents(BaseGLSEvent[] data) =>
+            Events = ResolveSameBeatConflicts(data).OfType<BaseLightRotationBase>().ToArray();
 
         public override Axis GetAxis() => (Axis)Axis;
     }

--- a/Assets/__Scripts/Beatmap/Base/BaseLightTranslationEventBox.cs
+++ b/Assets/__Scripts/Beatmap/Base/BaseLightTranslationEventBox.cs
@@ -34,6 +34,7 @@ namespace Beatmap.Base
             TranslationAffectFirst = translationAffectFirst;
             Axis = axis;
             Flip = flip;
+            // Group-level load finalization removes conflicts after parent beat and lane ownership are available for diagnostics.
             Events = events;
         }
 
@@ -58,6 +59,7 @@ namespace Beatmap.Base
             TranslationAffectFirst = translationAffectFirst;
             Axis = axis;
             Flip = flip;
+            // Group-level load finalization removes conflicts after parent beat and lane ownership are available for diagnostics.
             Events = events;
         }
 
@@ -94,8 +96,9 @@ namespace Beatmap.Base
 
         public override void ClearEvents() => Events = Array.Empty<BaseLightTranslationBase>();
 
+        // Translation-axis mutations use the shared occupied-beat replacement invariant before restoring their typed array.
         public override void SetEvents(BaseGLSEvent[] data) =>
-            Events = data.OfType<BaseLightTranslationBase>().ToArray();
+            Events = ResolveSameBeatConflicts(data).OfType<BaseLightTranslationBase>().ToArray();
 
         public override Axis GetAxis() => (Axis)Axis;
     }

--- a/Assets/__Scripts/Beatmap/Base/BaseVfxEventEventBox.cs
+++ b/Assets/__Scripts/Beatmap/Base/BaseVfxEventEventBox.cs
@@ -31,7 +31,8 @@ namespace Beatmap.Base
             VfxDistribution = vfxDistribution;
             VfxDistributionType = vfxDistributionType;
             VfxAffectFirst = vfxAffectFirst;
-            Events = Events.Select(e => (BaseFxEventFloat)e.Clone()).ToArray();
+            // Group-level load finalization removes conflicts after parent beat and lane ownership are available for diagnostics.
+            Events = floatFxEvents.ToArray();
         }
 
         protected BaseVfxEventEventBox(
@@ -51,7 +52,8 @@ namespace Beatmap.Base
             VfxDistribution = vfxDistribution;
             VfxDistributionType = vfxDistributionType;
             VfxAffectFirst = vfxAffectFirst;
-            Events = Events.Select(e => (BaseFxEventFloat)e.Clone()).ToArray();
+            // Group-level load finalization removes conflicts after parent beat and lane ownership are available for diagnostics.
+            Events = floatFxEvents.ToArray();
         }
 
         protected BaseVfxEventEventBox(BaseVfxEventEventBox other) : base(
@@ -84,6 +86,8 @@ namespace Beatmap.Base
 
         public override void ClearEvents() => Events = Array.Empty<BaseFxEventFloat>();
         
-        public override void SetEvents(BaseGLSEvent[] data) => Events = data.OfType<BaseFxEventFloat>().ToArray();
+        // FloatFX-lane mutations use the shared occupied-beat replacement invariant before restoring their typed array.
+        public override void SetEvents(BaseGLSEvent[] data) =>
+            Events = ResolveSameBeatConflicts(data).OfType<BaseFxEventFloat>().ToArray();
     }
 }

--- a/Assets/__Scripts/Beatmap/ColorBoostEventIndex.cs
+++ b/Assets/__Scripts/Beatmap/ColorBoostEventIndex.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Beatmap.Base;
 using Beatmap.Containers;
@@ -102,7 +103,9 @@ internal sealed class ColorBoostEventIndex
     }
 
     // Refresh only loaded light events between the earliest changed boost and its next palette boundary.
-    public void RefreshDependentAppearances(EventGridContainer gridContainer)
+    public void RefreshDependentAppearances(
+        EventGridContainer gridContainer,
+        Action<float, float> refreshGlsAppearances)
     {
         if (appearanceStartTime == float.PositiveInfinity)
         {
@@ -155,6 +158,8 @@ internal sealed class ColorBoostEventIndex
             (container as EventContainer).RefreshAppearance();
         }
 
+        // GLS collections own separate preview containers, so propagate this exact palette interval before clearing it.
+        refreshGlsAppearances?.Invoke(appearanceStartTime, appearanceEndTime);
         appearanceStartTime = float.PositiveInfinity;
         appearanceEndTime = float.NegativeInfinity;
     }

--- a/Assets/__Scripts/Beatmap/Containers/GLSGroupContainer.cs
+++ b/Assets/__Scripts/Beatmap/Containers/GLSGroupContainer.cs
@@ -191,19 +191,36 @@ namespace Beatmap.Containers
             switch (EventBoxGroupData)
             {
                 case BaseLightColorEventBoxGroup colorGroup:
-                    colorGroup.ResortOrderedEvents();
+                    // Preview rebuilds can happen repeatedly while scrolling, so consume the maintained ordering unless it is uninitialized.
+                    if (!colorGroup.OrderedEventsInitialized)
+                    {
+                        colorGroup.ResortOrderedEvents();
+                    }
+
                     ConfigurePreviewNodes(colorGroup.OrderedEvents, isBoostAt);
                     break;
                 case BaseLightRotationEventBoxGroup rotationGroup:
-                    rotationGroup.ResortOrderedEvents();
+                    if (!rotationGroup.OrderedEventsInitialized)
+                    {
+                        rotationGroup.ResortOrderedEvents();
+                    }
+
                     ConfigurePreviewNodes(rotationGroup.OrderedEvents, isBoostAt);
                     break;
                 case BaseLightTranslationEventBoxGroup translationGroup:
-                    translationGroup.ResortOrderedEvents();
+                    if (!translationGroup.OrderedEventsInitialized)
+                    {
+                        translationGroup.ResortOrderedEvents();
+                    }
+
                     ConfigurePreviewNodes(translationGroup.OrderedEvents, isBoostAt);
                     break;
                 case BaseVfxEventEventBoxGroup floatFxGroup:
-                    floatFxGroup.ResortOrderedEvents();
+                    if (!floatFxGroup.OrderedEventsInitialized)
+                    {
+                        floatFxGroup.ResortOrderedEvents();
+                    }
+
                     ConfigurePreviewNodes(floatFxGroup.OrderedEvents, isBoostAt);
                     break;
             }

--- a/Assets/__Scripts/Beatmap/Containers/GLSGroupContainer.cs
+++ b/Assets/__Scripts/Beatmap/Containers/GLSGroupContainer.cs
@@ -188,39 +188,22 @@ namespace Beatmap.Containers
                 return;
             }
 
+            // Preview rebuilds can happen repeatedly while scrolling, so consume the maintained ordering unless it is uninitialized.
+            if (!EventBoxGroupData.OrderedEventsInitialized)
+                EventBoxGroupData.ResortOrderedEvents();
+
             switch (EventBoxGroupData)
             {
                 case BaseLightColorEventBoxGroup colorGroup:
-                    // Preview rebuilds can happen repeatedly while scrolling, so consume the maintained ordering unless it is uninitialized.
-                    if (!colorGroup.OrderedEventsInitialized)
-                    {
-                        colorGroup.ResortOrderedEvents();
-                    }
-
                     ConfigurePreviewNodes(colorGroup.OrderedEvents, isBoostAt);
                     break;
                 case BaseLightRotationEventBoxGroup rotationGroup:
-                    if (!rotationGroup.OrderedEventsInitialized)
-                    {
-                        rotationGroup.ResortOrderedEvents();
-                    }
-
                     ConfigurePreviewNodes(rotationGroup.OrderedEvents, isBoostAt);
                     break;
                 case BaseLightTranslationEventBoxGroup translationGroup:
-                    if (!translationGroup.OrderedEventsInitialized)
-                    {
-                        translationGroup.ResortOrderedEvents();
-                    }
-
                     ConfigurePreviewNodes(translationGroup.OrderedEvents, isBoostAt);
                     break;
                 case BaseVfxEventEventBoxGroup floatFxGroup:
-                    if (!floatFxGroup.OrderedEventsInitialized)
-                    {
-                        floatFxGroup.ResortOrderedEvents();
-                    }
-
                     ConfigurePreviewNodes(floatFxGroup.OrderedEvents, isBoostAt);
                     break;
             }

--- a/Assets/__Scripts/Beatmap/V3/V3LightColorEventBoxGroup.cs
+++ b/Assets/__Scripts/Beatmap/V3/V3LightColorEventBoxGroup.cs
@@ -34,6 +34,8 @@ namespace Beatmap.V3
                 })
                 .ToList();
 
+            // Remove invalid same-lane/same-beat nodes once the loaded group can produce actionable beat diagnostics.
+            group.NormalizeLoadedEventConflicts();
             return group;
         }
 

--- a/Assets/__Scripts/Beatmap/V3/V3LightRotationEventBoxGroup.cs
+++ b/Assets/__Scripts/Beatmap/V3/V3LightRotationEventBoxGroup.cs
@@ -34,6 +34,8 @@ namespace Beatmap.V3
                 })
                 .ToList();
 
+            // Remove invalid same-lane/same-beat nodes once the loaded group can produce actionable beat diagnostics.
+            group.NormalizeLoadedEventConflicts();
             return group;
         }
 

--- a/Assets/__Scripts/Beatmap/V3/V3LightTranslationEventBoxGroup.cs
+++ b/Assets/__Scripts/Beatmap/V3/V3LightTranslationEventBoxGroup.cs
@@ -34,6 +34,8 @@ namespace Beatmap.V3
                 })
                 .ToList();
 
+            // Remove invalid same-lane/same-beat nodes once the loaded group can produce actionable beat diagnostics.
+            group.NormalizeLoadedEventConflicts();
             return group;
         }
 

--- a/Assets/__Scripts/Beatmap/V3/V3VfxEventEventBoxGroup.cs
+++ b/Assets/__Scripts/Beatmap/V3/V3VfxEventEventBoxGroup.cs
@@ -39,6 +39,8 @@ namespace Beatmap.V3
                 })
                 .ToList();
 
+            // Remove invalid same-lane/same-beat nodes once the loaded group can produce actionable beat diagnostics.
+            group.NormalizeLoadedEventConflicts();
             return group;
         }
 

--- a/Assets/__Scripts/Beatmap/V4/V4LightColorEventBoxGroup.cs
+++ b/Assets/__Scripts/Beatmap/V4/V4LightColorEventBoxGroup.cs
@@ -75,6 +75,8 @@ namespace Beatmap.V4
                 })
                 .ToList();
 
+            // Remove invalid same-lane/same-beat nodes once the loaded group can produce actionable beat diagnostics.
+            group.NormalizeLoadedEventConflicts();
             return group;
         }
 

--- a/Assets/__Scripts/Beatmap/V4/V4LightRotationEventBoxGroup.cs
+++ b/Assets/__Scripts/Beatmap/V4/V4LightRotationEventBoxGroup.cs
@@ -73,6 +73,8 @@ namespace Beatmap.V4
                 })
                 .ToList();
 
+            // Remove invalid same-lane/same-beat nodes once the loaded group can produce actionable beat diagnostics.
+            group.NormalizeLoadedEventConflicts();
             return group;
         }
 

--- a/Assets/__Scripts/Beatmap/V4/V4LightTranslationEventBoxGroup.cs
+++ b/Assets/__Scripts/Beatmap/V4/V4LightTranslationEventBoxGroup.cs
@@ -71,6 +71,8 @@ namespace Beatmap.V4
                 })
                 .ToList();
 
+            // Remove invalid same-lane/same-beat nodes once the loaded group can produce actionable beat diagnostics.
+            group.NormalizeLoadedEventConflicts();
             return group;
         }
 

--- a/Assets/__Scripts/Beatmap/V4/V4VfxEventEventBoxGroup.cs
+++ b/Assets/__Scripts/Beatmap/V4/V4VfxEventEventBoxGroup.cs
@@ -72,6 +72,8 @@ namespace Beatmap.V4
 
             group.CustomData = node["customData"];
 
+            // Remove invalid same-lane/same-beat nodes once the loaded group can produce actionable beat diagnostics.
+            group.NormalizeLoadedEventConflicts();
             return group;
         }
 

--- a/Assets/__Scripts/Editor/Grid/Collections/EventGridContainer.cs
+++ b/Assets/__Scripts/Editor/Grid/Collections/EventGridContainer.cs
@@ -30,6 +30,9 @@ public class EventGridContainer : BeatmapObjectContainerCollection<BaseEvent>, C
     // Isolate boost ordering and predecessor queries from the grid's rendering and invalidation responsibilities.
     private readonly ColorBoostEventIndex boostEventIndex = new();
 
+    // Let GLS preview collections repaint only the palette interval changed by a boost node edit.
+    public event Action<float, float> OnBoostAppearanceRangeInvalidated;
+
     public List<BaseEvent> AllBpmEvents = new();
 
     private readonly HashSet<BaseEvent> lightEventsWithKnownPrevNext = new();
@@ -116,7 +119,13 @@ public class EventGridContainer : BeatmapObjectContainerCollection<BaseEvent>, C
 
     public void OnCycleLightPropagationUp(InputAction.CallbackContext context)
     {
-        if (!context.performed || PropagationEditing == PropMode.Off) return;
+        // Shared PageUp must only change light-ID lanes while Basic Events owns the active editing context.
+        if (!context.performed
+            || !EditContext.EditingMode.HasFlag(EditingMode.BasicEvent)
+            || PropagationEditing != PropMode.Light)
+        {
+            return;
+        }
         var ids = TypeToManager.Keys.ToList();
         var id = ids.IndexOf(EventTypeToPropagate);
 
@@ -126,7 +135,13 @@ public class EventGridContainer : BeatmapObjectContainerCollection<BaseEvent>, C
 
     public void OnCycleLightPropagationDown(InputAction.CallbackContext context)
     {
-        if (!context.performed || PropagationEditing == PropMode.Off) return;
+        // Shared PageDown must only change light-ID lanes while Basic Events owns the active editing context.
+        if (!context.performed
+            || !EditContext.EditingMode.HasFlag(EditingMode.BasicEvent)
+            || PropagationEditing != PropMode.Light)
+        {
+            return;
+        }
         var ids = TypeToManager.Keys.ToList();
         var id = ids.IndexOf(EventTypeToPropagate);
 
@@ -449,8 +464,11 @@ public class EventGridContainer : BeatmapObjectContainerCollection<BaseEvent>, C
     public override void RefreshPool(float lowerBound, float upperBound, bool forceRefresh = false)
     {
         base.RefreshPool(lowerBound, upperBound, forceRefresh);
-        boostEventIndex.RefreshDependentAppearances(this);
+        boostEventIndex.RefreshDependentAppearances(this, RaiseBoostAppearanceRangeInvalidated);
     }
+
+    private void RaiseBoostAppearanceRangeInvalidated(float startJsonTime, float endJsonTime) =>
+        OnBoostAppearanceRangeInvalidated?.Invoke(startJsonTime, endJsonTime);
 
     protected override void UpdateContainerData(ObjectContainer con, BaseObject obj)
     {

--- a/Assets/__Scripts/Editor/Grid/Collections/GLSEventGridContainer.cs
+++ b/Assets/__Scripts/Editor/Grid/Collections/GLSEventGridContainer.cs
@@ -21,10 +21,15 @@ public class GLSEventGridContainer : BeatmapObjectContainerCollection<BaseGLSEve
 
     // A collection action replaces several child events before the parent GLS group can be rebuilt safely.
     private int groupReplacementBatchDepth;
+    // Alt-drag mutates a child still referenced by its parent, so the next replacement must consume an untouched pre-drag group clone.
+    private BaseEventBoxGroup nextReplacementOriginalGroupData;
     // Reuse indexed transition candidates because viewport refreshes occur while dragging and scrolling.
     private readonly List<BaseLightColorBase> retainedTransitionSources = new();
 
     public override ObjectType ContainerType => ObjectType.GLSEvent;
+
+    // Queue previews need the same boost lookup as finalized GLS child nodes without rediscovering the event grid.
+    public bool IsBoostAt(float jsonTime) => eventGridContainer.IsBoostAt(jsonTime);
 
     public override ObjectContainer CreateContainer() =>
         GLSEventContainer.SpawnGLSEvent(null, BeatmapContext.TracksDefinition, ref eventPrefab);
@@ -33,12 +38,32 @@ public class GLSEventGridContainer : BeatmapObjectContainerCollection<BaseGLSEve
     {
         BeatmapContext.Atsc.OnPlayToggled += HandlePlayToggle;
         glsEventGridProvider.OnGroupChanged += HandleGroupChanged;
+        eventGridContainer.OnBoostAppearanceRangeInvalidated += RefreshBoostDependentAppearances;
     }
 
     internal override void UnsubscribeToCallbacks()
     {
         BeatmapContext.Atsc.OnPlayToggled -= HandlePlayToggle;
         glsEventGridProvider.OnGroupChanged -= HandleGroupChanged;
+        eventGridContainer.OnBoostAppearanceRangeInvalidated -= RefreshBoostDependentAppearances;
+    }
+
+    private void RefreshBoostDependentAppearances(float startJsonTime, float endJsonTime)
+    {
+        foreach (var pair in LoadedContainers)
+        {
+            if (pair.Key is not BaseLightColorBase colorEvent
+                || colorEvent.JsonTime < startJsonTime
+                || colorEvent.JsonTime >= endJsonTime)
+            {
+                continue;
+            }
+
+            var container = pair.Value as GLSEventContainer;
+            // Basic events already repaint this interval; GLS child containers need the same boost lookup reapplied.
+            glsEventAppearance.SetAppearance(container, true, eventGridContainer.IsBoostAt(colorEvent.JsonTime));
+            glsEventAppearance.UpdateTransitionRibbon(container, eventGridContainer.IsBoostAt);
+        }
     }
 
     protected override void HandleObjectSpawned(BaseObject obj, bool inCollection = false)
@@ -67,6 +92,83 @@ public class GLSEventGridContainer : BeatmapObjectContainerCollection<BaseGLSEve
         if (groupReplacementBatchDepth == 0 && MapObjects.Count > 0) ReplaceGroup(MapObjects[0], message);
     }
 
+    // A nested parent replacement selects the parent, so restore the affected child identities after bulk child actions finish.
+    public void RebindSelectionAfterBatch(IEnumerable<BaseGLSEvent> sourceEvents)
+    {
+        var group = glsEventGridProvider.GroupContext;
+        if (group == null || MapObjects.Count == 0)
+        {
+            return;
+        }
+
+        SelectionController.Deselect(group, false);
+        var replacementLookup = new GLSEventReplacementLookup(MapObjects);
+        foreach (var sourceEvent in sourceEvents)
+        {
+            if (sourceEvent.EventBoxGroupData?.CompareTo(group) != 0)
+            {
+                continue;
+            }
+
+            if (replacementLookup.TryTake(sourceEvent, out var replacement))
+            {
+                SelectionController.Select(replacement, true, false, false);
+            }
+        }
+
+        SelectionController.OnSelectionChanged?.Invoke();
+    }
+
+    // Preserve the complete pre-drag parent, including the source and any destination conflict, for one replacement action.
+    public void UseOriginalGroupForNextReplacement(BaseEventBoxGroup originalGroup) =>
+        nextReplacementOriginalGroupData = originalGroup;
+
+    // Rejected drags need an action-free rollback because their live parent temporarily contains the dragged child's invalid offset.
+    public void RestoreRejectedDrag(BaseEventBoxGroup originalGroup)
+    {
+        var liveGroup = glsEventGridProvider.GroupContext;
+        if (liveGroup == null
+            || originalGroup == null
+            || liveGroup.GetType() != originalGroup.GetType())
+        {
+            // A rejected drag must never publish an invalid transient group merely because its original snapshot cannot be applied.
+            Debug.LogError("Could not restore a rejected GLS drag because its group context was unavailable.");
+            return;
+        }
+
+        // Color transition indexes own child identities, so retire them before Apply replaces every child clone in place.
+        if (liveGroup is BaseLightColorEventBoxGroup oldColorGroup)
+        {
+            GLSEventCommon.RemoveColorTransitionGroup(oldColorGroup);
+        }
+
+        // Restore the exact live group and its open child collection without creating an undo entry for the rejected destination.
+        liveGroup.Apply(originalGroup);
+        if (liveGroup is BaseLightColorEventBoxGroup restoredColorGroup)
+        {
+            GLSEventCommon.AddColorTransitionGroup(restoredColorGroup);
+        }
+
+        nextReplacementOriginalGroupData = null;
+        HandleGroupChanged(liveGroup);
+    }
+
+    // Selection deletion must publish one parent edit instead of one replacement action per selected child.
+    public BeatmapObjectUpdatedAction CreateSelectionDeleteAction(IReadOnlyCollection<BaseGLSEvent> deletedEvents)
+    {
+        var liveGroup = glsEventGridProvider.GroupContext;
+        if (liveGroup == null || deletedEvents.Count == 0)
+        {
+            return null;
+        }
+
+        // A hash set keeps the single open-group rebuild linear when many selected inner nodes are deleted together.
+        var excludedEvents = new HashSet<BaseGLSEvent>(deletedEvents);
+        var newGroup = BuildGroupFromMapObjects(liveGroup, excludedEvents);
+        // One parent replacement makes the entire inner GLS selection deletion one undoable action.
+        return new BeatmapObjectUpdatedAction(newGroup, liveGroup, "Deleted a selection of GLS events.");
+    }
+
     // stop it, no action for delete
     public override void RemoveConflictingObjects(
         IEnumerable<BaseGLSEvent> newObjects,
@@ -83,6 +185,7 @@ public class GLSEventGridContainer : BeatmapObjectContainerCollection<BaseGLSEve
                 var obj = localWindow[i];
                 if (obj.IsConflictingWith(newObject) && newObject != obj) conflicting.Add(obj);
             }
+
         }
 
         conflicting.ForEach(conflict => DeleteObject(conflict, false, false, triggerHandle: false));
@@ -91,19 +194,46 @@ public class GLSEventGridContainer : BeatmapObjectContainerCollection<BaseGLSEve
     private void ReplaceGroup(BaseObject obj, string msg)
     {
         var glsEvt = obj as BaseGLSEvent;
-        // convert back collection and replace the group instead
-        var newGroup = BeatmapFactory.Clone(glsEvt.EventBoxGroupData);
+        var liveOriginalGroup = glsEventGridProvider.GroupContext;
+        if (liveOriginalGroup == null
+            || !ReferenceEquals(glsEvt.EventBoxGroupData, liveOriginalGroup))
+        {
+            // A retired dragged child must never replace the currently open group after undo or another group action changes context.
+            // SpawnObject inserts before this callback, so remove the rejected stale child without publishing another group action.
+            SilentRemoveObject(glsEvt);
+            nextReplacementOriginalGroupData = null;
+            return;
+        }
+
+        var originalGroupData = nextReplacementOriginalGroupData;
+        nextReplacementOriginalGroupData = null;
+        // Convert the authoritative child collection back into one replacement parent group.
+        var newGroup = BuildGroupFromMapObjects(glsEvt.EventBoxGroupData);
+
+        if (originalGroupData != null)
+        {
+            // Restore the exact live group before manager removal; the immutable clone supplies its pre-drag child data only.
+            liveOriginalGroup.Apply(originalGroupData);
+        }
+
+        // Updated actions distinguish the exact live removal identity from the edited replacement needed for undo and redo.
+        var action = new BeatmapObjectUpdatedAction(newGroup, liveOriginalGroup, msg);
+        BeatmapActionContainer.AddAction(action, true);
+    }
+
+    // Share the open-group rebuild so single edits and bulk selection deletes preserve identical lane/conflict behavior.
+    private BaseEventBoxGroup BuildGroupFromMapObjects(
+        BaseEventBoxGroup sourceGroup,
+        ISet<BaseGLSEvent> excludedEvents = null)
+    {
+        // Every inner mutation must rebuild only its open parent and preserve all authored filter lanes.
+        var newGroup = BeatmapFactory.Clone(sourceGroup);
         // Preserve every authored lane when the final event is deleted so the mapper can place into them again.
         foreach (var box in newGroup.ReadOnlyBoxes) box.ClearEvents();
-        if (MapObjects.Count == 0)
-        {
-            Debug.Log(
-                $"[GLSEventDelete] Preserving empty group id={newGroup.ID} beat={newGroup.JsonTime} " +
-                $"lanes={newGroup.ReadOnlyBoxes.Count}.");
-        }
 
         // the typa shit i had to pull to amke this work
         foreach (var boxEvents in MapObjects
+            .Where(e => excludedEvents == null || !excludedEvents.Contains(e))
             .Select(e =>
             {
                 var newEvt = BeatmapFactory.Clone(e);
@@ -116,8 +246,9 @@ public class GLSEventGridContainer : BeatmapObjectContainerCollection<BaseGLSEve
             newGroup.ReadOnlyBoxes[boxEvents.Key].SetEvents(boxEvents.ToArray());
         // co-variant deez
 
-        var action = new BeatmapObjectPlacementAction(newGroup, new[] { glsEvt.EventBoxGroupData }, msg);
-        BeatmapActionContainer.AddAction(action, true);
+        // Rebuild the maintained preview ordering once at this mutation boundary so render refreshes never need to rescan the group.
+        newGroup.ResortOrderedEvents();
+        return newGroup;
     }
 
     private void HandlePlayToggle(bool playing)

--- a/Assets/__Scripts/Editor/Grid/Collections/GLSEventGridContainer.cs
+++ b/Assets/__Scripts/Editor/Grid/Collections/GLSEventGridContainer.cs
@@ -154,7 +154,7 @@ public class GLSEventGridContainer : BeatmapObjectContainerCollection<BaseGLSEve
     }
 
     // Selection deletion must publish one parent edit instead of one replacement action per selected child.
-    public BeatmapObjectUpdatedAction CreateSelectionDeleteAction(IReadOnlyCollection<BaseGLSEvent> deletedEvents)
+    public BeatmapAction CreateSelectionDeleteAction(IReadOnlyCollection<BaseGLSEvent> deletedEvents)
     {
         var liveGroup = glsEventGridProvider.GroupContext;
         if (liveGroup == null || deletedEvents.Count == 0)
@@ -165,8 +165,8 @@ public class GLSEventGridContainer : BeatmapObjectContainerCollection<BaseGLSEve
         // A hash set keeps the single open-group rebuild linear when many selected inner nodes are deleted together.
         var excludedEvents = new HashSet<BaseGLSEvent>(deletedEvents);
         var newGroup = BuildGroupFromMapObjects(liveGroup, excludedEvents);
-        // One parent replacement makes the entire inner GLS selection deletion one undoable action.
-        return new BeatmapObjectUpdatedAction(newGroup, liveGroup, "Deleted a selection of GLS events.");
+        // GLS parent actions intentionally do not select the outer group after replacing inner node identities.
+        return new BeatmapGLSEventBoxModifiedAction(newGroup, liveGroup, "Deleted a selection of GLS events.");
     }
 
     // stop it, no action for delete
@@ -216,8 +216,8 @@ public class GLSEventGridContainer : BeatmapObjectContainerCollection<BaseGLSEve
             liveOriginalGroup.Apply(originalGroupData);
         }
 
-        // Updated actions distinguish the exact live removal identity from the edited replacement needed for undo and redo.
-        var action = new BeatmapObjectUpdatedAction(newGroup, liveOriginalGroup, msg);
+        // Inner-node mutation replaces its parent, but must never auto-select that outer group in the EventBox view.
+        var action = new BeatmapGLSEventBoxModifiedAction(newGroup, liveOriginalGroup, msg);
         BeatmapActionContainer.AddAction(action, true);
     }
 

--- a/Assets/__Scripts/Editor/Grid/Collections/GLSGroupGridContainer.cs
+++ b/Assets/__Scripts/Editor/Grid/Collections/GLSGroupGridContainer.cs
@@ -43,7 +43,7 @@ public abstract class GLSGroupGridContainer<TGroup> : BeatmapObjectContainerColl
                 continue;
             }
 
-            var orderedEvents = group.ReadOnlyOrderedEvents;
+            var orderedEvents = group.OrderedEvents;
             if (HasPreviewEventInRange(orderedEvents, startJsonTime, endJsonTime))
             {
                 // Rebuild this outer group so every affected ghost resolves boost at its own absolute event time.
@@ -53,27 +53,21 @@ public abstract class GLSGroupGridContainer<TGroup> : BeatmapObjectContainerColl
     }
 
     private static bool HasPreviewEventInRange(
-        System.Collections.Generic.IReadOnlyList<BaseGLSEvent> orderedEvents,
+        System.Collections.Generic.List<BaseGLSEvent> orderedEvents,
         float startJsonTime,
         float endJsonTime)
     {
-        // Ordered GLS events share their group's start time, so their relative ordering is also absolute-time ordering.
-        var low = 0;
-        var high = orderedEvents.Count;
-        while (low < high)
+        // Reuse the shared sorted-list lookup so preview invalidation retains one binary-search implementation.
+        var eventIndex = orderedEvents.BinarySearchBy(startJsonTime, evt => evt.JsonTime);
+        if (eventIndex < 0)
         {
-            var middle = low + ((high - low) / 2);
-            if (orderedEvents[middle].JsonTime < startJsonTime)
-            {
-                low = middle + 1;
-            }
-            else
-            {
-                high = middle;
-            }
+            eventIndex = ~eventIndex;
         }
 
-        return low < orderedEvents.Count && orderedEvents[low].JsonTime < endJsonTime;
+        // BinarySearchBy can return the final item past the end of the range, so confirm the lower range bound too.
+        return eventIndex < orderedEvents.Count
+            && orderedEvents[eventIndex].JsonTime >= startJsonTime
+            && orderedEvents[eventIndex].JsonTime < endJsonTime;
     }
 
     protected override void HandleObjectDelete(BaseObject obj, bool inCollection = false) =>
@@ -114,7 +108,7 @@ public abstract class GLSGroupGridContainer<TGroup> : BeatmapObjectContainerColl
 
     private static float GetLastPreviewTime(TGroup group)
     {
-        var orderedEvents = group.ReadOnlyOrderedEvents;
+        var orderedEvents = group.OrderedEvents;
         if (orderedEvents.Count == 0)
         {
             return group.SongBpmTime;

--- a/Assets/__Scripts/Editor/Grid/Collections/GLSGroupGridContainer.cs
+++ b/Assets/__Scripts/Editor/Grid/Collections/GLSGroupGridContainer.cs
@@ -17,13 +17,64 @@ public abstract class GLSGroupGridContainer<TGroup> : BeatmapObjectContainerColl
     // Reuse the retention set because pool refreshes happen frequently while scrolling.
     private readonly System.Collections.Generic.HashSet<TGroup> retainedGroups = new();
 
+    // Outer GLS queue previews use the finalized event grid's boost timeline at their represented node time.
+    public bool IsBoostAt(float jsonTime) => eventGridContainer.IsBoostAt(jsonTime);
+
     internal override void SubscribeToCallbacks()
     {
         BeatmapContext.Atsc.OnPlayToggled += HandlePlayToggle;
+        eventGridContainer.OnBoostAppearanceRangeInvalidated += RefreshBoostDependentAppearances;
         // Rebuild loaded groups immediately when the ghost-preview setting changes.
         Settings.NotifyBySettingName(nameof(Settings.GLSOuterTrackGhostNodeOpacity), _ => RefreshPool(true));
     }
-    internal override void UnsubscribeToCallbacks() => BeatmapContext.Atsc.OnPlayToggled -= HandlePlayToggle;
+    internal override void UnsubscribeToCallbacks()
+    {
+        BeatmapContext.Atsc.OnPlayToggled -= HandlePlayToggle;
+        eventGridContainer.OnBoostAppearanceRangeInvalidated -= RefreshBoostDependentAppearances;
+    }
+
+    private void RefreshBoostDependentAppearances(float startJsonTime, float endJsonTime)
+    {
+        foreach (var pair in LoadedContainers)
+        {
+            // LoadedContainers is base-typed, so restore this collection's GLS group type before querying preview data.
+            if (pair.Key is not TGroup group)
+            {
+                continue;
+            }
+
+            var orderedEvents = group.ReadOnlyOrderedEvents;
+            if (HasPreviewEventInRange(orderedEvents, startJsonTime, endJsonTime))
+            {
+                // Rebuild this outer group so every affected ghost resolves boost at its own absolute event time.
+                (pair.Value as GLSGroupContainer).ConfigurePreviewNodes(eventGridContainer.IsBoostAt);
+            }
+        }
+    }
+
+    private static bool HasPreviewEventInRange(
+        System.Collections.Generic.IReadOnlyList<BaseGLSEvent> orderedEvents,
+        float startJsonTime,
+        float endJsonTime)
+    {
+        // Ordered GLS events share their group's start time, so their relative ordering is also absolute-time ordering.
+        var low = 0;
+        var high = orderedEvents.Count;
+        while (low < high)
+        {
+            var middle = low + ((high - low) / 2);
+            if (orderedEvents[middle].JsonTime < startJsonTime)
+            {
+                low = middle + 1;
+            }
+            else
+            {
+                high = middle;
+            }
+        }
+
+        return low < orderedEvents.Count && orderedEvents[low].JsonTime < endJsonTime;
+    }
 
     protected override void HandleObjectDelete(BaseObject obj, bool inCollection = false) =>
         countersPlus.UpdateStatistic(CountersPlusStatistic.GLSEvents);

--- a/Assets/__Scripts/Editor/Grid/Collections/GLSGroupGridProvider.cs
+++ b/Assets/__Scripts/Editor/Grid/Collections/GLSGroupGridProvider.cs
@@ -86,19 +86,25 @@ public class GLSGroupGridProvider : MonoBehaviour, CMInput.IGLSGroupTabsActions,
         RefreshGroupPageTrack();
     }
 
-    public void OnNextGroup(InputAction.CallbackContext context)
+    // The input action describes navigating a page of GLS groups, not selecting an individual group.
+    public void OnNextGroupsPage(InputAction.CallbackContext context)
     {
         if (!context.performed || !editContext.EditingMode.HasFlag(EditingMode.GLS) || GroupNameList.Count == 0) return;
-        CurrentGroupIdx++;
-        CurrentGroupIdx %= GroupNameList.Count;
-        RefreshGroupPageTrack();
+        // Match Basic Event page-up behavior with a dedicated action that advances the visible GLS tab.
+        CycleGroup(1);
     }
 
-    public void OnPreviousGroup(InputAction.CallbackContext context)
+    // The input action describes navigating a page of GLS groups, not selecting an individual group.
+    public void OnPreviousGroupsPage(InputAction.CallbackContext context)
     {
         if (!context.performed || !editContext.EditingMode.HasFlag(EditingMode.GLS) || GroupNameList.Count == 0) return;
-        CurrentGroupIdx--;
-        if (CurrentGroupIdx < 0) CurrentGroupIdx = GroupNameList.Count - 1;
+        // Match Basic Event page-down behavior with a dedicated action that reverses the visible GLS tab.
+        CycleGroup(-1);
+    }
+
+    private void CycleGroup(int direction)
+    {
+        CurrentGroupIdx = (CurrentGroupIdx + direction + GroupNameList.Count) % GroupNameList.Count;
         RefreshGroupPageTrack();
     }
 

--- a/Assets/__Scripts/Editor/Grid/PlacementLaneController.cs
+++ b/Assets/__Scripts/Editor/Grid/PlacementLaneController.cs
@@ -58,6 +58,9 @@ public class PlacementLaneController : MonoBehaviour
     {
         canExpand = BeatSaberSongContainer.Instance.Map.MajorVersion != 2;
         expandFullyOnBothState = BeatSaberSongContainer.Instance.Map.MajorVersion == 4;
+
+        // Apply the restored wall mode and lane-extension value after map-version capabilities become available.
+        UpdateGrid();
     }
 
     private void HandleModeChanged(PlacementModeController.PlacementMode _) => UpdateGrid();

--- a/Assets/__Scripts/Editor/Grid/Placements/BasePlacement.cs
+++ b/Assets/__Scripts/Editor/Grid/Placements/BasePlacement.cs
@@ -13,6 +13,12 @@ using UnityEngine;
 /// </summary>
 public abstract class BasePlacement : MonoBehaviour
 {
+    // Every gameplay placement shares this setting, so own it above note, bomb, and wall implementations.
+    public static readonly string ChromaColorKey = "PlaceChromaObjects";
+
+    // Notify all placement-adjacent controls when the shared gameplay-object Chroma setting changes.
+    public static event Action<bool> OnPlaceChromaObjectsChanged;
+
     [SerializeField] public ObjectType ObjectDataType;
     [SerializeField] public GameObject ObjectContainerPrefab;
 
@@ -53,6 +59,16 @@ public abstract class BasePlacement : MonoBehaviour
     public bool IsIdle => State == PlacementState.Idle;
     public bool IsActive => State == PlacementState.Active;
     public bool IsPlacing => State == PlacementState.Placing;
+
+    // Keep the Chroma object state separate from lighting-event placement while making it available to every placement type.
+    public static bool CanPlaceChromaObjects => (bool)Settings.NonPersistentSettings.GetValueOrDefault(ChromaColorKey, false);
+
+    // Route all controls through one notification path so the color tile and picker cannot diverge.
+    public static void SetPlaceChromaObjects(bool enabled)
+    {
+        Settings.NonPersistentSettings[ChromaColorKey] = enabled;
+        OnPlaceChromaObjectsChanged?.Invoke(enabled);
+    }
 
     public float RoundedJsonTime
     {

--- a/Assets/__Scripts/Editor/Grid/Placements/BasePlacement.cs
+++ b/Assets/__Scripts/Editor/Grid/Placements/BasePlacement.cs
@@ -47,6 +47,9 @@ public abstract class BasePlacement : MonoBehaviour
     public virtual bool CanClickAndDrag => true;
     public virtual bool CanPlace => boxSelectionPlacement.State == PlacementState.Idle;
 
+    // Two-click placement types can retain their first endpoint while the cursor temporarily leaves a valid grid surface.
+    public virtual bool RetainsPendingPlacementOnInvalidHit => false;
+
     public bool IsIdle => State == PlacementState.Idle;
     public bool IsActive => State == PlacementState.Active;
     public bool IsPlacing => State == PlacementState.Placing;

--- a/Assets/__Scripts/Editor/Grid/Placements/BombPlacement.cs
+++ b/Assets/__Scripts/Editor/Grid/Placements/BombPlacement.cs
@@ -22,8 +22,8 @@ public class BombPlacement : BasePlacement<BaseNote, NoteContainer, NoteGridCont
     {
         get
         {
-            if (Settings.NonPersistentSettings.ContainsKey(ChromaColorKey))
-                return (bool)Settings.NonPersistentSettings[ChromaColorKey];
+            if ((bool)Settings.NonPersistentSettings.GetValueOrDefault(ChromaColorKey, false))
+                return true;
             return false;
         }
     }
@@ -43,10 +43,18 @@ public class BombPlacement : BasePlacement<BaseNote, NoteContainer, NoteGridCont
     public override void Initialize(PlacementProvider provider)
     {
         base.Initialize(provider);
+        // Initialize the queued bomb ghost from its current object-Chroma state instead of its prefab material.
+        UpdateAppearance();
+    }
+
+    private void UpdateAppearance()
+    {
         PlacementVisualContainer.ModelController.MpbController.Mpb.SetFloat(alwaysTranslucent, 1);
         PlacementVisualContainer.ArrowMpbController.Mpb.SetFloat(alwaysTranslucent, 1);
-        PlacementVisualContainer.UpdateMaterials();
         PlacementVisualContainer.NoteData = QueuedData;
+        // if not set to null, the preview will stay chroma color after you turn chroma color off.
+        PlacementVisualContainer.SetColor(QueuedData.CustomColor != null ? QueuedData.CustomColor : null);
+        PlacementVisualContainer.UpdateMaterials();
     }
 
     protected override void HandleHitToPlacement(Intersections.IntersectionHit hit, Vector3 localPoint)
@@ -93,8 +101,8 @@ public class BombPlacement : BasePlacement<BaseNote, NoteContainer, NoteGridCont
 
     protected override void HandlePlacementToData(PlacementInputState inputState)
     {
-        // Check if Chroma Color notes button is active and apply _color
-        QueuedData.CustomColor = CanPlaceChromaObjects && dropdown.Visible
+        // Bombs use the same object-Chroma setting as notes and walls, even after the picker flyout is closed as long as the Color Type picker at the top has Chroma Color selected (which defaults to off when coming to this view even if you had it on for lights).
+        QueuedData.CustomColor = CanPlaceChromaObjects
             ? colorPicker.CurrentColor
             : null;
 
@@ -117,6 +125,10 @@ public class BombPlacement : BasePlacement<BaseNote, NoteContainer, NoteGridCont
                     ? new Vector2(pos.x - 2f, pos.y)
                     : null;
         }
+
+        // // Persist and repaint the queued bomb so its preview follows the current object-Chroma choice.
+        QueuedData.WriteCustom();
+        UpdateAppearance();
     }
 
     protected override void HandleRotationChanged(float rotation) => QueuedData.Rotation = (int)rotation;

--- a/Assets/__Scripts/Editor/Grid/Placements/BombPlacement.cs
+++ b/Assets/__Scripts/Editor/Grid/Placements/BombPlacement.cs
@@ -6,9 +6,6 @@ using UnityEngine;
 
 public class BombPlacement : BasePlacement<BaseNote, NoteContainer, NoteGridContainer>
 {
-    // Chroma Color Stuff
-    public static readonly string ChromaColorKey = "PlaceChromaObjects";
-
     private static readonly int alwaysTranslucent = Shader.PropertyToID("_AlwaysTranslucent");
     [SerializeField] private GridViewController gridViewController;
     [SerializeField] private ColorPicker colorPicker;
@@ -16,17 +13,6 @@ public class BombPlacement : BasePlacement<BaseNote, NoteContainer, NoteGridCont
     [SerializeField] private ToggleColourDropdown dropdown;
     private bool hasPreviousSnappedState;
     private Vector2 previousSnappedState;
-
-    // Chroma Color Check
-    public static bool CanPlaceChromaObjects
-    {
-        get
-        {
-            if ((bool)Settings.NonPersistentSettings.GetValueOrDefault(ChromaColorKey, false))
-                return true;
-            return false;
-        }
-    }
 
     protected override void ResetHysteresis()
     {

--- a/Assets/__Scripts/Editor/Grid/Placements/EventPlacement.cs
+++ b/Assets/__Scripts/Editor/Grid/Placements/EventPlacement.cs
@@ -197,7 +197,11 @@ public class EventPlacement : BasePlacement<BaseEvent, EventContainer, EventGrid
         }
 
         PlacementVisualContainer!.EventData = QueuedData;
-        eventAppearance.SetAppearance(PlacementVisualContainer, false);
+        // Queue previews must resolve the current color-boost state at their own beat like finalized event containers.
+        eventAppearance.SetAppearance(
+            PlacementVisualContainer,
+            false,
+            ObjectContainerCollection.IsBoostAt(QueuedData.JsonTime));
     }
 
     public override void CreateVisual()

--- a/Assets/__Scripts/Editor/Grid/Placements/GLSEventColorPlacement.cs
+++ b/Assets/__Scripts/Editor/Grid/Placements/GLSEventColorPlacement.cs
@@ -77,7 +77,10 @@ public class GLSEventColorPlacement : GLSEventPlacement<BaseLightColorEventBoxGr
             ? strobePicker.CurrentColor
             : null;
         QueuedData.SaveCustom();
-        if (PlacementVisualContainer != null) GlsEventAppearance.SetAppearance(PlacementVisualContainer, false);
+        if (PlacementVisualContainer != null)
+        {
+            RefreshAppearance();
+        }
     }
 
     private void HandleColorChanged(int value)
@@ -98,37 +101,40 @@ public class GLSEventColorPlacement : GLSEventPlacement<BaseLightColorEventBoxGr
             ? strobePicker.CurrentColor
             : null;
         QueuedData.SaveCustom();
-        if (PlacementVisualContainer != null) GlsEventAppearance.SetAppearance(PlacementVisualContainer, false);
+        if (PlacementVisualContainer != null)
+        {
+            RefreshAppearance();
+        }
     }
 
     private void HandleBrightnessChanged(float value)
     {
         QueuedData.Brightness = Mathf.Max(value, 0f);
-        GlsEventAppearance.SetAppearance(PlacementVisualContainer, false);
+        RefreshAppearance();
     }
 
     private void HandleStrobeFrequencyChanged(int value)
     {
         QueuedData.Frequency = value;
-        GlsEventAppearance.SetAppearance(PlacementVisualContainer, false);
+        RefreshAppearance();
     }
 
     private void HandleStrobeBrightnessChanged(float value)
     {
         QueuedData.StrobeBrightness = Mathf.Max(value, 0f);
-        GlsEventAppearance.SetAppearance(PlacementVisualContainer, false);
+        RefreshAppearance();
     }
 
     private void HandleSoftStrobeChanged(int value)
     {
         QueuedData.StrobeFade = value;
-        GlsEventAppearance.SetAppearance(PlacementVisualContainer, false);
+        RefreshAppearance();
     }
 
     private void HandleEasingChanged(int value)
     {
         QueuedData.Easing = (int)(value >= 0 ? EaseType.Linear : EaseType.None);
-        GlsEventAppearance.SetAppearance(PlacementVisualContainer, false);
+        RefreshAppearance();
     }
 
     private void HandleExtensionChanged(int value)
@@ -141,7 +147,7 @@ public class GLSEventColorPlacement : GLSEventPlacement<BaseLightColorEventBoxGr
             QueuedData.StrobeColor = null;
             QueuedData.SaveCustom();
         }
-        GlsEventAppearance.SetAppearance(PlacementVisualContainer, false);
+        RefreshAppearance();
     }
 
     protected override BaseLightColorBase GenerateOriginalData() => new();

--- a/Assets/__Scripts/Editor/Grid/Placements/GLSEventPlacement.cs
+++ b/Assets/__Scripts/Editor/Grid/Placements/GLSEventPlacement.cs
@@ -16,14 +16,17 @@ public abstract class
     [SerializeField] protected GLSEventAppearanceSO GlsEventAppearance;
     [SerializeField] private BeatmapRuntimeContext context;
     [SerializeField] protected BeatmapEasingsSelectionInputController EasingInputController;
+    // The authored parent retains the dragged child reference, so undo needs a deep group snapshot captured before movement mutates it.
+    private BaseEventBoxGroup originalDraggedGroup;
 
     public override bool CanPlace =>
         base.CanPlace
         && glsEventGridProvider.GroupContext != null
         && glsEventGridProvider.GroupContext.GetType() == typeof(TGroup)
         && QueuedData.EventBoxGroupData.ReadOnlyBoxes.Count > 0
-        // GLS event times are offsets from their group and cannot precede its beat.
-        && QueuedData.RelativeJsonTime >= 0f;
+        // Non-grid-aligned outer groups can produce a sub-epsilon negative residue at their visual zero offset.
+        // Fixes the weird float rounding CatKid issue
+        && QueuedData.RelativeJsonTime >= -BeatmapObjectContainerCollection.Epsilon;
 
     protected override BeatmapAction GenerateAction(BaseObject spawned, IEnumerable<BaseObject> conflicts) =>
         throw new ArgumentException("If you triggered this, you tried to use add object where it couldn't");
@@ -44,7 +47,7 @@ public abstract class
         QueuedData.EventBoxGroupData = glsEventGridProvider.GroupContext;
         PlacementVisualContainer.EventData = QueuedData;
         PlacementVisualContainer.SafeSetActive(CanPlace);
-        GlsEventAppearance.SetAppearance(PlacementVisualContainer, false);
+        RefreshAppearance();
     }
 
     protected override void HandlePlacementToData(PlacementInputState inputState)
@@ -62,6 +65,13 @@ public abstract class
         QueuedData.EventBoxGroupData = group;
         var i = (int)(PlacementVisualContainer.transform.localPosition.x - 0.5f);
         QueuedData.RelativeJsonTime = RoundedJsonTime - group.JsonTime;
+        // Preserve the zero-offset lane when absolute grid rounding lands a few float units before its outer group.
+        if (QueuedData.RelativeJsonTime < 0f
+            && QueuedData.RelativeJsonTime >= -BeatmapObjectContainerCollection.Epsilon)
+        {
+            QueuedData.RelativeJsonTime = 0f;
+        }
+
         QueuedData.RecomputeSongBpmTime();
         // Re-evaluate after updating the offset so the hover node immediately hides before the group.
         PlacementVisualContainer.SafeSetActive(CanPlace);
@@ -73,7 +83,7 @@ public abstract class
         // The hover preview bypasses collection positioning, so ground it with the finalized inner GLS node position.
         PlacementVisualContainer.UpdateGridPosition();
         // The hover preview's rotation/translation axis color depends on the box under the cursor.
-        GlsEventAppearance.SetAppearance(PlacementVisualContainer, false);
+        RefreshAppearance();
     }
 
     public override void HandleApply()
@@ -92,6 +102,12 @@ public abstract class
             base.Apply();
     }
 
+    // Match queued inner GLS node colors to the boost state used by finalized child-node containers.
+    protected void RefreshAppearance() => GlsEventAppearance.SetAppearance(
+        PlacementVisualContainer,
+        false,
+        ObjectContainerCollection.IsBoostAt(QueuedData.JsonTime));
+
     public override ObjectContainer StartDrag(GameObject draggedObject)
     {
         // GLS event placements share one ObjectType, so reject other GLS subtypes before the base path removes their node.
@@ -104,6 +120,9 @@ public abstract class
         var con = base.StartDrag(draggedObject);
         if (con == null) return null;
 
+        // Clone before any drag hover update changes the child still owned by the authoritative parent group.
+        originalDraggedGroup = BeatmapFactory.Clone(glsEventGridProvider.GroupContext);
+
         // imagine having to assign this bullshit again and agian
         DraggedObjectData.EventBoxGroupData = glsEventGridProvider.GroupContext;
         OriginalQueued.EventBoxGroupData = glsEventGridProvider.GroupContext;
@@ -115,32 +134,60 @@ public abstract class
 
     public override void FinishDrag()
     {
+        if (!ReferenceEquals(DraggedObjectData.EventBoxGroupData, glsEventGridProvider.GroupContext))
+        {
+            // Undo or another group action retired this drag's parent, so cancel instead of publishing its stale child into the new context.
+            ResetDragState();
+            return;
+        }
+
         // Restore the original node when a drag would move it before its group's beat.
         if (DraggedObjectData.RelativeJsonTime < 0f)
         {
-            ObjectContainerCollection.SpawnObject(OriginalDraggedObjectData, out _);
-            QueuedData = BeatmapFactory.Clone(OriginalQueued);
-            QueuedData.EventBoxGroupData = glsEventGridProvider.GroupContext;
-
-            DraggedObjectContainer.Dragged = false;
-            DraggedObjectContainer = null;
-            IsDragging = false;
-
-            PlacementVisualContainer.EventData = QueuedData;
+            // Normal spawning creates a group action whose original side still contains the transient negative child.
+            ObjectContainerCollection.RestoreRejectedDrag(originalDraggedGroup);
+            ResetDragState();
             return;
         }
 
         // slightly different, just no action
-        ObjectContainerCollection.SpawnObject(DraggedObjectData, out _);
+        // Publish the destination group against the untouched pre-drag parent so undo restores the original source location.
+        try
+        {
+            ObjectContainerCollection.UseOriginalGroupForNextReplacement(originalDraggedGroup);
+            ObjectContainerCollection.SpawnObject(DraggedObjectData, out _);
+        }
+        finally
+        {
+            // Input release remains active after exceptions, so always retire drag state to prevent per-frame duplicate insertion.
+            ResetDragState();
+        }
+    }
 
-        QueuedData = BeatmapFactory.Clone(OriginalQueued);
-        QueuedData.EventBoxGroupData = glsEventGridProvider.GroupContext;
+    private void ResetDragState(bool restoreQueuedData = true)
+    {
+        originalDraggedGroup = null;
+        if (restoreQueuedData)
+        {
+            QueuedData = BeatmapFactory.Clone(OriginalQueued);
+            QueuedData.EventBoxGroupData = glsEventGridProvider.GroupContext;
+            // Group restoration and replacement clone every lane, so never leave the queued node pointing at a retired box instance.
+            if (QueuedData.EventBoxGroupData != null
+                && QueuedData.BoxIndex >= 0
+                && QueuedData.BoxIndex < QueuedData.EventBoxGroupData.ReadOnlyBoxes.Count)
+            {
+                QueuedData.EventBoxData = QueuedData.EventBoxGroupData.ReadOnlyBoxes[QueuedData.BoxIndex];
+            }
+        }
 
-        DraggedObjectContainer.Dragged = false;
+        if (DraggedObjectContainer != null)
+        {
+            DraggedObjectContainer.Dragged = false;
+        }
+
         DraggedObjectContainer = null;
         HandleDragged();
         IsDragging = false;
-
         PlacementVisualContainer.EventData = QueuedData;
     }
 

--- a/Assets/__Scripts/Editor/Grid/Placements/GLSGroupColorPlacement.cs
+++ b/Assets/__Scripts/Editor/Grid/Placements/GLSGroupColorPlacement.cs
@@ -98,43 +98,43 @@ public class GLSGroupColorPlacement : GLSGroupPlacement<BaseLightColorEventBoxGr
             ? strobePicker.CurrentColor
             : null;
         firstEvt.SaveCustom();
-        GlsGroupAppearance.SetAppearance(PlacementVisualContainer, false);
+        RefreshAppearance();
     }
 
     private void HandleColorChanged(int value)
     {
         QueuedData.Boxes[0].Events[0].Color = value;
-        GlsGroupAppearance.SetAppearance(PlacementVisualContainer, false);
+        RefreshAppearance();
     }
 
     private void HandleBrightnessChanged(float value)
     {
         QueuedData.Boxes[0].Events[0].Brightness = Mathf.Max(value, 0f);
-        GlsGroupAppearance.SetAppearance(PlacementVisualContainer, false);
+        RefreshAppearance();
     }
 
     private void HandleStrobeFrequencyChanged(int value)
     {
         QueuedData.Boxes[0].Events[0].Frequency = value;
-        GlsGroupAppearance.SetAppearance(PlacementVisualContainer, false);
+        RefreshAppearance();
     }
 
     private void HandleStrobeBrightnessChanged(float value)
     {
         QueuedData.Boxes[0].Events[0].StrobeBrightness = Mathf.Max(value, 0f);
-        GlsGroupAppearance.SetAppearance(PlacementVisualContainer, false);
+        RefreshAppearance();
     }
 
     private void HandleSoftStrobeChanged(int value)
     {
         QueuedData.Boxes[0].Events[0].StrobeFade = value;
-        GlsGroupAppearance.SetAppearance(PlacementVisualContainer, false);
+        RefreshAppearance();
     }
 
     private void HandleEasingChanged(int value)
     {
         QueuedData.Boxes[0].Events[0].Easing = (int)(value >= 0 ? EaseType.Linear : EaseType.None);
-        GlsGroupAppearance.SetAppearance(PlacementVisualContainer, false);
+        RefreshAppearance();
     }
 
     private void HandleExtensionChanged(int value)
@@ -148,7 +148,7 @@ public class GLSGroupColorPlacement : GLSGroupPlacement<BaseLightColorEventBoxGr
             firstEvt.StrobeColor = null;
             firstEvt.SaveCustom();
         }
-        GlsGroupAppearance.SetAppearance(PlacementVisualContainer, false);
+        RefreshAppearance();
     }
 
     protected override BaseLightColorEventBoxGroup GenerateOriginalData() =>

--- a/Assets/__Scripts/Editor/Grid/Placements/GLSGroupColorPlacement.cs
+++ b/Assets/__Scripts/Editor/Grid/Placements/GLSGroupColorPlacement.cs
@@ -83,21 +83,28 @@ public class GLSGroupColorPlacement : GLSGroupPlacement<BaseLightColorEventBoxGr
     protected override void HandlePlacementToData(PlacementInputState inputState)
     {
         base.HandlePlacementToData(inputState);
-        var firstEvt = QueuedData.Boxes[0].Events[0];
-        // Extension nodes inherit color from the previous node and must not carry independent Chroma RGB data.
-        if (firstEvt.UsePrevious == 0 && EventPlacement.CanPlaceChromaEvents && colorPicker != null)
+        // An outer alt-drag moves the cloned group's beat only; do not treat an authored, possibly empty filter lane as the placement-menu starter node.
+        // TODO when dragging we use placement but might have nothing in box 0 inside the event group (EG empty light id lanes). If we actually wanted to preview ribbons live and be filter-aware
+        //  then the boxes[0].events[0] below needs to become much more sophisticated, and we then remove the !IsDragging check and always run the rest of this.
+        if (!IsDragging)
         {
-            firstEvt.CustomColor = colorPicker.CurrentColor;
+            var firstEvt = QueuedData.Boxes[0].Events[0];
+            // Extension nodes inherit color from the previous node and must not carry independent Chroma RGB data.
+            if (firstEvt.UsePrevious == 0 && EventPlacement.CanPlaceChromaEvents && colorPicker != null)
+            {
+                firstEvt.CustomColor = colorPicker.CurrentColor;
+            }
+            else
+            {
+                firstEvt.CustomColor = null;
+            }
+            // Apply the independent strobe picker only to the group's non-extension starter node.
+            firstEvt.StrobeColor = firstEvt.UsePrevious == 0 && StrobeColorPickerController.Instance is { IsEnabled: true } strobePicker
+                ? strobePicker.CurrentColor
+                : null;
+            firstEvt.SaveCustom();
         }
-        else
-        {
-            firstEvt.CustomColor = null;
-        }
-        // Apply the independent strobe picker only to the group's non-extension starter node.
-        firstEvt.StrobeColor = firstEvt.UsePrevious == 0 && StrobeColorPickerController.Instance is { IsEnabled: true } strobePicker
-            ? strobePicker.CurrentColor
-            : null;
-        firstEvt.SaveCustom();
+
         RefreshAppearance();
     }
 

--- a/Assets/__Scripts/Editor/Grid/Placements/GLSGroupPlacement.cs
+++ b/Assets/__Scripts/Editor/Grid/Placements/GLSGroupPlacement.cs
@@ -28,7 +28,7 @@ public abstract class GLSGroupPlacement<TGroup, TCollection> : BasePlacement<TGr
         PlacementVisualContainer.EventBoxGroupData = QueuedData;
         PlacementVisualContainer.transform.SetParent(PlacementTrack, false);
         PlacementVisualContainer.SafeSetActive(CanPlace);
-        GlsGroupAppearance.SetAppearance(PlacementVisualContainer, false);
+        RefreshAppearance();
     }
 
     protected override void HandlePlacementToData(PlacementInputState inputState)
@@ -46,6 +46,12 @@ public abstract class GLSGroupPlacement<TGroup, TCollection> : BasePlacement<TGr
         Mathf.Approximately(
             Mathf.Floor(PlacementVisualContainer.transform.localPosition.x),
             GLSGroupContainer.GetPositionFromTrackDefinition(beatmapRuntimeContext.TracksDefinition, QueuedData));
+
+    // Use the event grid's indexed boost state so outer queued GLS groups match their finalized preview node color.
+    protected void RefreshAppearance() => GlsGroupAppearance.SetAppearance(
+        PlacementVisualContainer,
+        false,
+        ObjectContainerCollection.IsBoostAt(QueuedData.JsonTime));
 
     public override ObjectContainer StartDrag(GameObject draggedObject)
     {

--- a/Assets/__Scripts/Editor/Grid/Placements/GLSGroupPlacement.cs
+++ b/Assets/__Scripts/Editor/Grid/Placements/GLSGroupPlacement.cs
@@ -33,6 +33,12 @@ public abstract class GLSGroupPlacement<TGroup, TCollection> : BasePlacement<TGr
 
     protected override void HandlePlacementToData(PlacementInputState inputState)
     {
+        // GLS group alt-drags may cross the map origin, but serialized group beats may not become negative.
+        if (IsDragging)
+        {
+            QueuedData.JsonTime = Mathf.Max(0f, QueuedData.JsonTime);
+        }
+
         PlacementVisualContainer.SafeSetActive(CanPlace);
         // The outer hover preview bypasses collection positioning, so align its smaller model base with finalized GLS nodes.
         var position = PlacementVisualContainer.transform.localPosition;

--- a/Assets/__Scripts/Editor/Grid/Placements/NotePlacement.cs
+++ b/Assets/__Scripts/Editor/Grid/Placements/NotePlacement.cs
@@ -10,12 +10,6 @@ using UnityEngine.UI;
 
 public class NotePlacement : BasePlacement<BaseNote, NoteContainer, NoteGridContainer>
 {
-    // Chroma Color Stuff
-    public static readonly string ChromaColorKey = "PlaceChromaObjects";
-
-    // Keep every gameplay-object Chroma control synchronized through the setting's single update path.
-    public static event System.Action<bool> OnPlaceChromaObjectsChanged;
-
     private static readonly int alwaysTranslucent = Shader.PropertyToID("_AlwaysTranslucent");
     [SerializeField] private GridViewController gridViewController;
     [SerializeField] private NoteAppearanceSO noteAppearance;
@@ -44,17 +38,6 @@ public class NotePlacement : BasePlacement<BaseNote, NoteContainer, NoteGridCont
 
     private bool updateAttachedSliderDirection;
 
-    // Chroma Color Check
-    public static bool CanPlaceChromaObjects
-    {
-        get
-        {
-            if (Settings.NonPersistentSettings.ContainsKey(ChromaColorKey))
-                return (bool)Settings.NonPersistentSettings[ChromaColorKey];
-            return false;
-        }
-    }
-
     public override void Start()
     {
         base.Start();
@@ -63,15 +46,8 @@ public class NotePlacement : BasePlacement<BaseNote, NoteContainer, NoteGridCont
 
     public void OnDestroy() => beatmapSharedNoteInputController.OnCutDirectionChanged -= HandleOnCutDirectionChanged;
 
-    // Preserve the scene callback while routing it through the shared gameplay-object Chroma state.
-    public void PlaceChromaObjects(bool enabled) => SetPlaceChromaObjects(enabled);
-
-    // Let the color tile and picker checkbox update the same non-persistent object placement setting.
-    public static void SetPlaceChromaObjects(bool enabled)
-    {
-        Settings.NonPersistentSettings[ChromaColorKey] = enabled;
-        OnPlaceChromaObjectsChanged?.Invoke(enabled);
-    }
+    // Preserve the scene callback while routing it through BasePlacement's shared gameplay-object Chroma state.
+    public void PlaceChromaObjects(bool enabled) => BasePlacement.SetPlaceChromaObjects(enabled);
 
     protected override BeatmapAction GenerateAction(BaseObject spawned, IEnumerable<BaseObject> conflicts) =>
         new BeatmapObjectPlacementAction(spawned, conflicts, "Placed a note.");

--- a/Assets/__Scripts/Editor/Grid/Placements/NotePlacement.cs
+++ b/Assets/__Scripts/Editor/Grid/Placements/NotePlacement.cs
@@ -13,6 +13,9 @@ public class NotePlacement : BasePlacement<BaseNote, NoteContainer, NoteGridCont
     // Chroma Color Stuff
     public static readonly string ChromaColorKey = "PlaceChromaObjects";
 
+    // Keep every gameplay-object Chroma control synchronized through the setting's single update path.
+    public static event System.Action<bool> OnPlaceChromaObjectsChanged;
+
     private static readonly int alwaysTranslucent = Shader.PropertyToID("_AlwaysTranslucent");
     [SerializeField] private GridViewController gridViewController;
     [SerializeField] private NoteAppearanceSO noteAppearance;
@@ -60,8 +63,15 @@ public class NotePlacement : BasePlacement<BaseNote, NoteContainer, NoteGridCont
 
     public void OnDestroy() => beatmapSharedNoteInputController.OnCutDirectionChanged -= HandleOnCutDirectionChanged;
 
-    // Toggle Chroma Color Function
-    public void PlaceChromaObjects(bool v) => Settings.NonPersistentSettings[ChromaColorKey] = v;
+    // Preserve the scene callback while routing it through the shared gameplay-object Chroma state.
+    public void PlaceChromaObjects(bool enabled) => SetPlaceChromaObjects(enabled);
+
+    // Let the color tile and picker checkbox update the same non-persistent object placement setting.
+    public static void SetPlaceChromaObjects(bool enabled)
+    {
+        Settings.NonPersistentSettings[ChromaColorKey] = enabled;
+        OnPlaceChromaObjectsChanged?.Invoke(enabled);
+    }
 
     protected override BeatmapAction GenerateAction(BaseObject spawned, IEnumerable<BaseObject> conflicts) =>
         new BeatmapObjectPlacementAction(spawned, conflicts, "Placed a note.");
@@ -276,8 +286,8 @@ public class NotePlacement : BasePlacement<BaseNote, NoteContainer, NoteGridCont
 
     protected override void HandlePlacementToData(PlacementInputState inputState)
     {
-        // Check if Chroma Color notes button is active and apply _color
-        QueuedData.CustomColor = CanPlaceChromaObjects && dropdown.Visible
+        // Apply the active gameplay-object Chroma color even when its picker flyout is not visible.
+        QueuedData.CustomColor = CanPlaceChromaObjects
             ? colorPicker.CurrentColor
             : null;
 
@@ -300,6 +310,10 @@ public class NotePlacement : BasePlacement<BaseNote, NoteContainer, NoteGridCont
                     ? new Vector2(pos.x - 2f, pos.y)
                     : null;
         }
+
+        // Refresh the queued ghost immediately so toggling object Chroma never leaves it on a stale primary color.
+        QueuedData.WriteCustom();
+        UpdateAppearance();
     }
 
     protected override void HandleRotationChanged(float rotation)

--- a/Assets/__Scripts/Editor/Grid/Placements/ObstaclePlacement.cs
+++ b/Assets/__Scripts/Editor/Grid/Placements/ObstaclePlacement.cs
@@ -8,12 +8,9 @@ using UnityEngine;
 
 public class ObstaclePlacement : BasePlacement<BaseObstacle, ObstacleContainer, ObstacleGridContainer>
 {
-    // Chroma Color Stuff
-    public static readonly string ChromaColorKey = "PlaceChromaObjects";
     [SerializeField] private GridViewController gridViewController;
     [SerializeField] private ObstacleAppearanceSO obstacleAppearance;
     [SerializeField] private ColorPicker colorPicker;
-    [SerializeField] private ToggleColourDropdown dropdown;
     private bool hasExpanded;
     private bool hasOffset;
     private bool hasPreviousSnappedState;
@@ -24,22 +21,13 @@ public class ObstaclePlacement : BasePlacement<BaseObstacle, ObstacleContainer, 
     private Vector3 scale;
 
     private float startJsonTime;
-    private float startSongBpmTime;
 
     private bool v2Mode;
 
-    // Chroma Color Check
-    public static bool CanPlaceChromaObjects
-    {
-        get
-        {
-            if (Settings.NonPersistentSettings.ContainsKey(ChromaColorKey))
-                return (bool)Settings.NonPersistentSettings[ChromaColorKey];
-            return false;
-        }
-    }
-
     private float SmallestRankableWallDuration => Atsc.GetBeatFromSeconds(0.016f);
+
+    // Keep a wall's first click when the cursor crosses a gap between grid planes during its two-click placement.
+    public override bool RetainsPendingPlacementOnInvalidHit => true;
 
     public void Awake() => LoadInitialMap.OnLevelLoaded += HandleLevelLoaded;
 
@@ -167,14 +155,13 @@ public class ObstaclePlacement : BasePlacement<BaseObstacle, ObstacleContainer, 
         }
         else
         {
-            QueuedData.Duration = RoundedJsonTime - startJsonTime;
-            if (Mathf.Abs(RoundedJsonTime - startJsonTime) < SmallestRankableWallDuration)
-                QueuedData.Duration = SmallestRankableWallDuration;
+            // Normalize reverse drags because obstacles store an earlier start time and positive duration only.
+            NormalizePlacementTimeRange();
         }
         // obstacleAppearanceSo.SetObstacleAppearance(PlacementVisualContainer);
 
-        // Check if Chroma Color notes button is active and apply _color
-        QueuedData.CustomColor = CanPlaceChromaObjects && dropdown.Visible
+        // Walls use the gameplay-object Chroma setting, independently from Chroma lighting event placement.
+        QueuedData.CustomColor = NotePlacement.CanPlaceChromaObjects && colorPicker != null
             ? colorPicker.CurrentColor
             : null;
 
@@ -196,6 +183,13 @@ public class ObstaclePlacement : BasePlacement<BaseObstacle, ObstacleContainer, 
         QueuedData.CustomSize = vanillaSize != (Vector2)scale ? (Vector2)scale : null;
         QueuedData.Width = (int)vanillaSize.x;
         QueuedData.Height = (int)vanillaSize.y;
+
+        // Persist the placement color with the remaining custom wall properties before the placement action captures this wall.
+        QueuedData.WriteCustom();
+
+        // Refresh the hover and drag preview from the current queued wall so it immediately reflects the active Chroma color.
+        PlacementVisualContainer.ObstacleData = QueuedData;
+        obstacleAppearance.SetObstacleAppearance(PlacementVisualContainer, true);
     }
 
     protected override void HandleRotationChanged(float rotation) => QueuedData.Rotation = (int)rotation;
@@ -204,16 +198,18 @@ public class ObstaclePlacement : BasePlacement<BaseObstacle, ObstacleContainer, 
     {
         if (IsPlacing)
         {
-            QueuedData.JsonTime = startJsonTime;
+            // Normalize again at commit so an input update immediately before release cannot retain a reverse interval.
+            NormalizePlacementTimeRange();
 
-            var endSongBpmTime =
-                startSongBpmTime + (PlacementVisualContainer.ObstacleScale.z / EditorScaleController.EditorScale);
+            var startSongBpmTime = (float)BeatSaberSongContainer.Instance.Map.JsonTimeToSongBpmTime(QueuedData.JsonTime);
+            var endSongBpmTime = (float)BeatSaberSongContainer.Instance.Map.JsonTimeToSongBpmTime(
+                QueuedData.JsonTime + QueuedData.Duration);
 
             if (endSongBpmTime - startSongBpmTime < SmallestRankableWallDuration)
             {
                 endSongBpmTime = startSongBpmTime + SmallestRankableWallDuration;
                 var endJsonTime = (float)BeatSaberSongContainer.Instance.Map.SongBpmTimeToJsonTime(endSongBpmTime);
-                QueuedData.Duration = endJsonTime - startJsonTime;
+                QueuedData.Duration = endJsonTime - QueuedData.JsonTime;
             }
 
             ObjectContainerCollection.SpawnObject(QueuedData, out var conflicting);
@@ -227,9 +223,23 @@ public class ObstaclePlacement : BasePlacement<BaseObstacle, ObstacleContainer, 
         {
             originPos = LanePosition;
             startJsonTime = RoundedJsonTime;
-            startSongBpmTime = SongBpmTime;
             State = PlacementState.Placing;
         }
+    }
+
+    // Store the two placement clicks as the forward interval required by Beat Saber obstacle data.
+    private void NormalizePlacementTimeRange()
+    {
+        var endJsonTime = RoundedJsonTime;
+        if (Mathf.Approximately(startJsonTime, endJsonTime)
+            && QueuedData.Duration > SmallestRankableWallDuration)
+        {
+            // Direct placement callers can provide an authored duration without a hover update; do not replace it with a zero-length drag.
+            return;
+        }
+
+        QueuedData.JsonTime = Mathf.Min(startJsonTime, endJsonTime);
+        QueuedData.Duration = Mathf.Max(Mathf.Abs(endJsonTime - startJsonTime), SmallestRankableWallDuration);
     }
 
     protected override void TransferQueuedToDraggedObject(ref BaseObstacle dragged, BaseObstacle queued)

--- a/Assets/__Scripts/Editor/Grid/Placements/ObstaclePlacement.cs
+++ b/Assets/__Scripts/Editor/Grid/Placements/ObstaclePlacement.cs
@@ -161,7 +161,7 @@ public class ObstaclePlacement : BasePlacement<BaseObstacle, ObstacleContainer, 
         // obstacleAppearanceSo.SetObstacleAppearance(PlacementVisualContainer);
 
         // Walls use the gameplay-object Chroma setting, independently from Chroma lighting event placement.
-        QueuedData.CustomColor = NotePlacement.CanPlaceChromaObjects && colorPicker != null
+        QueuedData.CustomColor = BasePlacement.CanPlaceChromaObjects && colorPicker != null
             ? colorPicker.CurrentColor
             : null;
 

--- a/Assets/__Scripts/Editor/Grid/Placements/PlacementInputSystem.cs
+++ b/Assets/__Scripts/Editor/Grid/Placements/PlacementInputSystem.cs
@@ -100,10 +100,25 @@ public class PlacementInputSystem : MonoBehaviour,
             return;
         }
 
-        if (HandleExitWhen(
-            (!CanInteract && inputState == PlacementInputState.Hover)
-            || !hasHit
-            || provider == null))
+        var invalidPlacementHit = !hasHit || provider == null;
+        // Hide a pending two-click preview across a grid gap without discarding its first endpoint.
+        if (invalidPlacementHit
+            && currentProvider != null
+            && CanInteract
+            && HasPendingPlacementThatRetainsInvalidHits(currentProvider.Placements))
+        {
+            foreach (var placement in currentProvider.Placements)
+            {
+                placement.HideVisual();
+            }
+
+            // Don't fully exit the provider, otherwise trying to place walls cancels randomly when you jump from vertical grid to horizontal grid
+            // Do set isOnGrid to false though so we don't place in random places?
+            // isOnGrid = false;
+            return;
+        }
+
+        if (HandleExitWhen((!CanInteract && inputState == PlacementInputState.Hover) || invalidPlacementHit))
             return;
 
         if (currentProvider != provider && !boxSelectionPlacement.IsPlacing)
@@ -147,6 +162,22 @@ public class PlacementInputSystem : MonoBehaviour,
 
     public void OnPlaceObject(InputAction.CallbackContext context)
     {
+        // An off-grid click cancels the retained endpoint instead of applying the last valid hover position.
+        if (currentProvider != null
+            && context.performed
+            && !isOnGrid)
+        {
+            foreach (var placement in currentProvider.Placements)
+            {
+                if (placement.IsPlacing)
+                {
+                    placement.Cancel();
+                }
+            }
+
+            return;
+        }
+
         if (currentProvider == null
             || !context.performed
             || !KeybindsController.IsMouseInWindow
@@ -295,6 +326,20 @@ public class PlacementInputSystem : MonoBehaviour,
         if (inputState == PlacementInputState.Hover) return;
         foreach (var placement in currentProvider.Placements.Where(p => p.IsDragging)) placement.FinishDrag();
         inputState = PlacementInputState.Hover;
+    }
+
+    // Restrict invalid-hit retention to placement types that explicitly preserve a first click.
+    private static bool HasPendingPlacementThatRetainsInvalidHits(BasePlacement[] placements)
+    {
+        for (var i = 0; i < placements.Length; i++)
+        {
+            if (placements[i].IsPlacing && placements[i].RetainsPendingPlacementOnInvalidHit)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private bool HandleExitWhen(bool shouldExit)

--- a/Assets/__Scripts/Editor/Grid/SelectionController.cs
+++ b/Assets/__Scripts/Editor/Grid/SelectionController.cs
@@ -381,11 +381,48 @@ public class SelectionController : MonoBehaviour, CMInput.ISelectingActions, CMI
     /// </summary>
     public void Delete(bool triggersAction = true)
     {
-        IEnumerable<BaseObject> objects = SelectedObjects
+        var objects = SelectedObjects
             .Where(x =>
                 (allowedObjectToEdit[x.ObjectType] & editModeContext.EditingMode) > 0)
             .ToArray();
-        if (triggersAction) BeatmapActionContainer.AddAction(new SelectionDeletedAction(objects));
+
+        if (triggersAction)
+        {
+            // Inner GLS nodes are stored through one parent group, so delete every selected child with one group replacement action.
+            var actions = new List<BeatmapAction>();
+            var regularObjects = objects.Where(x => x is not BaseGLSEvent).ToArray();
+            if (regularObjects.Length > 0)
+            {
+                actions.Add(new SelectionDeletedAction(regularObjects));
+            }
+
+            var glsEvents = objects.OfType<BaseGLSEvent>().ToArray();
+            if (glsEvents.Length > 0)
+            {
+                var glsCollection = BeatmapObjectContainerCollection.GetCollectionForType<GLSEventGridContainer>(
+                    ObjectType.GLSEvent);
+                var glsAction = glsCollection.CreateSelectionDeleteAction(glsEvents);
+                if (glsAction != null)
+                {
+                    actions.Add(glsAction);
+                }
+            }
+
+            if (actions.Count == 1)
+            {
+                BeatmapActionContainer.AddAction(actions[0], true);
+            }
+            else if (actions.Count > 1)
+            {
+                BeatmapActionContainer.AddAction(
+                    new ActionCollectionAction(actions, true, true, "Deleted a selection of objects."),
+                    true);
+            }
+
+            DeselectAll();
+            return;
+        }
+
         DeselectAll();
         foreach (var con in objects)
             BeatmapObjectContainerCollection.GetCollectionForType(con.ObjectType).DeleteObject(con, false, false);

--- a/Assets/__Scripts/Editor/Input/BeatmapEasingsSelectionInputController.cs
+++ b/Assets/__Scripts/Editor/Input/BeatmapEasingsSelectionInputController.cs
@@ -10,6 +10,8 @@ using UnityEngine.InputSystem;
 public class BeatmapEasingsSelectionInputController : BeatmapInputController<ObjectContainer>,
                                                       CMInput.IEasingsSelectionActions
 {
+    [SerializeField] private PlacementModeController placementModeController;
+
     public event Action<int> OnEasingChanged;
     public event Action<int> OnExtensionChanged;
 
@@ -306,7 +308,12 @@ public class BeatmapEasingsSelectionInputController : BeatmapInputController<Obj
 
     public void OnExtension(InputAction.CallbackContext context)
     {
-        if (context.performed) NotifyExtensionChanged(extension + 1);
+        if (context.performed)
+        {
+            // Use the same placement-mode controller path as GLS color shortcuts so the Delete picker and tool both update.
+            placementModeController.SetMode(PlacementModeController.PlacementMode.Note);
+            NotifyExtensionChanged(extension + 1);
+        }
     }
 
     public void OnExtensionHover(InputAction.CallbackContext context)

--- a/Assets/__Scripts/Editor/Input/BeatmapGLSEventColorInputController.cs
+++ b/Assets/__Scripts/Editor/Input/BeatmapGLSEventColorInputController.cs
@@ -19,19 +19,40 @@ public class BeatmapGLSEventColorInputController : BeatmapGLSEventInputControlle
     private float currentStrobeBrightness;
     private int currentSoftStrobe;
 
-    public void OnColor0Light(InputAction.CallbackContext context)
+    // Keep the keybind label aligned with the primary light color it selects.
+    public void OnPrimaryLightColor(InputAction.CallbackContext context)
     {
         if (context.performed) OnColorPerformed(LightColor.Red);
     }
 
-    public void OnColor1Light(InputAction.CallbackContext context)
+    // Keep the keybind label aligned with the secondary light color it selects.
+    public void OnSecondaryLightColor(InputAction.CallbackContext context)
     {
         if (context.performed) OnColorPerformed(LightColor.Blue);
     }
 
-    public void OnColorWLight(InputAction.CallbackContext context)
+    // Keep the keybind label aligned with the white light color it selects.
+    public void OnWhiteLightColor(InputAction.CallbackContext context)
     {
         if (context.performed) OnColorPerformed(LightColor.White);
+    }
+
+    // Avoid the gameplay-mode Bomb binding while routing Basic Events and both GLS views through the color tile handler.
+    public void OnChromaLightColor(InputAction.CallbackContext context)
+    {
+        if (context.performed && !EditContext.EditingMode.HasFlag(EditingMode.Gameplay))
+        {
+            ColorTypeController.RequestChromaLightColor();
+        }
+    }
+
+    // Keep the strobe-color hotkey routed through the picker so its persisted toggle and UI remain synchronized.
+    public void OnStrobeChromaColor(InputAction.CallbackContext context)
+    {
+        if (context.performed)
+        {
+            StrobeColorPickerController.ToggleEnabled();
+        }
     }
 
     private void OnColorPerformed(LightColor lightColor)
@@ -184,13 +205,16 @@ public class BeatmapGLSEventColorInputController : BeatmapGLSEventInputControlle
         if (context.performed) OnSetBrightnessOnlyPerformed(1.5f);
     }
 
-    public void OnBrightnessHover(InputAction.CallbackContext context)
+    // Keep hover value mutations under the Tweak prefix in keybind settings.
+    public void OnTweakBrightnessHover(InputAction.CallbackContext context)
     {
-        // Unity hover containers need explicit null checks before resolving their inner event.
-        var evt = IsHovering && HoveredObject != null
-            ? HoveredObject.EventData as BaseLightColorBase
-            : null;
+        // Re-resolve after every clone-producing wheel tick so pooled containers cannot redirect the next mutation.
+        TryGetHoveredEvent(context, out var evt);
         GLSEventHoverMutation.AdjustColorBrightness(context, evt, ScrollPrecisionController);
+        if (evt != null)
+        {
+            RefreshHoveredVisualAfterMutation();
+        }
     }
 
     public void NotifyBrightnessChanged(float value)
@@ -234,13 +258,15 @@ public class BeatmapGLSEventColorInputController : BeatmapGLSEventInputControlle
         }
     }
 
-    public void OnStrobeFrequencyHover(InputAction.CallbackContext context)
+    public void OnTweakStrobeFrequencyHover(InputAction.CallbackContext context)
     {
-        // Unity hover containers need explicit null checks before resolving their inner event.
-        var evt = IsHovering && HoveredObject != null
-            ? HoveredObject.EventData as BaseLightColorBase
-            : null;
+        // Re-resolve after every clone-producing wheel tick so pooled containers cannot redirect the next mutation.
+        TryGetHoveredEvent(context, out var evt);
         GLSEventHoverMutation.AdjustColorFrequency(context, evt, ScrollPrecisionController);
+        if (evt != null)
+        {
+            RefreshHoveredVisualAfterMutation();
+        }
     }
 
     public void NotifyStrobeFrequencyChanged(int value)
@@ -264,22 +290,26 @@ public class BeatmapGLSEventColorInputController : BeatmapGLSEventInputControlle
         }
     }
 
-    public void OnStrobeBrightnessHover(InputAction.CallbackContext context)
+    public void OnTweakStrobeBrightnessHover(InputAction.CallbackContext context)
     {
-        // Unity hover containers need explicit null checks before resolving their inner event.
-        var evt = IsHovering && HoveredObject != null
-            ? HoveredObject.EventData as BaseLightColorBase
-            : null;
+        // Re-resolve after every clone-producing wheel tick so pooled containers cannot redirect the next mutation.
+        TryGetHoveredEvent(context, out var evt);
         GLSEventHoverMutation.AdjustColorStrobeBrightness(context, evt, ScrollPrecisionController);
+        if (evt != null)
+        {
+            RefreshHoveredVisualAfterMutation();
+        }
     }
 
     public void OnTweakEasingHover(InputAction.CallbackContext context)
     {
-        // Unity hover containers need explicit null checks before resolving their inner event.
-        var evt = IsHovering && HoveredObject != null
-            ? HoveredObject.EventData as BaseLightColorBase
-            : null;
+        // Re-resolve after every clone-producing wheel tick so pooled containers cannot redirect the next mutation.
+        TryGetHoveredEvent(context, out var evt);
         GLSEventHoverMutation.AdjustColorEasing(context, evt);
+        if (evt != null)
+        {
+            RefreshHoveredVisualAfterMutation();
+        }
     }
 
     public void NotifyStrobeBrightnessChanged(float value)
@@ -297,11 +327,13 @@ public class BeatmapGLSEventColorInputController : BeatmapGLSEventInputControlle
 
     public void OnMirrorHover(InputAction.CallbackContext context)
     {
-        // Unity hover containers need explicit null checks before resolving their inner event.
-        var evt = IsHovering && HoveredObject != null
-            ? HoveredObject.EventData as BaseLightColorBase
-            : null;
+        // Re-resolve after every clone-producing wheel tick so pooled containers cannot redirect the next mutation.
+        TryGetHoveredEvent(context, out var evt);
         GLSEventHoverMutation.MirrorColor(context, evt);
+        if (evt != null)
+        {
+            RefreshHoveredVisualAfterMutation();
+        }
     }
 
     public void OnApplyToSelected(InputAction.CallbackContext context) { }

--- a/Assets/__Scripts/Editor/Input/BeatmapGLSEventFloatFXInputController.cs
+++ b/Assets/__Scripts/Editor/Input/BeatmapGLSEventFloatFXInputController.cs
@@ -49,23 +49,28 @@ public class BeatmapGLSEventFloatFXInputController : BeatmapGLSEventInputControl
         if (context.performed) OnValueChange(1f);
     }
 
-    public void OnValueHover(InputAction.CallbackContext context)
+    // Keep hover value mutations under the Tweak prefix in keybind settings.
+    public void OnTweakValueHover(InputAction.CallbackContext context)
     {
-        // Unity hover containers need explicit null checks before resolving their inner event.
-        var evt = IsHovering && HoveredObject != null
-            ? HoveredObject.EventData as BaseFxEventFloat
-            : null;
+        // Re-resolve after every clone-producing wheel tick so pooled containers cannot redirect the next mutation.
+        TryGetHoveredEvent(context, out var evt);
         GLSEventHoverMutation.AdjustFloatFx(context, evt, ScrollPrecisionController);
+        if (evt != null)
+        {
+            RefreshHoveredVisualAfterMutation();
+        }
     }
 
     // Use the explicit Ctrl+Alt action because the Alt-only value action is suppressed by more-specific chords.
     public void OnTweakEasingHover(InputAction.CallbackContext context)
     {
-        // Unity hover containers need explicit null checks before resolving their inner event.
-        var evt = IsHovering && HoveredObject != null
-            ? HoveredObject.EventData as BaseFxEventFloat
-            : null;
+        // Re-resolve after every clone-producing wheel tick so pooled containers cannot redirect the next mutation.
+        TryGetHoveredEvent(context, out var evt);
         GLSEventHoverMutation.AdjustFloatFxEasing(context, evt);
+        if (evt != null)
+        {
+            RefreshHoveredVisualAfterMutation();
+        }
     }
 
     public void NotifyValueChanged(float value)

--- a/Assets/__Scripts/Editor/Input/BeatmapGLSEventInputController.cs
+++ b/Assets/__Scripts/Editor/Input/BeatmapGLSEventInputController.cs
@@ -1,6 +1,7 @@
 ﻿using Beatmap.Base;
 using Beatmap.Containers;
 using UnityEngine;
+using UnityEngine.InputSystem;
 public static class GLSEventInputHoverTracker
 {
     private static int hoveredControllerCount;
@@ -35,6 +36,69 @@ public abstract class BeatmapGLSEventInputController<TData> : BeatmapInputContro
         if (!wasHovering) return;
         wasHovering = false;
         GLSEventInputHoverTracker.SetHovering(false);
+    }
+
+    // Group actions recycle and rebind inner containers synchronously, so wheel callbacks must resolve the physical target again.
+    protected bool TryGetHoveredEvent(InputAction.CallbackContext context, out TData evt)
+    {
+        evt = null;
+        if (!context.performed || !IsHovering)
+        {
+            return false;
+        }
+
+        var cachedContainer = HoveredObject;
+        var cachedEvent = cachedContainer != null
+            ? cachedContainer.EventData
+            : null;
+        BeatmapRaycastCache.Invalidate();
+        if (!RaycastFirstObject(out var currentContainer))
+        {
+            return false;
+        }
+
+        evt = currentContainer.EventData as TData;
+        if (evt == null
+            || evt.EventBoxData == null
+            || evt.EventBoxGroupData == null
+            || evt.BoxIndex < 0
+            || evt.BoxIndex >= evt.EventBoxGroupData.ReadOnlyBoxes.Count
+            || !ReferenceEquals(evt.EventBoxGroupData.ReadOnlyBoxes[evt.BoxIndex], evt.EventBoxData))
+        {
+            evt = null;
+            return false;
+        }
+
+        SetHoveredContainer(currentContainer);
+        return true;
+    }
+
+    // Clone-producing commands synchronously rebuild the pool, so reacquire and highlight the physical target after that rebuild too.
+    protected void RefreshHoveredVisualAfterMutation()
+    {
+        BeatmapRaycastCache.Invalidate();
+        if (RaycastFirstObject(out var currentContainer))
+        {
+            SetHoveredContainer(currentContainer);
+        }
+    }
+
+    private void SetHoveredContainer(GLSEventContainer currentContainer)
+    {
+        if (HoveredObject != currentContainer)
+        {
+            // Pool refresh can rebind the highlighted container to another node, so transfer hover visuals before rendering.
+            if (HoveredObject != null)
+            {
+                HoveredObject.Highlighted = false;
+            }
+
+        }
+
+        // The pool may have reset this same container during rebinding, so reassert the target outline even when its identity is unchanged.
+        currentContainer.Highlighted = true;
+        HoveredObject = currentContainer;
+        IsHovering = true;
     }
 
     protected override bool ValidObject(GLSEventContainer container) => container.ObjectData is TData;

--- a/Assets/__Scripts/Editor/Input/BeatmapGLSEventRotationInputController.cs
+++ b/Assets/__Scripts/Editor/Input/BeatmapGLSEventRotationInputController.cs
@@ -177,54 +177,66 @@ public class BeatmapGLSEventRotationInputController : BeatmapGLSEventInputContro
 
     public void OnAngle270(InputAction.CallbackContext context) => HandleKeyUpdate(context, leftKey);
 
-    public void OnAngleHover(InputAction.CallbackContext context)
+    // Keep hover value mutations under the Tweak prefix in keybind settings.
+    public void OnTweakAngleHover(InputAction.CallbackContext context)
     {
-        // Unity hover containers need explicit null checks before resolving their inner event.
-        var evt = IsHovering && HoveredObject != null
-            ? HoveredObject.EventData as BaseLightRotationBase
-            : null;
+        // Re-resolve after every clone-producing wheel tick so pooled containers cannot redirect the next mutation.
+        TryGetHoveredEvent(context, out var evt);
         // Reuse the outer-track implementation so modifier behavior stays identical in both GLS views.
         GLSEventHoverMutation.AdjustRotation(context, evt, ScrollPrecisionController);
+        if (evt != null)
+        {
+            RefreshHoveredVisualAfterMutation();
+        }
     }
 
     public void OnTweakLoopHover(InputAction.CallbackContext context)
     {
-        // Unity hover containers need explicit null checks before resolving their inner event.
-        var evt = IsHovering && HoveredObject != null
-            ? HoveredObject.EventData as BaseLightRotationBase
-            : null;
+        // Re-resolve after every clone-producing wheel tick so pooled containers cannot redirect the next mutation.
+        TryGetHoveredEvent(context, out var evt);
         // The three-modifier loop chord is shared with the outer GLS group preview.
         GLSEventHoverMutation.AdjustRotationLoop(context, evt);
+        if (evt != null)
+        {
+            RefreshHoveredVisualAfterMutation();
+        }
     }
 
     public void OnTweakEasingHover(InputAction.CallbackContext context)
     {
-        // Unity hover containers need explicit null checks before resolving their inner event.
-        var evt = IsHovering && HoveredObject != null
-            ? HoveredObject.EventData as BaseLightRotationBase
-            : null;
+        // Re-resolve after every clone-producing wheel tick so pooled containers cannot redirect the next mutation.
+        TryGetHoveredEvent(context, out var evt);
         // The two-modifier easing chord is shared with the outer GLS group preview.
         GLSEventHoverMutation.AdjustRotationEasing(context, evt);
+        if (evt != null)
+        {
+            RefreshHoveredVisualAfterMutation();
+        }
     }
 
-    public void OnCycleAxisHover(InputAction.CallbackContext context)
+    // Name the scroll-wheel axis mutation consistently with the concise keybind label.
+    public void OnTweakAxisHover(InputAction.CallbackContext context)
     {
-        // Unity hover containers need explicit null checks before resolving their inner event.
-        var evt = IsHovering && HoveredObject != null
-            ? HoveredObject.EventData as BaseLightRotationBase
-            : null;
+        // Re-resolve after every clone-producing wheel tick so pooled containers cannot redirect the next mutation.
+        TryGetHoveredEvent(context, out var evt);
         // Inner event-box mode uses the same group-safe axis mutation as the outer preview.
         GLSCommonCommand.CycleEventAxis(context, evt);
+        if (evt != null)
+        {
+            RefreshHoveredVisualAfterMutation();
+        }
     }
 
-    public void OnCycleDirectionHover(InputAction.CallbackContext context)
+    public void OnTweakDirectionHover(InputAction.CallbackContext context)
     {
-        // Unity hover containers need explicit null checks before resolving their inner event.
-        var evt = IsHovering && HoveredObject != null
-            ? HoveredObject.EventData as BaseLightRotationBase
-            : null;
+        // Re-resolve after every clone-producing wheel tick so pooled containers cannot redirect the next mutation.
+        TryGetHoveredEvent(context, out var evt);
         // Keep direction cycling matched with the outer GLS group preview.
         GLSEventHoverMutation.CycleRotationDirection(context, evt);
+        if (evt != null)
+        {
+            RefreshHoveredVisualAfterMutation();
+        }
     }
 
     private void OnRotationPerformed(LightRotationDirection lightRotationDirection)

--- a/Assets/__Scripts/Editor/Input/BeatmapGLSEventTranslationInputController.cs
+++ b/Assets/__Scripts/Editor/Input/BeatmapGLSEventTranslationInputController.cs
@@ -50,33 +50,41 @@ public class BeatmapGLSEventTranslationInputController : BeatmapGLSEventInputCon
         if (context.performed) OnValueChange(1f);
     }
 
-    public void OnValueHover(InputAction.CallbackContext context)
+    // Keep hover value mutations under the Tweak prefix in keybind settings.
+    public void OnTweakValueHover(InputAction.CallbackContext context)
     {
-        // Unity hover containers need explicit null checks before resolving their inner event.
-        var evt = IsHovering && HoveredObject != null
-            ? HoveredObject.EventData as BaseLightTranslationBase
-            : null;
+        // Re-resolve after every clone-producing wheel tick so pooled containers cannot redirect the next mutation.
+        TryGetHoveredEvent(context, out var evt);
         GLSEventHoverMutation.AdjustTranslation(context, evt, ScrollPrecisionController);
+        if (evt != null)
+        {
+            RefreshHoveredVisualAfterMutation();
+        }
     }
 
     // Use the explicit Ctrl+Alt action because the Alt-only value action is suppressed by more-specific chords.
     public void OnTweakEasingHover(InputAction.CallbackContext context)
     {
-        // Unity hover containers need explicit null checks before resolving their inner event.
-        var evt = IsHovering && HoveredObject != null
-            ? HoveredObject.EventData as BaseLightTranslationBase
-            : null;
+        // Re-resolve after every clone-producing wheel tick so pooled containers cannot redirect the next mutation.
+        TryGetHoveredEvent(context, out var evt);
         GLSEventHoverMutation.AdjustTranslationEasing(context, evt);
+        if (evt != null)
+        {
+            RefreshHoveredVisualAfterMutation();
+        }
     }
 
-    public void OnCycleAxisHover(InputAction.CallbackContext context)
+    // Name the scroll-wheel axis mutation consistently with the concise keybind label.
+    public void OnTweakAxisHover(InputAction.CallbackContext context)
     {
-        // Unity hover containers need explicit null checks before resolving their inner event.
-        var evt = IsHovering && HoveredObject != null
-            ? HoveredObject.EventData as BaseLightTranslationBase
-            : null;
+        // Re-resolve after every clone-producing wheel tick so pooled containers cannot redirect the next mutation.
+        TryGetHoveredEvent(context, out var evt);
         // Inner event-box mode uses the same group-safe axis mutation as the outer preview.
         GLSCommonCommand.CycleEventAxis(context, evt);
+        if (evt != null)
+        {
+            RefreshHoveredVisualAfterMutation();
+        }
     }
 
     public void NotifyValueChanged(float value)

--- a/Assets/__Scripts/Editor/Input/BeatmapGLSGroupColorInputController.cs
+++ b/Assets/__Scripts/Editor/Input/BeatmapGLSGroupColorInputController.cs
@@ -16,17 +16,18 @@ public class BeatmapGLSGroupColorInputController : BeatmapGLSGroupInputControlle
     private ScrollPrecisionController ScrollPrecisionController =>
         ResolvePrecision(ref scrollPrecisionController);
 
-    public void OnBrightnessHover(InputAction.CallbackContext context)
+    // Keep hover value mutations under the Tweak prefix in keybind settings.
+    public void OnTweakBrightnessHover(InputAction.CallbackContext context)
     {
         GLSEventHoverMutation.AdjustColorBrightness(context, TryGetHoveredEvent(context, out var evt) ? evt : null, ScrollPrecisionController);
     }
 
-    public void OnStrobeFrequencyHover(InputAction.CallbackContext context)
+    public void OnTweakStrobeFrequencyHover(InputAction.CallbackContext context)
     {
         GLSEventHoverMutation.AdjustColorFrequency(context, TryGetHoveredEvent(context, out var evt) ? evt : null, ScrollPrecisionController);
     }
 
-    public void OnStrobeBrightnessHover(InputAction.CallbackContext context)
+    public void OnTweakStrobeBrightnessHover(InputAction.CallbackContext context)
     {
         GLSEventHoverMutation.AdjustColorStrobeBrightness(context, TryGetHoveredEvent(context, out var evt) ? evt : null, ScrollPrecisionController);
     }
@@ -38,9 +39,11 @@ public class BeatmapGLSGroupColorInputController : BeatmapGLSGroupInputControlle
     }
 
     // Outer previews support only hover-specific mutations; non-hover actions remain owned by the inner editor.
-    public void OnColor0Light(InputAction.CallbackContext context) { }
-    public void OnColor1Light(InputAction.CallbackContext context) { }
-    public void OnColorWLight(InputAction.CallbackContext context) { }
+    public void OnPrimaryLightColor(InputAction.CallbackContext context) { }
+    public void OnSecondaryLightColor(InputAction.CallbackContext context) { }
+    public void OnWhiteLightColor(InputAction.CallbackContext context) { }
+    public void OnChromaLightColor(InputAction.CallbackContext context) { }
+    public void OnStrobeChromaColor(InputAction.CallbackContext context) { }
     public void OnStatic0Brightness(InputAction.CallbackContext context) { }
     public void OnStatic50Brightness(InputAction.CallbackContext context) { }
     public void OnStatic100Brightness(InputAction.CallbackContext context) { }

--- a/Assets/__Scripts/Editor/Input/BeatmapGLSGroupFloatFXInputController.cs
+++ b/Assets/__Scripts/Editor/Input/BeatmapGLSGroupFloatFXInputController.cs
@@ -13,7 +13,8 @@ public class BeatmapGLSGroupFloatFXInputController : BeatmapGLSGroupInputControl
 
     private ScrollPrecisionController Precision => ResolvePrecision(ref precision);
 
-    public void OnValueHover(InputAction.CallbackContext context)
+    // Keep hover value mutations under the Tweak prefix in keybind settings.
+    public void OnTweakValueHover(InputAction.CallbackContext context)
     {
         GLSEventHoverMutation.AdjustFloatFx(context, TryGetHoveredEvent(context, out var evt) ? evt : null, Precision);
     }

--- a/Assets/__Scripts/Editor/Input/BeatmapGLSGroupRotationInputController.cs
+++ b/Assets/__Scripts/Editor/Input/BeatmapGLSGroupRotationInputController.cs
@@ -10,7 +10,8 @@ public class BeatmapGLSGroupRotationInputController : BeatmapGLSGroupInputContro
 
     private ScrollPrecisionController Precision => ResolvePrecision(ref precision);
 
-    public void OnAngleHover(UnityEngine.InputSystem.InputAction.CallbackContext context)
+    // Keep hover value mutations under the Tweak prefix in keybind settings.
+    public void OnTweakAngleHover(UnityEngine.InputSystem.InputAction.CallbackContext context)
     {
         GLSEventHoverMutation.AdjustRotation(context, TryGetHoveredEvent(context, out var evt) ? evt : null, Precision);
     }
@@ -26,14 +27,15 @@ public class BeatmapGLSGroupRotationInputController : BeatmapGLSGroupInputContro
         GLSEventHoverMutation.AdjustRotationEasing(context, resolved);
     }
 
-    public void OnCycleAxisHover(UnityEngine.InputSystem.InputAction.CallbackContext context)
+    // Name the scroll-wheel axis mutation consistently with the concise keybind label.
+    public void OnTweakAxisHover(UnityEngine.InputSystem.InputAction.CallbackContext context)
     {
         // The authored axis action targets this controller's outer preview event.
         var resolved = TryGetHoveredEvent(context, out var evt) ? evt : null;
         GLSCommonCommand.CycleEventAxis(context, resolved);
     }
 
-    public void OnCycleDirectionHover(UnityEngine.InputSystem.InputAction.CallbackContext context)
+    public void OnTweakDirectionHover(UnityEngine.InputSystem.InputAction.CallbackContext context)
     {
         GLSEventHoverMutation.CycleRotationDirection(context, TryGetHoveredEvent(context, out var evt) ? evt : null);
     }

--- a/Assets/__Scripts/Editor/Input/BeatmapGLSGroupTranslationInputController.cs
+++ b/Assets/__Scripts/Editor/Input/BeatmapGLSGroupTranslationInputController.cs
@@ -11,7 +11,8 @@ public class
 
     private ScrollPrecisionController Precision => ResolvePrecision(ref precision);
 
-    public void OnValueHover(UnityEngine.InputSystem.InputAction.CallbackContext context)
+    // Keep hover value mutations under the Tweak prefix in keybind settings.
+    public void OnTweakValueHover(UnityEngine.InputSystem.InputAction.CallbackContext context)
     {
         GLSEventHoverMutation.AdjustTranslation(context, TryGetHoveredEvent(context, out var evt) ? evt : null, Precision);
     }
@@ -23,7 +24,8 @@ public class
         GLSEventHoverMutation.AdjustTranslationEasing(context, resolved);
     }
 
-    public void OnCycleAxisHover(UnityEngine.InputSystem.InputAction.CallbackContext context)
+    // Name the scroll-wheel axis mutation consistently with the concise keybind label.
+    public void OnTweakAxisHover(UnityEngine.InputSystem.InputAction.CallbackContext context)
     {
         // The authored axis action targets this controller's outer preview event.
         var resolved = TryGetHoveredEvent(context, out var evt) ? evt : null;

--- a/Assets/__Scripts/Editor/Input/BeatmapRotationInputController.cs
+++ b/Assets/__Scripts/Editor/Input/BeatmapRotationInputController.cs
@@ -122,7 +122,8 @@ public class BeatmapRotationInputController : BeatmapInputController<ObjectConta
         laneRotationProvider.SetEditRotation(rotation);
     }
 
-    public void OnModifyHover(InputAction.CallbackContext context)
+    // Keep the scroll-wheel hover mutation under the Tweak prefix in keybind settings.
+    public void OnTweakModifyHover(InputAction.CallbackContext context)
     {
         if (CustomStandaloneInputModule.IsPointerOverGameObject<GraphicRaycaster>(0, true)
             || !context.performed

--- a/Assets/__Scripts/Input/LoadKeybindsController.cs
+++ b/Assets/__Scripts/Input/LoadKeybindsController.cs
@@ -10,6 +10,25 @@ public class LoadKeybindsController : MonoBehaviour
 {
     private static readonly string version = "1.0.0";
 
+    // Saved overrides identify actions by their display name, so preserve remaps across the current keybind-label cleanup.
+    private static readonly Dictionary<string, string> LegacyActionNames = new()
+    {
+        { "TweakChainCount", "Tweak Chain Count" },
+        { "TweakChainSquish", "Tweak Chain Squish" },
+        { "Brightness (Hover)", "Tweak Brightness (Hover)" },
+        { "Color0 Light", "Primary Light Color" },
+        { "Color1 Light", "Secondary Light Color" },
+        { "ColorW Light", "White Light Color" },
+        { "Strobe Brightness (Hover)", "Tweak Strobe Brightness (Hover)" },
+        { "Strobe Frequency (Hover)", "Tweak Strobe Frequency (Hover)" },
+        { "Value (Hover)", "Tweak Value (Hover)" },
+        { "Next Group", "Next Groups Page" },
+        { "Angle (Hover)", "Tweak Angle (Hover)" },
+        { "Cycle Axis (Hover)", "Tweak Axis (Hover)" },
+        { "Cycle Direction (Hover)", "Tweak Direction (Hover)" },
+        { "Modify (Hover)", "Tweak Modify (Hover)" }
+    };
+
     public static List<KeybindOverride> AllOverrides = new List<KeybindOverride>();
 
     private string path;
@@ -88,6 +107,8 @@ public class LoadKeybindsController : MonoBehaviour
     /// <param name="keybindOverride"></param>
     public static void AddKeybindOverride(KeybindOverride keybindOverride)
     {
+        // Normalize old persisted labels before lookup and saving so a renamed action retains the user's override.
+        keybindOverride.InputActionName = MigrateActionName(keybindOverride.InputActionName);
         // Do not override keybinds if paths are not in acceptable bounds
         if (keybindOverride.OverrideKeybindPaths.Count <= 0 || keybindOverride.OverrideKeybindPaths.Count > 4) return;
         // Remove anyexisting override to prevent duplicates
@@ -174,6 +195,11 @@ public class LoadKeybindsController : MonoBehaviour
         Debug.Log($"Added keybind override for {keybindOverride.InputActionName}.");
         AllOverrides.Add(keybindOverride);
     }
+
+    private static string MigrateActionName(string actionName) =>
+        actionName != null && LegacyActionNames.TryGetValue(actionName, out var migratedName)
+            ? migratedName
+            : actionName;
 
     // Renames override binding to match original
     private static void RenameCompositeBinding(InputAction action, KeybindOverride keybindOverride)

--- a/Assets/__Scripts/Localization/Localization.asset
+++ b/Assets/__Scripts/Localization/Localization.asset
@@ -709,6 +709,22 @@ MonoBehaviour:
 
     Let us be free!!'
   - The message has already been said through patches of violet...
+  - Generating more work for Future You.
+  - 'Loading complete? 
+  
+    Sus.'
+  - Searching for the off-time note you definitely meant to place.
+  - Warming up ChroMapper''s tiny little silicon feelings.
+  - If this takes too long, it''s probably your map''s fault.
+  - Initializing questionable mapping decisions...
+  - 'Looking forward to when your map becomes someone else''s problem?
+
+    uwu'
+  - 'You made this?
+  
+    Oh....'
+  - Frantically googling "how make good map beatsaber game" for you <3
+  - You''ll finally complete your map in NaN days!
   WaifuSprites:
   - {fileID: 21300000, guid: ffbd6560516bb294d8c477a9fe4b21bb, type: 3}
   - {fileID: 21300000, guid: 47cd6bfc82037cf4fbe3fbb33bdd2def, type: 3}

--- a/Assets/__Scripts/UI/Editor/Chroma/ColourPicker.cs
+++ b/Assets/__Scripts/UI/Editor/Chroma/ColourPicker.cs
@@ -16,6 +16,8 @@ public class ColourPicker : MonoBehaviour, IEditorStateProvider
     [SerializeField] private ToggleColourDropdown dropdown;
     [SerializeField] private Toggle toggle;
     [SerializeField] private Toggle placeChromaToggle;
+    // Keep the object-placement toggle explicitly wired so prefab hierarchy changes cannot break Chroma synchronization.
+    [SerializeField] private Toggle placeChromaObjectsToggle;
 
     // The main Chroma picker is editor-wired with Chroma toggles, while the strobe flyout intentionally leaves them unset.
     private bool IsPrimaryPicker => toggle != null || placeChromaToggle != null;
@@ -31,6 +33,13 @@ public class ColourPicker : MonoBehaviour, IEditorStateProvider
         {
             ActivePicker = picker;
             SelectionController.OnObjectWasSelected += SelectedOnObject;
+            NotePlacement.OnPlaceChromaObjectsChanged += HandlePlaceChromaObjectsChanged;
+            // The prefab has separate object and event toggles; preserve the object's existing scene callback.
+            if (placeChromaObjectsToggle != null)
+            {
+                placeChromaObjectsToggle.SetIsOnWithoutNotify(NotePlacement.CanPlaceChromaObjects);
+            }
+
             EditorStateService.Register(this);
         }
         // Strobe's flyout host intentionally has no Chroma toggles of its own.
@@ -41,7 +50,7 @@ public class ColourPicker : MonoBehaviour, IEditorStateProvider
 
         if (placeChromaToggle != null)
         {
-            // Replace the scene callback so tile and flyout changes share one setting update path.
+            // This prefab reference is the dedicated Place Chroma Events toggle.
             placeChromaToggle.onValueChanged = new Toggle.ToggleEvent();
             placeChromaToggle.onValueChanged.AddListener(SetPlaceChromaEvents);
             SetPlaceChromaEvents(Settings.Instance.PlaceChromaColor);
@@ -55,6 +64,7 @@ public class ColourPicker : MonoBehaviour, IEditorStateProvider
         if (IsPrimaryPicker)
         {
             SelectionController.OnObjectWasSelected -= SelectedOnObject;
+            NotePlacement.OnPlaceChromaObjectsChanged -= HandlePlaceChromaObjectsChanged;
             EditorStateService.Unregister(this);
             // Do not leave a destroyed menu picker available to placement components.
             if (ReferenceEquals(ActivePicker, picker))
@@ -70,6 +80,12 @@ public class ColourPicker : MonoBehaviour, IEditorStateProvider
         SetPlaceChromaEvents(true);
         dropdown.ToggleDropdown(true);
     }
+
+    // Gameplay object placement owns a separate setting but uses the same picker flyout.
+    public void OpenPicker() => dropdown.ToggleDropdown(true);
+
+    // Let the color tile distinguish an intentional close from an already-open picker state toggle.
+    public bool IsOpen => dropdown.Visible;
 
     // Keep the tile's deselect action from leaving Chroma placement enabled behind a closed picker.
     public void CloseForChromaEvents()
@@ -91,6 +107,15 @@ public class ColourPicker : MonoBehaviour, IEditorStateProvider
         }
 
         OnPlaceChromaEventsChanged?.Invoke(enabled);
+    }
+
+    // Reflect color-tile changes in the dedicated object checkbox without re-entering its scene callback.
+    private void HandlePlaceChromaObjectsChanged(bool enabled)
+    {
+        if (placeChromaObjectsToggle != null)
+        {
+            placeChromaObjectsToggle.SetIsOnWithoutNotify(enabled);
+        }
     }
 
     // Serialize palette data here so the service never has to discover UI objects.

--- a/Assets/__Scripts/UI/Editor/Chroma/ColourPicker.cs
+++ b/Assets/__Scripts/UI/Editor/Chroma/ColourPicker.cs
@@ -33,11 +33,11 @@ public class ColourPicker : MonoBehaviour, IEditorStateProvider
         {
             ActivePicker = picker;
             SelectionController.OnObjectWasSelected += SelectedOnObject;
-            NotePlacement.OnPlaceChromaObjectsChanged += HandlePlaceChromaObjectsChanged;
+            BasePlacement.OnPlaceChromaObjectsChanged += HandlePlaceChromaObjectsChanged;
             // The prefab has separate object and event toggles; preserve the object's existing scene callback.
             if (placeChromaObjectsToggle != null)
             {
-                placeChromaObjectsToggle.SetIsOnWithoutNotify(NotePlacement.CanPlaceChromaObjects);
+                placeChromaObjectsToggle.SetIsOnWithoutNotify(BasePlacement.CanPlaceChromaObjects);
             }
 
             EditorStateService.Register(this);
@@ -64,7 +64,7 @@ public class ColourPicker : MonoBehaviour, IEditorStateProvider
         if (IsPrimaryPicker)
         {
             SelectionController.OnObjectWasSelected -= SelectedOnObject;
-            NotePlacement.OnPlaceChromaObjectsChanged -= HandlePlaceChromaObjectsChanged;
+            BasePlacement.OnPlaceChromaObjectsChanged -= HandlePlaceChromaObjectsChanged;
             EditorStateService.Unregister(this);
             // Do not leave a destroyed menu picker available to placement components.
             if (ReferenceEquals(ActivePicker, picker))

--- a/Assets/__Scripts/UI/Editor/Chroma/PaintSelectedObjects.cs
+++ b/Assets/__Scripts/UI/Editor/Chroma/PaintSelectedObjects.cs
@@ -13,8 +13,14 @@ public class PaintSelectedObjects : MonoBehaviour
     public void Paint()
     {
         var allActions = new List<BeatmapAction>();
+        // Painting does not replace selection until AddAction below, so reuse the authoritative selection for every pre-action pass.
+        var selectedGlsColorEvents = GLSEventLookupIndex.GroupSelectedEvents(SelectionController.SelectedObjects);
         foreach (var obj in SelectionController.SelectedObjects)
         {
+            // GLS children must be replaced through their owning parent group, not through the inner child collection.
+            if (obj is BaseGLSEvent)
+                continue;
+
             if (obj is BaseBpmEvent or BaseCustomEvent)
                 continue; //These should probably not be colored.
             var beforePaint = BeatmapFactory.Clone(obj);
@@ -31,6 +37,38 @@ public class PaintSelectedObjects : MonoBehaviour
                     "a",
                     true));
             }
+        }
+
+        foreach (var (originalGroup, selectedEvents) in selectedGlsColorEvents)
+        {
+            var editedGroup = BeatmapFactory.Clone(originalGroup);
+            var eventLookup = new GLSEventLookupIndex(originalGroup);
+            var paintedEventCount = 0;
+            foreach (var selectedEvent in selectedEvents)
+            {
+                // GLS rotation, translation, and FloatFX nodes have no Chroma color payload to paint.
+                if (selectedEvent is not BaseLightColorBase
+                    || !eventLookup.TryGetCloneEvent(selectedEvent, editedGroup, out _, out var editedEvent)
+                    || editedEvent is not BaseLightColorBase editedColorEvent)
+                {
+                    continue;
+                }
+
+                editedColorEvent.CustomColor = picker.CurrentColor;
+                editedColorEvent.WriteCustom();
+                paintedEventCount++;
+            }
+
+            if (paintedEventCount == 0)
+            {
+                continue;
+            }
+
+            // Parent replacement preserves the inner collection's identity and prevents extra child placement actions.
+            allActions.Add(new BeatmapGLSEventBoxModifiedAction(
+                editedGroup,
+                originalGroup,
+                "Painted GLS event box group."));
         }
 
         if (allActions.Count == 0) return;

--- a/Assets/__Scripts/UI/Editor/Chroma/StrobeColorPickerController.cs
+++ b/Assets/__Scripts/UI/Editor/Chroma/StrobeColorPickerController.cs
@@ -46,6 +46,30 @@ public class StrobeColorPickerController : MonoBehaviour, IEditorStateProvider
         }
     }
 
+    // Keep the hotkey equivalent to the strobe tile: enabling opens the picker and disabling closes it.
+    public static void ToggleEnabled()
+    {
+        if (Settings.Instance.PlaceGLSStrobeColor)
+        {
+            if (Instance != null)
+            {
+                Instance.Close();
+            }
+
+            SetLoadedEnabled(false);
+            return;
+        }
+
+        if (Instance != null)
+        {
+            Instance.Open();
+        }
+        else
+        {
+            SetLoadedEnabled(true);
+        }
+    }
+
     // Reapply the map-scoped setting after UI initialization so the checkbox always matches placement behavior.
     public static void RefreshLoadedEnabledUi()
     {

--- a/Assets/__Scripts/UI/Editor/GLSGroupPageViewController.cs
+++ b/Assets/__Scripts/UI/Editor/GLSGroupPageViewController.cs
@@ -48,6 +48,7 @@ public class GLSGroupPageViewController : MonoBehaviour
             // The button's child selectable receives hover events, so host the remappable hint there rather than on the component root.
             var tooltipTarget = text.Selectable != null ? text.Selectable.gameObject : text.gameObject;
             var tooltip = tooltipTarget.GetComponent<Tooltip>() ?? tooltipTarget.AddComponent<Tooltip>();
+            // TODO: Localize this tooltip before Stable so the new remappable hint follows the rest of the UI.
             tooltip.TooltipOverride = "Cycle GLS tabs";
             tooltip.AdvancedTooltip = "Cycle GLS tabs";
             tooltip.AppearDelay = 0.3f;

--- a/Assets/__Scripts/UI/Editor/GLSGroupPageViewController.cs
+++ b/Assets/__Scripts/UI/Editor/GLSGroupPageViewController.cs
@@ -45,6 +45,15 @@ public class GLSGroupPageViewController : MonoBehaviour
             text.name = n;
             text.SetLabelText(n);
             text.OnClick(() => glsGroupGridProvider.SetGroupPage(n));
+            // The button's child selectable receives hover events, so host the remappable hint there rather than on the component root.
+            var tooltipTarget = text.Selectable != null ? text.Selectable.gameObject : text.gameObject;
+            var tooltip = tooltipTarget.GetComponent<Tooltip>() ?? tooltipTarget.AddComponent<Tooltip>();
+            tooltip.TooltipOverride = "Cycle GLS tabs";
+            tooltip.AdvancedTooltip = "Cycle GLS tabs";
+            tooltip.AppearDelay = 0.3f;
+            tooltip.HotkeyActionMap = "GLS Group Tabs";
+            tooltip.HotkeyActionName = "Next Groups Page";
+            tooltip.AdditionalHotkeyActionName = "Previous Groups Page";
             text.gameObject.SetActive(true);
             loadedText.Add(text);
             groupToText.Add(n, text);

--- a/Assets/__Scripts/UI/Editor/MirrorSelection.cs
+++ b/Assets/__Scripts/UI/Editor/MirrorSelection.cs
@@ -245,11 +245,11 @@ public class MirrorSelection : MonoBehaviour
     // Rebuild each affected GLS group once so replay does not spawn individual nodes through ReplaceGroup.
     private List<BeatmapAction> CreateMirroredGlsActions(
         bool moveNotes,
-        List<BaseGLSEvent> mirroredSelectedGlsEvents)
+        List<BaseGLSEvent> mirroredSelectedGlsEvents,
+        Dictionary<BaseEventBoxGroup, List<BaseGLSEvent>> selectedGroups)
     {
         var actions = new List<BeatmapAction>();
-        // Group and index source nodes once so mirroring keeps stacked selections aligned with cloned event arrays.
-        var selectedGroups = GLSEventLookupIndex.GroupSelectedEvents(SelectionController.SelectedObjects);
+        // Group and index source nodes once so mirroring keeps selected lanes aligned with cloned event arrays.
         foreach (var groupEntry in selectedGroups)
         {
             var originalGroup = groupEntry.Key;
@@ -328,6 +328,8 @@ public class MirrorSelection : MonoBehaviour
                 }
             }
 
+            // Mirroring rewrites box event arrays, so refresh ordering once here instead of forcing every preview repaint to scan them.
+            editedGroup.ResortOrderedEvents();
             editedGroup.SaveCustom();
             actions.Add(new BeatmapGLSEventBoxModifiedAction(
                 editedGroup,
@@ -355,11 +357,15 @@ public class MirrorSelection : MonoBehaviour
         // Keep the basic-event lane maps separate because their lanes are defined by the active event-grid mode.
         var selectedBasicEventTypeMirrorMap = BuildSelectedBasicEventTypeMirrorMap();
         var mirroredSelectedGlsEvents = new List<BaseGLSEvent>();
-        var glsActions = CreateMirroredGlsActions(moveNotes, mirroredSelectedGlsEvents);
+        // Inner GLS nodes own their parent replacement, so do not also mirror a parent that is selected beside them.
+        var selectedGlsGroups = GLSEventLookupIndex.GroupSelectedEvents(SelectionController.SelectedObjects);
+        var glsActions = CreateMirroredGlsActions(moveNotes, mirroredSelectedGlsEvents, selectedGlsGroups);
         var events = BeatmapObjectContainerCollection.GetCollectionForType<EventGridContainer>(ObjectType.Event);
         var originalObjects = new List<BaseObject>();
         var editedObjects = new List<BaseObject>();
-        foreach (var original in SelectionController.SelectedObjects.Where(obj => obj is not BaseGLSEvent))
+        foreach (var original in SelectionController.SelectedObjects.Where(obj =>
+                     obj is not BaseGLSEvent
+                     && (obj is not BaseEventBoxGroup eventBoxGroup || !selectedGlsGroups.ContainsKey(eventBoxGroup))))
         {
             var edited = BeatmapFactory.Clone(original);
             if (edited is BaseObstacle obstacle && moveNotes)
@@ -778,15 +784,12 @@ public class MirrorSelection : MonoBehaviour
                 true);
         }
 
-        // Group replacement clears selection; restore mirrored GLS nodes without adding selection history entries.
-        foreach (var mirroredSelectedGlsEvent in mirroredSelectedGlsEvents)
-        {
-            SelectionController.Select(mirroredSelectedGlsEvent, true, false, false);
-        }
-
+        // Parent replacement recreates child identities, so rebind mirror selection to the authoritative inner nodes.
         if (mirroredSelectedGlsEvents.Count > 0)
         {
-            SelectionController.OnSelectionChanged?.Invoke();
+            BeatmapObjectContainerCollection
+                .GetCollectionForType<GLSEventGridContainer>(ObjectType.GLSEvent)
+                .RebindSelectionAfterBatch(mirroredSelectedGlsEvents);
         }
     }
 }

--- a/Assets/__Scripts/UI/Editor/NodeEditor/NodeEditorController.cs
+++ b/Assets/__Scripts/UI/Editor/NodeEditor/NodeEditorController.cs
@@ -230,23 +230,24 @@ public class NodeEditorController : MonoBehaviour, CMInput.INodeEditorActions
 
             ApplyJson(editingNode.AsObject, newNode.AsObject, objectJsonMap);
 
-            var editedObjects = objectJsonMap
-                .Select(pair =>
-                {
-                    var reference = pair.Key;
-                    var json = pair.Value;
-                    var edited = BeatmapFactory.Clone(reference);
-                    edited.Apply(Activator.CreateInstance(reference.GetType(), new object[] { json }) as BaseObject);
-                    return edited;
-                })
-                .ToList();
+            // Inner GLS nodes are owned by their group, unlike every ordinary Node Editor object.
+            if (editingObjects.All(obj => obj is BaseGLSEvent))
+            {
+                ApplyInnerGlsEdit(objectJsonMap);
+            }
+            else
+            {
+                var editedObjects = objectJsonMap
+                    .Select(pair => CreateEditedObject(pair.Key, pair.Value))
+                    .ToList();
 
-            BeatmapActionContainer.AddAction(
-                new BeatmapObjectModifiedCollectionAction(
-                    editedObjects,
-                    editingObjects,
-                    $"Edited ({editingObjects.Count}) objects with Node Editor."),
-                true);
+                BeatmapActionContainer.AddAction(
+                    new BeatmapObjectModifiedCollectionAction(
+                        editedObjects,
+                        editingObjects,
+                        $"Edited ({editingObjects.Count}) objects with Node Editor."),
+                    true);
+            }
             UpdateJson();
         }
         catch (Exception e)
@@ -268,6 +269,51 @@ public class NodeEditorController : MonoBehaviour, CMInput.INodeEditorActions
             }
 
             PersistentUI.Instance.ShowDialogBox(message, null, PersistentUI.DialogBoxPresetType.Ok);
+        }
+    }
+
+    private static BaseObject CreateEditedObject(BaseObject reference, JSONNode json)
+    {
+        var edited = BeatmapFactory.Clone(reference);
+        edited.Apply(Activator.CreateInstance(reference.GetType(), new object[] { json }) as BaseObject);
+        return edited;
+    }
+
+    private void ApplyInnerGlsEdit(IReadOnlyDictionary<BaseObject, JSONNode> objectJsonMap)
+    {
+        // The open inner GLS grid can select nodes from only its current parent group.
+        var originalGroup = ((BaseGLSEvent)editingObjects[0]).EventBoxGroupData;
+        var editedGroup = BeatmapFactory.Clone(originalGroup);
+        var eventLookup = new GLSEventLookupIndex(originalGroup);
+        var editedSelectedEvents = new List<BaseGLSEvent>();
+        foreach (var selectedEvent in editingObjects.Cast<BaseGLSEvent>())
+        {
+            if (!eventLookup.TryGetCloneEvent(selectedEvent, editedGroup, out _, out var editedEvent))
+            {
+                continue;
+            }
+
+            editedEvent.Apply(CreateEditedObject(selectedEvent, objectJsonMap[selectedEvent]));
+            editedSelectedEvents.Add(editedEvent);
+        }
+
+        // Parent replacement keeps child identities authoritative across undo and redo.
+        BeatmapActionContainer.AddAction(
+            new BeatmapGLSEventBoxModifiedAction(
+                editedGroup,
+                originalGroup,
+                "Edited GLS events with Node Editor."),
+            true);
+
+        // Parent replacement clears selection, so retain the edited nodes without creating selection history.
+        foreach (var editedEvent in editedSelectedEvents)
+        {
+            SelectionController.Select(editedEvent, true, false, false);
+        }
+
+        if (editedSelectedEvents.Count > 0)
+        {
+            SelectionController.OnSelectionChanged?.Invoke();
         }
     }
 

--- a/Assets/__Scripts/UI/Editor/PlacementController/ColorTypeController.cs
+++ b/Assets/__Scripts/UI/Editor/PlacementController/ColorTypeController.cs
@@ -44,14 +44,14 @@ public class ColorTypeController : MonoBehaviour, IEditorStateProvider
         redSelected.enabled = true;
         blueSelected.enabled = false;
         whiteSelected.enabled = false;
-        SetChromaUi(IsGameplayEditing ? NotePlacement.CanPlaceChromaObjects : Settings.Instance.PlaceChromaColor);
+        SetChromaUi(IsGameplayEditing ? BasePlacement.CanPlaceChromaObjects : Settings.Instance.PlaceChromaColor);
         customColorsUIController.Context = beatmapRuntimeContext;
         customColorsUIController.RefreshColors();
         beatmapRuntimeContext.OnColorSchemeChanged += HandleColorSchemeChanged;
         editModeContext.OnEditModeChanged += HandleEditModeModeChanged;
         customColorsUIController.OnCustomColorsUpdated += HandleCustomColorUIControllerUpdated;
         ColourPicker.OnPlaceChromaEventsChanged += HandlePlaceChromaEventsChanged;
-        NotePlacement.OnPlaceChromaObjectsChanged += HandlePlaceChromaObjectsChanged;
+        BasePlacement.OnPlaceChromaObjectsChanged += HandlePlaceChromaObjectsChanged;
         chromaColorValuePicker.ONValueChanged.AddListener(SetChromaColor);
         OnChromaLightColorRequested += HandleChromaLightColorRequested;
         SetChromaColor(chromaColorValuePicker.CurrentColor);
@@ -68,7 +68,7 @@ public class ColorTypeController : MonoBehaviour, IEditorStateProvider
         editModeContext.OnEditModeChanged -= HandleEditModeModeChanged;
         customColorsUIController.OnCustomColorsUpdated -= HandleCustomColorUIControllerUpdated;
         ColourPicker.OnPlaceChromaEventsChanged -= HandlePlaceChromaEventsChanged;
-        NotePlacement.OnPlaceChromaObjectsChanged -= HandlePlaceChromaObjectsChanged;
+        BasePlacement.OnPlaceChromaObjectsChanged -= HandlePlaceChromaObjectsChanged;
         chromaColorValuePicker.ONValueChanged.RemoveListener(SetChromaColor);
         OnChromaLightColorRequested -= HandleChromaLightColorRequested;
     }
@@ -107,7 +107,7 @@ public class ColorTypeController : MonoBehaviour, IEditorStateProvider
         }
 
         HandleColorSchemeChanged(beatmapRuntimeContext.ColorScheme);
-        SetChromaUi(IsGameplayEditing ? NotePlacement.CanPlaceChromaObjects : Settings.Instance.PlaceChromaColor);
+        SetChromaUi(IsGameplayEditing ? BasePlacement.CanPlaceChromaObjects : Settings.Instance.PlaceChromaColor);
     }
 
     private void HandleCustomColorUIControllerUpdated() => HandleColorSchemeChanged(beatmapRuntimeContext.ColorScheme);
@@ -177,7 +177,7 @@ public class ColorTypeController : MonoBehaviour, IEditorStateProvider
         {
             // Close only the picker so the selected Chroma type and its active placement setting remain unchanged.
             chromaColorPicker.ClosePicker();
-            SetChromaUi(IsGameplayEditing ? NotePlacement.CanPlaceChromaObjects : Settings.Instance.PlaceChromaColor);
+            SetChromaUi(IsGameplayEditing ? BasePlacement.CanPlaceChromaObjects : Settings.Instance.PlaceChromaColor);
             return;
         }
 
@@ -281,7 +281,7 @@ public class ColorTypeController : MonoBehaviour, IEditorStateProvider
     // Keep object-placement state in its existing non-persistent setting instead of sharing the lighting event setting.
     private void SetPlaceChromaObjects(bool enabled)
     {
-        NotePlacement.SetPlaceChromaObjects(enabled);
+        BasePlacement.SetPlaceChromaObjects(enabled);
         SetChromaUi(enabled);
     }
 

--- a/Assets/__Scripts/UI/Editor/PlacementController/ColorTypeController.cs
+++ b/Assets/__Scripts/UI/Editor/PlacementController/ColorTypeController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Beatmap.Enums;
 using SimpleJSON;
 using UnityEngine;
@@ -6,6 +6,9 @@ using UnityEngine.UI;
 
 public class ColorTypeController : MonoBehaviour, IEditorStateProvider
 {
+    // GLS color input owns the shortcut while this controller owns the tile and picker state.
+    public static event Action OnChromaLightColorRequested;
+
     [SerializeField] private BeatmapRuntimeContext beatmapRuntimeContext;
     [SerializeField] private EditModeContext editModeContext;
     [SerializeField] private NotePlacement notePlacement;
@@ -41,14 +44,16 @@ public class ColorTypeController : MonoBehaviour, IEditorStateProvider
         redSelected.enabled = true;
         blueSelected.enabled = false;
         whiteSelected.enabled = false;
-        SetChromaUi(Settings.Instance.PlaceChromaColor);
+        SetChromaUi(IsGameplayEditing ? NotePlacement.CanPlaceChromaObjects : Settings.Instance.PlaceChromaColor);
         customColorsUIController.Context = beatmapRuntimeContext;
         customColorsUIController.RefreshColors();
         beatmapRuntimeContext.OnColorSchemeChanged += HandleColorSchemeChanged;
         editModeContext.OnEditModeChanged += HandleEditModeModeChanged;
         customColorsUIController.OnCustomColorsUpdated += HandleCustomColorUIControllerUpdated;
-        ColourPicker.OnPlaceChromaEventsChanged += SetChromaUi;
+        ColourPicker.OnPlaceChromaEventsChanged += HandlePlaceChromaEventsChanged;
+        NotePlacement.OnPlaceChromaObjectsChanged += HandlePlaceChromaObjectsChanged;
         chromaColorValuePicker.ONValueChanged.AddListener(SetChromaColor);
+        OnChromaLightColorRequested += HandleChromaLightColorRequested;
         SetChromaColor(chromaColorValuePicker.CurrentColor);
 
         HandleEditModeModeChanged(editModeContext.EditingMode);
@@ -62,8 +67,10 @@ public class ColorTypeController : MonoBehaviour, IEditorStateProvider
         beatmapRuntimeContext.OnColorSchemeChanged -= HandleColorSchemeChanged;
         editModeContext.OnEditModeChanged -= HandleEditModeModeChanged;
         customColorsUIController.OnCustomColorsUpdated -= HandleCustomColorUIControllerUpdated;
-        ColourPicker.OnPlaceChromaEventsChanged -= SetChromaUi;
+        ColourPicker.OnPlaceChromaEventsChanged -= HandlePlaceChromaEventsChanged;
+        NotePlacement.OnPlaceChromaObjectsChanged -= HandlePlaceChromaObjectsChanged;
         chromaColorValuePicker.ONValueChanged.RemoveListener(SetChromaColor);
+        OnChromaLightColorRequested -= HandleChromaLightColorRequested;
     }
 
     private void HandleColorSchemeChanged(ColorSchemeSO colorScheme)
@@ -89,7 +96,7 @@ public class ColorTypeController : MonoBehaviour, IEditorStateProvider
     {
         if (mode.HasFlag(EditingMode.Gameplay))
         {
-            gridLayoutGroup.cellSize = new Vector2(20, 20);
+            gridLayoutGroup.cellSize = new Vector2(15, 15);
             whiteTarget.SetActive(false);
         }
         else
@@ -100,6 +107,7 @@ public class ColorTypeController : MonoBehaviour, IEditorStateProvider
         }
 
         HandleColorSchemeChanged(beatmapRuntimeContext.ColorScheme);
+        SetChromaUi(IsGameplayEditing ? NotePlacement.CanPlaceChromaObjects : Settings.Instance.PlaceChromaColor);
     }
 
     private void HandleCustomColorUIControllerUpdated() => HandleColorSchemeChanged(beatmapRuntimeContext.ColorScheme);
@@ -147,31 +155,54 @@ public class ColorTypeController : MonoBehaviour, IEditorStateProvider
     }
 
     // The Chroma color tile augments the current OEM color rather than replacing its fallback event type.
-    public void ChromaColor(bool active)
+    public void ChromaColor(bool _)
     {
         if (chromaColorPicker == null)
         {
             Debug.LogError("[ColorTypeController] Chroma Color Picker is not assigned in 03_Mapper.");
-            Settings.Instance.PlaceChromaColor = false;
-            SetChromaUi(false);
+            if (IsGameplayEditing)
+            {
+                SetPlaceChromaObjects(false);
+            }
+            else
+            {
+                Settings.Instance.PlaceChromaColor = false;
+                SetChromaUi(false);
+            }
+
             return;
         }
 
-        if (active)
+        if (chromaColorPicker.IsOpen)
+        {
+            // Close only the picker so the selected Chroma type and its active placement setting remain unchanged.
+            chromaColorPicker.ClosePicker();
+            SetChromaUi(IsGameplayEditing ? NotePlacement.CanPlaceChromaObjects : Settings.Instance.PlaceChromaColor);
+            return;
+        }
+
+        // A closed picker always opens with Chroma placement enabled, regardless of the toggle callback's previous state.
+        if (SelectedColorType == (int)NoteType.Bomb)
         {
             // White light events intentionally render as white, so switch their non-Chroma fallback to Primary before applying an RGB override.
-            if (SelectedColorType == (int)NoteType.Bomb)
-            {
-                UpdateValue((int)NoteType.Red);
-            }
+            UpdateValue((int)NoteType.Red);
+        }
 
-            chromaColorPicker.OpenForChromaEvents();
+        if (IsGameplayEditing)
+        {
+            SetPlaceChromaObjects(true);
+            chromaColorPicker.OpenPicker();
         }
         else
         {
-            chromaColorPicker.CloseForChromaEvents();
+            chromaColorPicker.OpenForChromaEvents();
         }
     }
+
+    // Route shortcut activation through the same handler as the Chroma color tile.
+    public static void RequestChromaLightColor() => OnChromaLightColorRequested?.Invoke();
+
+    private void HandleChromaLightColorRequested() => ChromaColor(true);
 
     public void UpdateValue(int type)
     {
@@ -193,10 +224,18 @@ public class ColorTypeController : MonoBehaviour, IEditorStateProvider
     {
         if (chromaToggle.isOn)
         {
-            // OEM selection must disable the same Chroma color event mode that the tile enables.
+            // OEM selection must disable the Chroma placement mode owned by the active editor view.
             if (chromaColorPicker != null)
             {
-                chromaColorPicker.CloseForChromaEvents();
+                if (IsGameplayEditing)
+                {
+                    SetPlaceChromaObjects(false);
+                    chromaColorPicker.ClosePicker();
+                }
+                else
+                {
+                    chromaColorPicker.CloseForChromaEvents();
+                }
             }
         }
 
@@ -219,6 +258,31 @@ public class ColorTypeController : MonoBehaviour, IEditorStateProvider
             // Dim OEM fallback tiles to 40% opacity so the active Chroma tile is visually unambiguous.
             canvasGroup.alpha = enabled ? 0.4f : 1f;
         }
+    }
+
+    // Lighting updates must not replace the gameplay object's independent Chroma placement selection.
+    private void HandlePlaceChromaEventsChanged(bool enabled)
+    {
+        if (!IsGameplayEditing)
+        {
+            SetChromaUi(enabled);
+        }
+    }
+
+    // Gameplay picker-checkbox changes must immediately update the tile that represents object placement.
+    private void HandlePlaceChromaObjectsChanged(bool enabled)
+    {
+        if (IsGameplayEditing)
+        {
+            SetChromaUi(enabled);
+        }
+    }
+
+    // Keep object-placement state in its existing non-persistent setting instead of sharing the lighting event setting.
+    private void SetPlaceChromaObjects(bool enabled)
+    {
+        NotePlacement.SetPlaceChromaObjects(enabled);
+        SetChromaUi(enabled);
     }
 
     // Match the Chroma tile's single fill image to the shared picker color.
@@ -249,6 +313,8 @@ public class ColorTypeController : MonoBehaviour, IEditorStateProvider
     }
 
     public static event Action<int> OnColorChanged;
+
+    private bool IsGameplayEditing => editModeContext.EditingMode.HasFlag(EditingMode.Gameplay);
 
     private static int NoteTypeToLightColor(int type) =>
         type == (int)NoteType.Bomb ? (int)LightColor.White : type;

--- a/Assets/__Scripts/UI/Editor/PlacementController/InputEasingViewController.cs
+++ b/Assets/__Scripts/UI/Editor/PlacementController/InputEasingViewController.cs
@@ -27,6 +27,8 @@ public class InputEasingViewController : ToggleableViewController, IEditorStateP
         inputController.OnEasingChanged += HandleEasingChanged;
 
         extensionToggle.OnValueChanged(HandleExtensionInputChanged);
+        // Attach to the toggle's selectable because it receives pointer hover events, and read the binding at display time after remaps.
+        AddExtensionTooltip();
 
         curveInToggle.OnValueChanged(HandleCurveInInputChanged);
         curveOutToggle.OnValueChanged(HandleCurveOutInputChanged);
@@ -77,6 +79,20 @@ public class InputEasingViewController : ToggleableViewController, IEditorStateP
 
     private void HandleExtensionInputChanged(bool value) => inputController.NotifyExtensionChanged(value ? 1 : 0);
     private void HandleExtensionChanged(int value) => extensionToggle.SetValueWithoutNotify(value == 1);
+
+    private void AddExtensionTooltip()
+    {
+        var tooltipTarget = extensionToggle.Selectable != null
+            ? extensionToggle.Selectable.gameObject
+            : extensionToggle.gameObject;
+        var tooltip = tooltipTarget.GetComponent<Tooltip>() ?? tooltipTarget.AddComponent<Tooltip>();
+        tooltip.TooltipOverride = "Extend the previous light event";
+        tooltip.AdvancedTooltip = "Extend the previous light event";
+        tooltip.AppearDelay = 0.25f;
+        tooltip.HotkeyActionMap = "Easings Selection";
+        tooltip.HotkeyActionName = "Extension";
+        tooltip.HotkeyDisplayPrefix = "Press ";
+    }
 
     // Apply editor metadata directly to the rendered toggles after map loading, bypassing input-event timing.
     public void ApplyEditorState(int easing, int extension)

--- a/Assets/__Scripts/UI/Editor/PlacementController/InputEasingViewController.cs
+++ b/Assets/__Scripts/UI/Editor/PlacementController/InputEasingViewController.cs
@@ -86,6 +86,7 @@ public class InputEasingViewController : ToggleableViewController, IEditorStateP
             ? extensionToggle.Selectable.gameObject
             : extensionToggle.gameObject;
         var tooltip = tooltipTarget.GetComponent<Tooltip>() ?? tooltipTarget.AddComponent<Tooltip>();
+        // TODO: Localize this tooltip before Stable so the new remappable hint follows the rest of the UI.
         tooltip.TooltipOverride = "Extend the previous light event";
         tooltip.AdvancedTooltip = "Extend the previous light event";
         tooltip.AppearDelay = 0.25f;

--- a/Assets/__Scripts/UI/Tooltip.cs
+++ b/Assets/__Scripts/UI/Tooltip.cs
@@ -23,6 +23,12 @@ public class Tooltip : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler
     [Tooltip("Input action name within the map to display as a hotkey hint (e.g. 'GLSEdit')")]
     [SerializeField] public string HotkeyActionName;
 
+    // GLS page tabs need a second action hint so both remappable directions appear together.
+    [SerializeField] public string AdditionalHotkeyActionName;
+
+    // Some action descriptions read naturally as an instruction, so preserve the explicit "Press" wording before a remappable hint.
+    [SerializeField] public string HotkeyDisplayPrefix;
+
     private Coroutine routine;
 
     private void OnDisable() => OnPointerExit(null);
@@ -55,7 +61,10 @@ public class Tooltip : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler
 
         var hotkey = GetHotkeyDisplayString();
         if (!string.IsNullOrEmpty(hotkey))
-            tooltipTextResult = $"{tooltipTextResult} [{hotkey}]";
+        {
+            // Keep the binding itself dynamic while allowing the owning control to supply a short instructional prefix.
+            tooltipTextResult = $"{tooltipTextResult} [{HotkeyDisplayPrefix}{hotkey}]";
+        }
 
         PersistentUI.Instance.SetTooltip(tooltipTextResult, AdvancedTooltip);
         yield return new WaitForSeconds(timeToWait);
@@ -70,10 +79,12 @@ public class Tooltip : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler
         if (input == null)
             return null;
 
+        // Resolve the action map once so an optional second hotkey can use the same remappable binding context.
+        InputActionMap map = null;
         InputAction action = null;
         if (!string.IsNullOrEmpty(HotkeyActionMap))
         {
-            var map = input.asset.FindActionMap(HotkeyActionMap);
+            map = input.asset.FindActionMap(HotkeyActionMap);
             action = map?.FindAction(HotkeyActionName);
         }
         else
@@ -85,6 +96,18 @@ public class Tooltip : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler
             return null;
 
         var displayString = action.GetBindingDisplayString(InputBinding.DisplayStringOptions.DontUseShortDisplayNames);
-        return string.IsNullOrEmpty(displayString) ? null : displayString;
+        if (string.IsNullOrEmpty(AdditionalHotkeyActionName))
+        {
+            return string.IsNullOrEmpty(displayString) ? null : displayString;
+        }
+
+        var additionalAction = (map ?? action.actionMap)?.FindAction(AdditionalHotkeyActionName);
+        var additionalDisplayString = additionalAction?.GetBindingDisplayString(InputBinding.DisplayStringOptions.DontUseShortDisplayNames);
+        if (string.IsNullOrEmpty(displayString))
+        {
+            return string.IsNullOrEmpty(additionalDisplayString) ? null : additionalDisplayString;
+        }
+
+        return string.IsNullOrEmpty(additionalDisplayString) ? displayString : $"{displayString}/{additionalDisplayString}";
     }
 }

--- a/Assets/__Scripts/Utils/DataStructures/StateChunksContainer.cs
+++ b/Assets/__Scripts/Utils/DataStructures/StateChunksContainer.cs
@@ -5,6 +5,8 @@ using UnityEngine;
 public class StateChunksContainer<TState, TData> where TState : StateData<TData> where TData : BaseObject
 {
     public readonly SortedBucketArray<TState> Collection = new(value => value?.StartTime ?? 0f, 10, 100);
+    // GLS group moves can cross a float-derived bucket boundary, so removal must resolve the exact inserted identity directly.
+    private readonly Dictionary<TData, TState> statesByBase = new();
     public TState CurrentState;
 
     private List<TState> currBucket;
@@ -13,7 +15,12 @@ public class StateChunksContainer<TState, TData> where TState : StateData<TData>
 
     public void Resize(float max) => Collection.Resize((int)max);
 
-    public void AddState(TState state) => Collection.Add(state);
+    // Maintain the identity index alongside the ordered buckets so movement never scans or guesses a removal bucket.
+    public void AddState(TState state)
+    {
+        Collection.Add(state);
+        statesByBase[state.Base] = state;
+    }
 
     public bool IsCurrentOrFindState(float time, bool playing) =>
         playing ? UseCurrentOrNextState(time) : UseCurrentOrFindState(time);
@@ -141,17 +148,17 @@ public class StateChunksContainer<TState, TData> where TState : StateData<TData>
     /// Gets a state from the container by reference.
     /// The reference must be the exact live instance originally inserted into the state bucket.
     /// </summary>
-    public TState GetStateFrom(TData reference, TData original)
+    public TState GetStateFrom(TData reference, TData _)
     {
-        // Use the outgoing object's original time so replacements never scan the entire beatmap state cache.
-        var chunk = Collection.GetBucketFrom(original.SongBpmTime);
-        var idx = chunk.FindIndex(x => x.Base == reference);
-        if (idx >= 0)
-            return chunk[idx];
-
-        return null;
+        return statesByBase.TryGetValue(reference, out var state)
+            ? state
+            : null;
     }
 
-    // StateManager resolves the exact cached state before requesting its bucket removal.
-    public bool RemoveState(TState state) => Collection.Remove(state);
+    // Remove both representations together so a later group replacement cannot resolve a stale state identity.
+    public bool RemoveState(TState state)
+    {
+        statesByBase.Remove(state.Base);
+        return Collection.Remove(state);
+    }
 }


### PR DESCRIPTION
Fix queued preview color issues placing Walls, Bombs, Notes.
Fix queued event preview color not respecting latest Boost event colors in Light Color Basic / GLS events.
Fix color-type tile size in Beatmap view.
Streamline Chroma Color Type selector tile behavior to be less clunky, function the same everywhere (separate state for beatmap vs lights still).
Consolidate all Tweaks hover event naming so they group together in hotkeys menu.
Fix some bad keybind names.
Creating walls by dragging backwards places the wall the preview indicates it would.
Fixed glitchy wall placement cancellation when mouse leaves vertical grid but has not reached horizontal grid yet.
Bound GLS groups page cycling to page up / page down per discord consensus a month ago.
Keybind for Chroma Light Color, default 4 (moved extension to 6).
Fixed GLS queued light previews not respecting boost color.
GLS keybind for Strobe Chroma Color = C (nearby F,R,T,G other strobe bindings).
Fixed GLS cached node mixup glitchy nonsense, and CatKids alt drag bug.
Loading messages.

8/16 commits fixed the following bugs:
Alt dragging inner gls event nodes sometimes creating ghost nodes after undo.
Chroma Pickers "Paint Selected Objects" creating phantom undo points for the outer GLS event group when painting inner nodes.
Alt Dragging inner gls event nodes phantom-selecting the outer gls event group, resulting in very confusing node-editor experiences showing no json properties and wrong number of selected items.
Able to drag GLS event groups to negative absolute beats, causing inner gls events to behave strange when outer beat + offset was still < 0.
Node editor on inner gls nodes sometimes creating phantom group undo errors.
Undo /  Redo in general sometimes getting into a weird state with GLS event group inner node actions.