### PR TITLE
Port improved chain placement behavior from slinkmapper

### DIFF
--- a/Assets/__Scripts/Editor/Grid/CommonBeatmapUtils.cs
+++ b/Assets/__Scripts/Editor/Grid/CommonBeatmapUtils.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Beatmap.Base;
+using Beatmap.Containers;
+using Beatmap.Enums;
+using Beatmap.Helper;
+using UnityEngine;
+using UnityEngine.InputSystem;
+using UnityEngine.Serialization;
+
+public static class CommonBeatmapUtils
+{
+    private static readonly float[] CutDirectionAngles =
+    {
+        180f, 0f, 270f, 90f, 225f, 135f, 315f, 45f, 0f
+    };
+
+    public static float GetAngle(int cutDirection)
+    {
+        if (cutDirection < 0 || cutDirection >= CutDirectionAngles.Length)
+            throw new ArgumentOutOfRangeException(nameof(cutDirection));
+        return CutDirectionAngles[cutDirection];
+    }
+
+    public static Vector2 AngleToVector(float angle)
+    {
+        angle *= Mathf.Deg2Rad;
+        return new Vector2(Mathf.Sin(angle), -Mathf.Cos(angle));
+    }
+
+    public static float VectorToAngle(Vector2 vector)
+    {
+        vector.Normalize();
+        return Mathf.Atan2(vector.x, -vector.y) * Mathf.Rad2Deg;
+    }
+
+    public static NoteCutDirection AngleToCutDirection(float angle, out float angleOffset, bool useAny = false)
+    {
+        if (useAny)
+        {
+            angleOffset = angle;
+            return NoteCutDirection.Any;
+        }
+
+        angle = Mathf.Repeat(angle, 360f);
+
+        var bestDir = 0;
+        var bestDelta = float.MaxValue;
+        for (var i = 0; i < CutDirectionAngles.Length; i++)
+        {
+            var delta = Mathf.DeltaAngle(angle, CutDirectionAngles[i]);
+            if (Mathf.Abs(delta) < Mathf.Abs(bestDelta))
+            {
+                bestDelta = delta;
+                bestDir = i;
+            }
+        }
+
+        angleOffset = angle - CutDirectionAngles[bestDir];
+        return (NoteCutDirection)bestDir;
+    }
+
+    public static float GetOverallCutAngle(BaseNote note)
+    {
+        var angle = GetAngle(note.CutDirection);
+        if (note.AngleOffset != 0) angle += note.AngleOffset;
+        return angle;
+    }
+
+    public static Vector2 GetOverallCutVector(BaseNote note)
+    {
+        var angle = GetOverallCutAngle(note);
+        return AngleToVector(angle);
+    }
+
+    public static bool HeadPointsTowardTail(BaseNote head, BaseNote tail)
+    {
+        var headDir = head.CutDirection == (int)NoteCutDirection.Any ? Vector2.zero : GetOverallCutVector(head);
+        var tailDir = tail.CutDirection == (int)NoteCutDirection.Any ? Vector2.zero : GetOverallCutVector(tail);
+        if (Vector2.Dot(headDir, tailDir) < -0.9f)
+            return false;
+
+        var averageDir = (headDir + tailDir).normalized;
+        // if both are dots, averageDir is zero; treat as not misaligned so no swap
+        if (averageDir.sqrMagnitude < 0.001f) return true;
+
+        var headPos = head.GetPosition();
+        var tailPos = tail.GetPosition();
+
+        // this fixes the case where a dot is sitting right next to an arrow note,
+        // otherwise it wouldnt be consistent. Arrow chain is more common anyway.
+        // probably can move this somewhere else because this *is* chain related,
+        // but it also makes this a little more consistent for non chain cases if this
+        // is ever to be used. idk.
+        headPos -= headDir * 0.25f;
+        tailPos -= tailDir * 0.25f;
+
+        var headDot = Vector2.Dot(headPos, averageDir);
+        var tailDot = Vector2.Dot(tailPos, averageDir);
+
+        return headDot < tailDot;
+    }
+}

--- a/Assets/__Scripts/Editor/Grid/Placements/ChainPlacement.cs
+++ b/Assets/__Scripts/Editor/Grid/Placements/ChainPlacement.cs
@@ -20,8 +20,6 @@ public class ChainPlacement : BasePlacement<BaseChain, ChainContainer, ChainGrid
     [NonSerialized] public float Squish = Settings.Instance.DefaultChainSquish;
     [NonSerialized] public int SliceCount = Settings.Instance.DefaultChainSliceCount;
 
-    private static HashSet<BaseObject> SelectedObjects => SelectionController.SelectedObjects;
-
     /// <summary>
     ///     Perform all check for spawning a chain. Maybe should swap `n1` and `n2` when `n2` is actually pointing to `n1`
     /// </summary>
@@ -40,7 +38,7 @@ public class ChainPlacement : BasePlacement<BaseChain, ChainContainer, ChainGrid
 
     public int SpawnChainFromSelection()
     {
-        var allNotes = SelectedObjects.Where(IsColorNote).Cast<BaseNote>().ToList();
+        var allNotes = SelectionController.SelectedObjects.Where(IsColorNote).Cast<BaseNote>().ToList();
         allNotes.Sort((a, b) => a.JsonTime.CompareTo(b.JsonTime));
 
         if (Settings.Instance.MapVersion == 2 && allNotes.Count > 1)
@@ -80,7 +78,7 @@ public class ChainPlacement : BasePlacement<BaseChain, ChainContainer, ChainGrid
 
                 if (head.JsonTime > tail.JsonTime + 0.001f) (head, tail) = (tail, head);
 
-                var misaligned = !HeadPointsTowardTail(head, tail);
+                var misaligned = !CommonBeatmapUtils.HeadPointsTowardTail(head, tail);
 
                 if (Mathf.Abs(head.JsonTime - tail.JsonTime) < 0.001f && misaligned)
                     (head, tail) = (tail, head);
@@ -182,102 +180,23 @@ public class ChainPlacement : BasePlacement<BaseChain, ChainContainer, ChainGrid
             }
 
             delta.Normalize();
-            var tailCutVector = AngleToVector(GetAngle(tail.CutDirection));
+            var tailCutVector = CommonBeatmapUtils.AngleToVector(CommonBeatmapUtils.GetAngle(tail.CutDirection));
 
             const float ReflectDotCoeff = 2.5f;
             var headCutVector = -(tailCutVector - ReflectDotCoeff * Vector2.Dot(tailCutVector, delta) * delta).normalized;
-            var headAngle = VectorToAngle(headCutVector);
-            var headCutDirection = AngleToCutDirection(headAngle, out _);
+            var headAngle = CommonBeatmapUtils.VectorToAngle(headCutVector);
+            var headCutDirection = CommonBeatmapUtils.AngleToCutDirection(headAngle, out _);
 
             chain = new BaseChain(head, tail)
             {
                 CutDirection = (int)headCutDirection
             };
-            dotHeadAngle = GetAngle((int)headCutDirection);
+            dotHeadAngle = CommonBeatmapUtils.GetAngle((int)headCutDirection);
             return true;
         }
 
         chain = new BaseChain(head, tail);
         return true;
     }
-
-    private static readonly float[] CutDirectionAngles =
-    {
-        180f, 0f, 270f, 90f, 225f, 135f, 315f, 45f, 0f
-    };
-
-    private static float GetAngle(int cutDirection)
-    {
-        if (cutDirection < 0 || cutDirection >= CutDirectionAngles.Length)
-            throw new ArgumentOutOfRangeException(nameof(cutDirection));
-        return CutDirectionAngles[cutDirection];
-    }
-
-    private static Vector2 AngleToVector(float angle)
-    {
-        angle *= Mathf.Deg2Rad;
-        return new Vector2(Mathf.Sin(angle), -Mathf.Cos(angle));
-    }
-
-    private static float VectorToAngle(Vector2 vector)
-    {
-        vector.Normalize();
-        return Mathf.Atan2(vector.x, -vector.y) * Mathf.Rad2Deg;
-    }
-
-    private static NoteCutDirection AngleToCutDirection(float angle, out float angleOffset, bool useAny = false)
-    {
-        if (useAny)
-        {
-            angleOffset = angle;
-            return NoteCutDirection.Any;
-        }
-
-        angle = Mathf.Repeat(angle, 360f);
-
-        var bestDir = 0;
-        var bestDelta = float.MaxValue;
-        for (var i = 0; i < CutDirectionAngles.Length; i++)
-        {
-            var delta = Mathf.DeltaAngle(angle, CutDirectionAngles[i]);
-            if (Mathf.Abs(delta) < Mathf.Abs(bestDelta))
-            {
-                bestDelta = delta;
-                bestDir = i;
-            }
-        }
-
-        angleOffset = angle - CutDirectionAngles[bestDir];
-        return (NoteCutDirection)bestDir;
-    }
-
-    private static float GetOverallCutAngle(BaseNote note)
-    {
-        var angle = GetAngle(note.CutDirection);
-        if (note.AngleOffset != 0) angle += note.AngleOffset;
-        return angle;
-    }
-
-    private static Vector2 GetOverallCutVector(BaseNote note)
-    {
-        var angle = GetOverallCutAngle(note);
-        return AngleToVector(angle);
-    }
-
-    private static bool HeadPointsTowardTail(BaseNote head, BaseNote tail)
-    {
-        var headDir = head.CutDirection == (int)NoteCutDirection.Any ? Vector2.zero : GetOverallCutVector(head);
-        var tailDir = tail.CutDirection == (int)NoteCutDirection.Any ? Vector2.zero : GetOverallCutVector(tail);
-        if (Vector2.Dot(headDir, tailDir) < -0.9f)
-            return false;
-
-        var averageDir = (headDir + tailDir).normalized;
-        // if both are dots, averageDir is zero; treat as not misaligned so no swap
-        if (averageDir.sqrMagnitude < 0.001f) return true;
-
-        var headDot = Vector2.Dot(head.GetPosition(), averageDir);
-        var tailDot = Vector2.Dot(tail.GetPosition(), averageDir);
-
-        return headDot < tailDot;
-    }
 }
+

--- a/Assets/__Scripts/Editor/Grid/Placements/ChainPlacement.cs
+++ b/Assets/__Scripts/Editor/Grid/Placements/ChainPlacement.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Beatmap.Base;
 using Beatmap.Containers;
 using Beatmap.Enums;
+using Beatmap.Helper;
 using UnityEngine;
 using UnityEngine.InputSystem;
 using UnityEngine.Serialization;
@@ -39,10 +40,10 @@ public class ChainPlacement : BasePlacement<BaseChain, ChainContainer, ChainGrid
 
     public int SpawnChainFromSelection()
     {
-        var notes = SelectedObjects.Where(IsColorNote).Cast<BaseNote>().ToList();
-        notes.Sort((a, b) => a.JsonTime.CompareTo(b.JsonTime));
+        var allNotes = SelectedObjects.Where(IsColorNote).Cast<BaseNote>().ToList();
+        allNotes.Sort((a, b) => a.JsonTime.CompareTo(b.JsonTime));
 
-        if (Settings.Instance.MapVersion == 2 && notes.Count > 1)
+        if (Settings.Instance.MapVersion == 2 && allNotes.Count > 1)
         {
             PersistentUI.Instance.ShowDialogBox(
                 "Chain placement is not supported in v2 format.\nConvert map to v3 to place chains.",
@@ -52,49 +53,98 @@ public class ChainPlacement : BasePlacement<BaseChain, ChainContainer, ChainGrid
         }
 
         var removedTailNotes = new List<BaseNote>();
-        var generatedObjects = new List<BaseChain>();
+        var generatedChains = new List<BaseChain>();
+        var modifiedHeadOld = new List<BaseNote>();
+        var modifiedHeadNew = new List<BaseNote>();
 
-        // is there better way than this?
-        var redNotes = notes.Where(n => n.Color == (int)NoteColor.Red).ToList();
-        var blueNotes = notes.Where(n => n.Color == (int)NoteColor.Blue).ToList();
+        var notesByHand = allNotes.GroupBy(n => n.Type);
 
-        for (var i = 1; i < redNotes.Count; i++)
+        foreach (var handGroup in notesByHand)
         {
-            if (TryCreateChainData(redNotes[i - 1], redNotes[i], out var chain, out var tailNote))
+            var notes = handGroup.ToList();
+            BaseNote head = null;
+
+            foreach (var note in notes)
             {
-                removedTailNotes.Add(tailNote);
-                generatedObjects.Add(chain);
+                if (head == null)
+                {
+                    head = note;
+                    continue;
+                }
+
+                var tail = note;
+
+                if (head.CutDirection == (int)NoteCutDirection.Any &&
+                    tail.CutDirection == (int)NoteCutDirection.Any)
+                    continue;
+
+                if (head.JsonTime > tail.JsonTime + 0.001f) (head, tail) = (tail, head);
+
+                var misaligned = !HeadPointsTowardTail(head, tail);
+
+                if (Mathf.Abs(head.JsonTime - tail.JsonTime) < 0.001f && misaligned)
+                    (head, tail) = (tail, head);
+
+                if (!TryCreateChainDataInternal(head, tail, out var chain, out var dotHeadAngle))
+                    continue;
+
+                if (head.CutDirection == (int)NoteCutDirection.Any)
+                {
+                    var modified = BeatmapFactory.Clone(head);
+                    modified.CutDirection = (int)NoteCutDirection.Any;
+                    modified.AngleOffset = (int)dotHeadAngle;
+                    modifiedHeadOld.Add(head);
+                    modifiedHeadNew.Add(modified);
+                }
+
+                chain.SliceCount = SliceCount;
+                chain.Squish = Squish;
+
+                generatedChains.Add(chain);
+                removedTailNotes.Add(tail);
+
+                head = null;
             }
         }
 
-        for (var i = 1; i < blueNotes.Count; i++)
+        if (generatedChains.Count > 0)
         {
-            if (TryCreateChainData(blueNotes[i - 1], blueNotes[i], out var chain, out var tailNote))
-            {
-                removedTailNotes.Add(tailNote);
-                generatedObjects.Add(chain);
-            }
-        }
+            var spawned = new List<BaseObject>(generatedChains);
+            spawned.AddRange(modifiedHeadNew);
+            var deleted = new List<BaseObject>(removedTailNotes);
+            deleted.AddRange(modifiedHeadOld);
 
-        if (generatedObjects.Count > 0)
-        {
+            var selectedBefore = new HashSet<BaseObject>(SelectionController.SelectedObjects);
+            var selectedAfter = new HashSet<BaseObject>(selectedBefore);
+            selectedAfter.UnionWith(spawned);
+            foreach (var obj in deleted) selectedAfter.Remove(obj);
+
+            var finalSelection = new HashSet<BaseObject>(generatedChains);
+
             SelectionController.DeselectAll();
-            SelectionController.SelectedObjects = new HashSet<BaseObject>(removedTailNotes);
-            selectionController.Delete(false);
 
-            foreach (var chainData in generatedObjects) ObjectContainerCollection.SpawnObject(chainData, false);
+            foreach (var obj in deleted)
+                BeatmapObjectContainerCollection.GetCollectionForType(obj.ObjectType)
+                    .DeleteObject(obj, false, false);
 
-            SelectionController.SelectedObjects = new HashSet<BaseObject>(generatedObjects);
+            foreach (var obj in spawned)
+                BeatmapObjectContainerCollection.GetCollectionForType(obj.ObjectType)
+                    .SpawnObject(obj, false, false);
+
+            BeatmapObjectContainerCollection.RefreshAllPools();
+
+            SelectionController.SelectedObjects = finalSelection;
             SelectionController.OnSelectionChanged?.Invoke();
             SelectionController.RefreshSelectionMaterial(false);
+
             BeatmapActionContainer.AddAction(
                 new BeatmapObjectPlacementAction(
-                    generatedObjects.ToArray(),
-                    removedTailNotes,
-                    $"Placed {generatedObjects.Count} chains"));
+                    spawned.ToArray(),
+                    deleted.ToArray(),
+                    $"Placed {generatedChains.Count} chain(s)"));
         }
 
-        return generatedObjects.Count;
+        return generatedChains.Count;
     }
 
     private static bool IsColorNote(BaseObject o) => ArcPlacement.IsColorNote(o);
@@ -105,13 +155,129 @@ public class ChainPlacement : BasePlacement<BaseChain, ChainContainer, ChainGrid
 
         tailNote = tail;
 
-        if (head.CutDirection == (int)NoteCutDirection.Any)
+        if (TryCreateChainDataInternal(head, tail, out chain, out _))
         {
-            chain = null;
-            return false;
+            chain.SliceCount = SliceCount;
+            chain.Squish = Squish;
+            return true;
         }
 
-        chain = new BaseChain(head, tail) { SliceCount = SliceCount, Squish = Squish };
+        chain = null;
+        return false;
+    }
+
+    private bool TryCreateChainDataInternal(BaseNote head, BaseNote tail, out BaseChain chain, out float dotHeadAngle)
+    {
+        dotHeadAngle = 0f;
+
+        if (head.CutDirection == (int)NoteCutDirection.Any)
+        {
+            // work backwards from the tail (which has an arrow) to get a reasonable
+            // estimate of a good cut direction for the head
+            var delta = head.GetPosition() - tail.GetPosition();
+            if (tail.CutDirection == (int)NoteCutDirection.Any || delta.sqrMagnitude < 0.1f)
+            {
+                chain = null;
+                return false;
+            }
+
+            delta.Normalize();
+            var tailCutVector = AngleToVector(GetAngle(tail.CutDirection));
+
+            const float ReflectDotCoeff = 2.5f;
+            var headCutVector = -(tailCutVector - ReflectDotCoeff * Vector2.Dot(tailCutVector, delta) * delta).normalized;
+            var headAngle = VectorToAngle(headCutVector);
+            var headCutDirection = AngleToCutDirection(headAngle, out _);
+
+            chain = new BaseChain(head, tail)
+            {
+                CutDirection = (int)headCutDirection
+            };
+            dotHeadAngle = GetAngle((int)headCutDirection);
+            return true;
+        }
+
+        chain = new BaseChain(head, tail);
         return true;
+    }
+
+    private static readonly float[] CutDirectionAngles =
+    {
+        180f, 0f, 270f, 90f, 225f, 135f, 315f, 45f, 0f
+    };
+
+    private static float GetAngle(int cutDirection)
+    {
+        if (cutDirection < 0 || cutDirection >= CutDirectionAngles.Length)
+            throw new ArgumentOutOfRangeException(nameof(cutDirection));
+        return CutDirectionAngles[cutDirection];
+    }
+
+    private static Vector2 AngleToVector(float angle)
+    {
+        angle *= Mathf.Deg2Rad;
+        return new Vector2(Mathf.Sin(angle), -Mathf.Cos(angle));
+    }
+
+    private static float VectorToAngle(Vector2 vector)
+    {
+        vector.Normalize();
+        return Mathf.Atan2(vector.x, -vector.y) * Mathf.Rad2Deg;
+    }
+
+    private static NoteCutDirection AngleToCutDirection(float angle, out float angleOffset, bool useAny = false)
+    {
+        if (useAny)
+        {
+            angleOffset = angle;
+            return NoteCutDirection.Any;
+        }
+
+        angle = Mathf.Repeat(angle, 360f);
+
+        var bestDir = 0;
+        var bestDelta = float.MaxValue;
+        for (var i = 0; i < CutDirectionAngles.Length; i++)
+        {
+            var delta = Mathf.DeltaAngle(angle, CutDirectionAngles[i]);
+            if (Mathf.Abs(delta) < Mathf.Abs(bestDelta))
+            {
+                bestDelta = delta;
+                bestDir = i;
+            }
+        }
+
+        angleOffset = angle - CutDirectionAngles[bestDir];
+        return (NoteCutDirection)bestDir;
+    }
+
+    private static float GetOverallCutAngle(BaseNote note)
+    {
+        var angle = GetAngle(note.CutDirection);
+        if (note.AngleOffset != 0) angle += note.AngleOffset;
+        return angle;
+    }
+
+    private static Vector2 GetOverallCutVector(BaseNote note)
+    {
+        var angle = GetOverallCutAngle(note);
+        return AngleToVector(angle);
+    }
+
+    private static bool HeadPointsTowardTail(BaseNote head, BaseNote tail)
+    {
+        var headDir = head.CutDirection == (int)NoteCutDirection.Any ? Vector2.zero : GetOverallCutVector(head);
+        var tailDir = tail.CutDirection == (int)NoteCutDirection.Any ? Vector2.zero : GetOverallCutVector(tail);
+        if (Vector2.Dot(headDir, tailDir) < -0.9f)
+            return false;
+
+        var averageDir = (headDir + tailDir).normalized;
+        // if both are dots, averageDir is zero; treat as not misaligned so no swap
+        if (averageDir.sqrMagnitude < 0.001f) return true;
+
+        var headDot = Vector2.Dot(head.GetPosition(), averageDir);
+        var tailDot = Vector2.Dot(tail.GetPosition(), averageDir);
+
+        return headDot < tailDot;
     }
 }


### PR DESCRIPTION
(pretty much all just workflow QOL)
Change chain placement to be more robust, following the implementation from my SlinkMapper plugin for stable.
- pairs are flipped to make the head first
- if the head is very close to the tail time-wise, flip based on direction and position dot product comparison to make the first note in the swing the head
- if the head is a dot, and the tail is an arrow, estimate a sensible angle for the head based on the tail and make a dot chain